### PR TITLE
Add link to working group on ECMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C# language standard
 
-Working space for ECMA-TC49-TG2, the C# standard committee.
+Working space for [ECMA-TC49-TG2](https://www.ecma-international.org/task-groups/tc49-tg2/), the C# standard committee.
 
 - The text is licensed under the [Creative Commons license](LICENSE).
 - The code for our tools is licensed under the [MIT license](LICENSE-CODE).


### PR DESCRIPTION
We should link back to the parent organization.

As suggested by @Nigel-Ecma 