### PR TITLE
Fix bad link references

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -2173,7 +2173,7 @@ The `typeof` operator can be used on a type parameter. The result is the `System
 
 ### 12.7.13 The sizeof operator
 
-The `sizeof` operator returns the number of 8-bit bytes occupied by a variable of a given type. The type specified as an operand to sizeof shall be an *unmanaged_type* ($unmanaged-types-new-clause).
+The `sizeof` operator returns the number of 8-bit bytes occupied by a variable of a given type. The type specified as an operand to sizeof shall be an *unmanaged_type* (§unmanaged-types-new-clause).
 
 ```ANTLR
 sizeof_expression

--- a/standard/types.md
+++ b/standard/types.md
@@ -444,7 +444,7 @@ The detailed rules for name lookup in the *namespace_or_type_name* productions i
 > ```
 > *end example*
 
-A non-enum constructed type shall not be used as an *unmanaged_type* ($unmanaged-types-new-clause).
+A non-enum constructed type shall not be used as an *unmanaged_type* (§unmanaged-types-new-clause).
 
 ### 9.4.2 Type arguments
 
@@ -543,7 +543,7 @@ Since a type parameter can be instantiated with many different type arguments, t
 > - A `new` expression [§12.7.11.2](expressions.md#127112-object-creation-expressions) can only be used with a type parameter if the type parameter is constrained by a *constructor_constraint* or the value type constraint [§15.2.5](classes.md#1525-type-parameter-constraints).
 > - A type parameter cannot be used anywhere within an attribute.
 > - A type parameter cannot be used in a member access [§12.7.5](expressions.md#1275-member-access) or type name [§8.8](basic-concepts.md#88-namespace-and-type-names) to identify a static member or a nested type.
-> - A type parameter cannot be used as an *unmanaged_type* ($unmanaged-types-new-clause). *end note*
+> - A type parameter cannot be used as an *unmanaged_type* (§unmanaged-types-new-clause). *end note*
 
 As a type, type parameters are purely a compile-time construct. At run-time, each type parameter is bound to a run-time type that was specified by supplying a type argument to the generic type declaration. Thus, the type of a variable declared with a type parameter will, at run-time, be a closed constructed type [§9.4.3](types.md#943-open-and-closed-types). The run-time execution of all statements and expressions involving type parameters uses the type that was supplied as the type argument for that parameter.
 

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -95,7 +95,7 @@ When the `unsafe` modifier is used on a partial type declaration ([§15.2.7](cla
 
 In an unsafe context, a *type* ([§9.1](types.md#91-general)) can be a *pointer_type* as well as a *value_type*, a *reference_type*, or a *type_parameter*. In an unsafe context a pointer-type may also be the element type of an array ([§17](arrays.md#17-arrays)). A *pointer-type* may also be used in a typeof expression ([§12.7.12](expressions.md#12712-the-typeof-operator)) outside of an unsafe context (as such usage is not unsafe).
 
-A *pointer_type* is written as an *unmanaged_type* ($unmanaged-types-new-clause) or the keyword `void`, followed by a `*` token:
+A *pointer_type* is written as an *unmanaged_type* (§unmanaged-types-new-clause) or the keyword `void`, followed by a `*` token:
 
 ```ANTLR
 pointer_type
@@ -845,9 +845,9 @@ stackalloc_initializer
     ;
 ```
 
-The *unmanaged_type* ($unmanaged-types-new-clause) indicates the type of the items that will be stored in the newly allocated location, and the *expression* indicates the number of these items. Taken together, these specify the required allocation size. Since the size of a stack allocation cannot be negative, it is a compile-time error to specify the number of items as a *constant_expression* that evaluates to a negative value.
+The *unmanaged_type* (§unmanaged-types-new-clause) indicates the type of the items that will be stored in the newly allocated location, and the *expression* indicates the number of these items. Taken together, these specify the required allocation size. Since the size of a stack allocation cannot be negative, it is a compile-time error to specify the number of items as a *constant_expression* that evaluates to a negative value.
 
-A stack allocation initializer of the form stackalloc `T[E]` requires `T` to be an unmanaged type ([§23.3](unsafe-code.md#233-pointer-types)) and `E` to be an expression implicitly convertible to type int. The construct allocates `E * sizeof(T)` bytes from the call stack and returns a pointer, of type `T*`, to the newly allocated block. If `E` is a negative value, then the behavior is undefined. If `E` is zero, then no allocation is made, and the pointer returned is implementation-defined. If there is not enough memory available to allocate a block of the given size, a `System.StackOverflowException` is thrown.
+A stack allocation initializer of the form stackalloc `T[E]` requires `T` to be an unmanaged type ([§23.3](unsafe-code.md#233-pointer-types)) and `E` to be an expression implicitly convertible to type `int`. The construct allocates `E * sizeof(T)` bytes from the call stack and returns a pointer, of type `T*`, to the newly allocated block. If `E` is a negative value, then the behavior is undefined. If `E` is zero, then no allocation is made, and the pointer returned is implementation-defined. If there is not enough memory available to allocate a block of the given size, a `System.StackOverflowException` is thrown.
 
 The content of the newly allocated memory is undefined.
 


### PR DESCRIPTION
In 4 places in 3 files, I'd written $ instead of § to introduce a link's destination for a link that did not yet exist.

I also fixed a code-fencing error.