### PR TITLE
Remove section 12.3.7.2 (invariance of the meaning of names in a block)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,6 @@ This folder contains an ANTLR grammar-extraction tool and support files.
     - [§12.7.2](standard/expressions.md#1272-literals)  Literals
     - [§12.7.3](standard/expressions.md#1273-simple-names)  Simple names
       - [§12.7.3.1](standard/expressions.md#12731-general)  General
-      - [§12.7.3.2](standard/expressions.md#12732-invariant-meaning-in-blocks)  Invariant meaning in blocks
     - [§12.7.4](standard/expressions.md#1274-parenthesized-expressions)  Parenthesized expressions
     - [§12.7.5](standard/expressions.md#1275-member-access)  Member access
       - [§12.7.5.1](standard/expressions.md#12751-general)  General

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1178,59 +1178,6 @@ A *simple_name* is either of the form `I` or of the form `I<A₁, ..., Aₑ>`, 
   > *Note*: This entire step is exactly parallel to the corresponding step in the processing of a *namespace_or_type_name* ([§8.8](basic-concepts.md#88-namespace-and-type-names)). *end note*
 - Otherwise, the *simple_name* is undefined and a compile-time error occurs.
 
-#### 12.7.3.2 Invariant meaning in blocks
-
-For each occurrence of a given identifier as a full *simple_name* (without a type argument list) in an expression or declarator, within the local variable declaration space ([§8.3](basic-concepts.md#83-declarations)) immediately enclosing that occurrence, every other occurrence of the same identifier as a full *simple_name* in an expression or declarator shall refer to the same entity. 
-
-> *Note*: This rule ensures that the meaning of a name is always the same within a given block, switch block, `for`, `foreach` or `using` statement, or anonymous function. *end note*
-
-> *Example*: The example
-> ```csharp
-> class Test
-> {
->    double x;
->    void F(bool b) {
->       x = 1.0;
->       if (b) {
->          int x;
->          x = 1;
->       }
->    }
-> }
-> ```
-> results in a compile-time error because `X` refers to different entities within the outer block (the extent of which includes the nested block in the `if` statement). In contrast, the example
-> ```csharp
-> class Test
-> {
->    double x;
->    void F(bool b) {
->       if (b) {
->          x = 1.0;
->       }
->       else {
->          int x;
->          x = 1;
->       }
->    }
-> }
-> ```
-> is permitted because the name `X` is never used in the outer block. *end example*
-
-> *Note*: The rule of invariant meaning applies only to simple names. It is perfectly valid for the same identifier to have one meaning as a simple name and another meaning as right operand of a member access ([§12.7.5](expressions.md#1275-member-access)). *end note*
-
-> *Example*:
-> ```csharp
-> struct Point
-> {
->    int x, y;
->    public Point(int x, int y) {
->       this.x = x;
->       this.y = y;
->    }
-> }
-> ```
-> The example above illustrates a common pattern of using the names of fields as parameter names in an instance constructor. In the example, the simple names `x` and `y` refer to the parameters, but that does not prevent the member access expressions `this.x` and `this.y` from accessing the fields. *end example*
-
 ### 12.7.4 Parenthesized expressions
 
 A *parenthesized_expression* consists of an *expression* enclosed in parentheses.

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -118,8 +118,6 @@ A *block* consists of an optional *statement_list* ([§13.3.2](statements.md#133
 
 A block may contain declaration statements ([§13.6](statements.md#136-declaration-statements)). The scope of a local variable or constant declared in a block is the block.
 
-Within a block, the meaning of a name used in an expression context shall always be the same ([§12.7.3.2](expressions.md#12732-invariant-meaning-in-blocks)).
-
 A block is executed as follows:
 
 - If the block is empty, control is transferred to the end point of the block.
@@ -594,8 +592,6 @@ Multiple labels are permitted in a *switch_section*.
 When the governing type of a `switch` statement is `string` or a nullable value type, the value `null` is permitted as a `case` label constant.
 
 The *statement_list*s of a *switch_block* may contain declaration statements ([§13.6](statements.md#136-declaration-statements)). The scope of a local variable or constant declared in a switch block is the switch block.
-
-Within a switch block, the meaning of a name used in an expression context shall always be the same ([§12.7.3.2](expressions.md#12732-invariant-meaning-in-blocks)).
 
 The statement list of a given switch section is reachable if the `switch` statement is reachable and at least one of the following is true:
 


### PR DESCRIPTION
This rule was never consistently implemented, and was removed in C# 6

Fixes #124

Note that I ran the section renumbering tool, which helped me find the references in statements.md. It made a number of unrelated changes which I've discarded, to keep this PR purely focused on the matter at hand.