### PR TITLE
C# 7.x: Allow field-targeted attributes on auto-property declarations

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -275,7 +275,7 @@ No other values for *global_attribute_target* are allowed.
 The standardized *attribute_target* names are `event`, `field`, `method`, `param`, `property`, `return`, `type`, and `typevar`. These target names shall only be used in the following contexts:
 
 - `event` — an event.
-- `field` — a field. A field-like event (i.e., one without accessors) can also have an attribute with this target.
+- `field` — a field. A field-like event (i.e., one without accessors) ([§14.8.2](classes.md#1482-field-like-events)) and an automatically implemented property ([§14.7.4](classes.md#1474-automatically-implemented-properties)) can also have an attribute with this target.
 - `method` — a constructor, finalizer, method, operator, property get and set accessors, indexer get and set accessors, and event add and remove accessors. A field-like event (i.e., one without accessors) can also have an attribute with this target.
 - `param` — a property set accessor, an indexer set accessor, event add and remove accessors, and a parameter in a constructor, method, and operator.
 - `property` — a property and an indexer.
@@ -300,6 +300,8 @@ Certain contexts permit the specification of an attribute on more than one targe
 - For an attribute specified on a set accessor for a property or indexer declaration the default target is the associated method. Otherwise when the *attribute_target* is equal to:
   - `method` — the target is the associated method
   - `param` — the target is the lone implicit parameter
+- For an attribute on an automatically implemented property declaration the default target is the property. Otherwise when the *attribute_target* is equal to:
+  - `field` — the target is the compiler-generated backing field for the property
 - For an attribute specified on an event declaration that omits *event_accessor_declarations* the default target is the event declaration. Otherwise when the *attribute_target* is equal to:
   - `event` — the target is the event declaration
   - `field` — the target is the field

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3458,7 +3458,9 @@ Although the backing field is hidden, that field may have field-targeted attribu
 >     public string MySecret { get; set; }
 > }
 > ```
+>
 > results in the field-targeted attribute `NonSerialized` being applied to the compiler-generated backing field, as if the code had been written as follows:
+>
 > ```csharp
 > [Serializable]
 > public class Foo

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3452,6 +3452,7 @@ Although the backing field is hidden, that field may have field-targeted attribu
 > *Example*: The following code
 >
 > ```csharp
+> [Serializable]
 > public class Foo
 > {
 >     [field: NonSerialized]

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3447,6 +3447,34 @@ An auto-property may optionally have a *property_initializer*, which is applied 
 >
 > *end example*
 
+Although the backing field is hidden, that field may have field-targeted attributes applied directly to it via the automatically implemented property's *property_declaration* ([§14.7.1](classes.md#1471-general)).
+
+> *Example*: The following code
+>
+> ```csharp
+> public class Foo
+> {
+>     [field: NonSerialized]
+>     public string MySecret { get; set; }
+> }
+> ```
+> results in the field-targeted attribute `NonSerialized` being applied to the compiler-generated backing field, as if the code had been written as follows:
+> ```csharp
+> [Serializable]
+> public class Foo
+> {
+>     [NonSerialized]
+>     private string _mySecretBackingField;
+>     public string MySecret
+>     {
+>         get { return _mySecretBackingField; }
+>         set { _mySecretBackingField = value; }
+>     }
+> }
+> ```
+>
+> *end example*
+
 ### 14.7.5 Accessibility
 
 If an accessor has an *accessor_modifier*, the accessibility domain ([§7.5.3](basic-concepts.md#753-accessibility-domains)) of the accessor is determined using the declared accessibility of the *accessor_modifier*. If an accessor does not have an *accessor_modifier*, the accessibility domain of the accessor is determined from the declared accessibility of the property or indexer.


### PR DESCRIPTION
Note that v6 PR #11 modifies much of 15.7.4, and in this new PR, we’re adding new text at the end of that section, which should not overlap with the v6 mods, which had not yet been merged when this new PR was created.