### PR TITLE
Update markdown-links-verifier to 0.1.0

### DIFF
--- a/.github/workflows/markdown-links-verifier.yaml
+++ b/.github/workflows/markdown-links-verifier.yaml
@@ -11,4 +11,4 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Validate links
-      uses: Youssef1313/markdown-links-verifier@v0.0.9
+      uses: Youssef1313/markdown-links-verifier@v0.1.0


### PR DESCRIPTION
Changes:

- Validate heading links. See [PR #71](https://github.com/Youssef1313/markdown-links-verifier/pull/71).

