### PR TITLE
Resolve numerous ANTLR issues

### DIFF
--- a/tools/GetGrammar/grammar-lexer-members.txt
+++ b/tools/GetGrammar/grammar-lexer-members.txt
@@ -1,0 +1,10 @@
+
+@lexer::members {
+bool IsLetterCharacter()       { return true; }
+bool IsCombiningCharacter()    { return true; }
+bool IsDecimalDigitCharacter() { return true; }
+bool IsConnectingCharacter()   { return true; }
+bool IsFormattingCharacter()   { return true; }
+bool IsNotAKeyword()           { return true; }
+bool IsNotTrueOrFalse()        { return true; }
+}

--- a/tools/validate-grammar.sh
+++ b/tools/validate-grammar.sh
@@ -29,6 +29,7 @@ dotnet build $GRAMMAR_PROJECT -c Release
 dotnet publish $GRAMMAR_PROJECT -c Release -o $GRAMMAR_PROJECT/publish
 
 echo "grammar CSGrammar;" > $OUTPUT_FILE
+cat $GRAMMAR_PROJECT/grammar-lexer-members.txt >>$OUTPUT_FILE
 
 for file in "${SPEC_FILES[@]}"
 do


### PR DESCRIPTION
This PR addresses the issues raised in Issue #230 as well as Issue #37, Proposal 3. Specifically, it

- Replaces all lexer rule alternatives of the form `'<...>'` with correct content
- Uses semantic predicates to resolve numerous issues, especially w.r.t identifier spelling
- Uses ranges

@BillWagner, to support the semantic predicates, from a validation pov, we'll need to get the following text into the grammar file that we extract/generate, immediately following the current `grammar` directive in tools/validate-grammar.sh:

```ANTLR
echo "grammar CSGrammar;" > $OUTPUT_FILE
```

```ANTLR
@lexer::members {
bool IsLetterCharacter()       { return true; }
bool IsCombiningCharacter()    { return true; }
bool IsDecimalDigitCharacter() { return true; }
bool IsConnectingCharacter()   { return true; }
bool IsFormattingCharacter()   { return true; }
bool IsNotAKeyword()           { return true; }
bool IsNotTrueOrFalse()        { return true; }
}
```

Note that these are simply place-holder methods to allow validation. Clearly, they are *quite incomplete* from a lexer pov.

For now, I'm made this a DRAFT PR pending pushback on the two final uses of semantic predicates I proposed in Issue 230.