### PR TITLE
Use different antlr validator

### DIFF
--- a/tools/update-grammar-annex.sh
+++ b/tools/update-grammar-annex.sh
@@ -28,8 +28,6 @@ declare -a SPEC_FILES=(
 dotnet build $GRAMMAR_PROJECT -c Release
 dotnet publish $GRAMMAR_PROJECT -c Release -o $GRAMMAR_PROJECT/publish
 
-rm $OUTPUT_FILE
-
 echo Insert General/Lexical Headers
 cat $GRAMMAR_PROJECT/grammar-general-lexical-insert.md >$OUTPUT_FILE
 dotnet $GRAMMAR_PROJECT/publish/$GRAMMAR_PROJECT.dll $SPEC_DIRECTORY/lexical-structure.md >>$OUTPUT_FILE

--- a/tools/validate-grammar.sh
+++ b/tools/validate-grammar.sh
@@ -28,8 +28,6 @@ declare -a SPEC_FILES=(
 dotnet build $GRAMMAR_PROJECT -c Release
 dotnet publish $GRAMMAR_PROJECT -c Release -o $GRAMMAR_PROJECT/publish
 
-rm $OUTPUT_FILE
-
 echo "grammar CSGrammar;" > $OUTPUT_FILE
 
 for file in "${SPEC_FILES[@]}"
@@ -40,4 +38,4 @@ done
 
 # Now, validate it:
 curl -H "Accept: application/zip" https://repo1.maven.org/maven2/com/tunnelvisionlabs/antlr4/4.9.0/antlr4-4.9.0-complete.jar -o antlr-4.9.0-complete.jar
-java -jar antlr-4.9.0-complete.jar -Dlanguage=CSharp $OUTPUT_FILE   
+java -jar antlr-4.9.0-complete.jar -Dlanguage=CSharp $OUTPUT_FILE


### PR DESCRIPTION
This updates the script that runs the grammar validator to use the ANTLR grammar validator from @sharwell 

I ran it, and it does work better, but we still have grammar updates to do.

