### PR TITLE
change language identifier on code block

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -4081,7 +4081,7 @@ Finalizers are invoked automatically, and cannot be invoked explicitly. An insta
 > }
 > ```
 > is
-> ```csharp
+> ```console
 > B's finalizer
 > A's finalizer
 > ```


### PR DESCRIPTION
GitHub is showing the text output formatted as C# using syntax highlighting. This sample is showing the output from a program, so should use the "console" language identifier.