### PR TITLE
Remove "implementation" from terms and definitions

### DIFF
--- a/standard/terms-and-definitions.md
+++ b/standard/terms-and-definitions.md
@@ -32,8 +32,6 @@ For the purposes of this specification, the following definitions apply. Other t
   - error reported during program translation
 - **exception**
   - exceptional condition reported during program execution
-- **implementation**
-  - particular set of software (running in a particular translation environment under particular control options) that performs translation of programs for, and supports execution of methods in, a particular execution environment
 - **namespace**
   - logical organizational system grouping related program elements
 - **parameter**


### PR DESCRIPTION
Fixes #18 by removing the definition entirely.

The terms and definitions section is somewhat ill-defined anyway
(see #19). The term "implementation" is usually clear enough in the
context of usage, whereas defining it *without* context is tricky.