### PR TITLE
C# 7.x: accessing fixed fields without pinning

### DIFF
--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -962,7 +962,6 @@ In a member access of the form `E.I`, if `E` is of a struct type and a member lo
 
 - If the expression `E.I` does not occur in an unsafe context, a compile-time error occurs.
 - If `E` is classified as a value, a compile-time error occurs.
-- Otherwise, if `E` is a moveable variable ([§22.4](unsafe-code.md#224-fixed-and-moveable-variables)) and the expression `E.I` is not a *fixed_pointer_initializer* ([§22.7](unsafe-code.md#227-the-fixed-statement)), a compile-time error occurs.
 - Otherwise, `E` references a fixed variable and the result of the expression is a pointer to the first element of the fixed-size buffer member `I` in `E`. The result is of type `S*`, where S is the element type of `I`, and is classified as a value.
 
 The subsequent elements of the fixed-size buffer can be accessed using pointer operations from the first element. Unlike access to arrays, access to the elements of a fixed-size buffer is an unsafe operation and is not range checked.

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -954,20 +954,20 @@ A fixed-size buffer declaration that declares multiple fixed-size buffers is equ
 
 Member lookup ([§11.5](expressions.md#115-member-lookup)) of a fixed-size buffer member proceeds exactly like member lookup of a field.
 
-A fixed-size buffer can be referenced in an expression using a *simple_name* ([§11.7.4](expressions.md#1174-simple-names)) or a *member_access* ([§11.7.6](expressions.md#1176-member-access)).
+A fixed-size buffer can be referenced in an expression using a *simple_name* ([§11.7.4](expressions.md#1174-simple-names)), a *member_access* ([§11.7.6](expressions.md#1176-member-access)), or an *element_access* (§11.7.10).
 
 When a fixed-size buffer member is referenced as a simple name, the effect is the same as a member access of the form `this.I`, where `I` is the fixed-size buffer member.
 
-In a member access of the form `E.I`, if `E` is of a struct type and a member lookup of `I` in that struct type identifies a fixed-size member, then `E.I` is evaluated an classified as follows:
+In a member access of the form `E.I`, if `E` is of a struct type and a member lookup of `I` in that struct type identifies a fixed-size member, then `E.I` is evaluated and classified as follows:
 
 - If the expression `E.I` does not occur in an unsafe context, a compile-time error occurs.
 - If `E` is classified as a value, a compile-time error occurs.
-- Otherwise, if `E` is a moveable variable ([§22.4](unsafe-code.md#224-fixed-and-moveable-variables)), the expression `E.I` must be one of the following, or a compile-time error occurs:
-  - A *fixed_pointer_initializer* ([§22.7](unsafe-code.md#227-the-fixed-statement))
-  - An *pointer_element_access* (§22.6.4) expression where `I` is *fixed-size buffer* (§22.8).
+- Otherwise, if `E` is a moveable variable ([§22.4](unsafe-code.md#224-fixed-and-moveable-variables)) and the expression `E.I` is not a *fixed_pointer_initializer* ([§22.7](unsafe-code.md#227-the-fixed-statement)), a compile-time error occurs.
 - Otherwise, `E` references a fixed variable and the result of the expression is a pointer to the first element of the fixed-size buffer member `I` in `E`. The result is of type `S*`, where S is the element type of `I`, and is classified as a value.
 
 The subsequent elements of the fixed-size buffer can be accessed using pointer operations from the first element. Unlike access to arrays, access to the elements of a fixed-size buffer is an unsafe operation and is not range checked.
+
+In an element access of the form `E[I]`, if `E` is a fixed-sized buffer, and `I` is implicitly convertible to `int`, then `E[I]` is evaluated exactly as the *pointer_element_access* (§22.6.4), `P[I]`, where `P` is the address of the fixed-sized buffer, `E`.
 
 > *Example*: The following declares and uses a struct with a fixed-size buffer member.
 >

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -964,7 +964,7 @@ In a member access of the form `E.I` where `E.` may be the implicit `this.`, if 
 - If `E` is classified as a value, a compile-time error occurs.
 - Otherwise, if `E` is a moveable variable (§22.4) then:
   - If the expression `E.I` is a *fixed_pointer_initializer* (§22.7), then the result of the expression is a pointer to the first element of the fixed size buffer member `I` in `E`.
-  - Otherwise if the expression `E.I` is a *primary_no_array_creation_expression* within an *element_access* expression of the form `E.I[J]` then then the result of the expression is the result of the *primary_no_array_creation_expression* (§11.7.10.1).
+  - Otherwise if the expression `E.I` is a *primary_no_array_creation_expression* (§11.7.10.1) within an *element_access* (§11.7.10) of the form `E.I[J]`, then the result of `E.I` is a pointer, `P`, to the first element of the fixed size buffer member `I` in `E`, and the enclosing *element_access* is then evaluated as the *pointer_element_access* (§22.6.4) `P[J]`.
   - Otherwise a compile-time error occurs.
 - Otherwise, `E` references a fixed variable and the result of the expression is a pointer to the first element of the fixed-size buffer member `I` in `E`. The result is of type `S*`, where S is the element type of `I`, and is classified as a value.
 

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -962,6 +962,9 @@ In a member access of the form `E.I`, if `E` is of a struct type and a member lo
 
 - If the expression `E.I` does not occur in an unsafe context, a compile-time error occurs.
 - If `E` is classified as a value, a compile-time error occurs.
+- Otherwise, if `E` is a moveable variable ([§22.4](unsafe-code.md#224-fixed-and-moveable-variables)), the expression `E.I` must be one of the following, or a compile-time error occurs:
+  - A *fixed_pointer_initializer* ([§22.7](unsafe-code.md#227-the-fixed-statement))
+  - An *pointer_element_access* (§22.6.4) expression where `I` is *fixed-size buffer* (§22.8).
 - Otherwise, `E` references a fixed variable and the result of the expression is a pointer to the first element of the fixed-size buffer member `I` in `E`. The result is of type `S*`, where S is the element type of `I`, and is classified as a value.
 
 The subsequent elements of the fixed-size buffer can be accessed using pointer operations from the first element. Unlike access to arrays, access to the elements of a fixed-size buffer is an unsafe operation and is not range checked.

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -958,16 +958,17 @@ A fixed-size buffer can be referenced in an expression using a *simple_name* ([�
 
 When a fixed-size buffer member is referenced as a simple name, the effect is the same as a member access of the form `this.I`, where `I` is the fixed-size buffer member.
 
-In a member access of the form `E.I`, if `E` is of a struct type and a member lookup of `I` in that struct type identifies a fixed-size member, then `E.I` is evaluated and classified as follows:
+In a member access of the form `E.I` where `E.` may be the implicit `this.`, if `E` is of a struct type and a member lookup of `I` in that struct type identifies a fixed-size member, then `E.I` is evaluated and classified as follows:
 
 - If the expression `E.I` does not occur in an unsafe context, a compile-time error occurs.
 - If `E` is classified as a value, a compile-time error occurs.
-- Otherwise, if `E` is a moveable variable ([§22.4](unsafe-code.md#224-fixed-and-moveable-variables)) and the expression `E.I` is not a *fixed_pointer_initializer* ([§22.7](unsafe-code.md#227-the-fixed-statement)), a compile-time error occurs.
+- Otherwise, if `E` is a moveable variable (§22.4) then:
+  - If the expression `E.I` is a *fixed_pointer_initializer* (§22.7), then the result of the expression is a pointer to the first element of the fixed size buffer member `I` in `E`.
+  - Otherwise if the expression `E.I` is a *primary_no_array_creation_expression* within an *element_access* expression of the form `E.I[J]` then then the result of the expression is the result of the *primary_no_array_creation_expression* (§11.7.10.1).
+  - Otherwise a compile-time error occurs.
 - Otherwise, `E` references a fixed variable and the result of the expression is a pointer to the first element of the fixed-size buffer member `I` in `E`. The result is of type `S*`, where S is the element type of `I`, and is classified as a value.
 
 The subsequent elements of the fixed-size buffer can be accessed using pointer operations from the first element. Unlike access to arrays, access to the elements of a fixed-size buffer is an unsafe operation and is not range checked.
-
-In an element access of the form `E[I]`, if `E` is a fixed-sized buffer, and `I` is implicitly convertible to `int`, then `E[I]` is evaluated exactly as the *pointer_element_access* (§22.6.4), `P[I]`, where `P` is the address of the fixed-sized buffer, `E`.
 
 > *Example*: The following declares and uses a struct with a fixed-size buffer member.
 >


### PR DESCRIPTION
While I think my solution allows the newer behavior, it might be too permissive.

See 'The main “challenge discussion in https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.3/indexing-movable-fixed-fields.md.