### PR TITLE
Allow (null) as a LHS of the null-coalescing operator

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3970,7 +3970,7 @@ null_coalescing_expression
     ;
 ```
 
-A null coalescing expression of the form `a ?? b` requires `a` to be the `null` literal ([§7.4.5.7](lexical-structure.md#7457-the-null-literal)), or to be of a nullable value type or reference type. If `a` is non-`null`, the result of `a ?? b` is `a`; otherwise, the result is `b`. The operation evaluates `b` only if `a` is `null`.
+In a null coalescing expression of the form `a ?? b`, if `a` is non-`null`, the result is `a`; otherwise, the result is `b`. The operation evaluates `b` only if `a` is `null`.
 
 The null coalescing operator is right-associative, meaning that operations are grouped from right to left.
 
@@ -3979,7 +3979,7 @@ The null coalescing operator is right-associative, meaning that operations are g
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
 -   If `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
--   If `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
+-   Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
 -   Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
 -   Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, a is first evaluated. If a is not null, a becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.
 -   Otherwise, if `A` exists and is a nullable value type, `b` has a type `B` and an implicit conversion exists from `A₀` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀` and converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.


### PR DESCRIPTION
(But still prohibit lambda expressions.)

Fixes #178.
