### PR TITLE
Section renumbering tool fixes

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -2319,7 +2319,7 @@ If the *type* in a *default_value_expression* evaluates at run-time to a referen
 
 A *default_value_expression* is a constant expression ([§12.20](expressions.md#1220-constant-expressions)) if *type* is a reference type or a type parameter that is known to be a reference type ([§9.2](types.md#92-reference-types)). In addition, a *default_value_expression* is a constant expression if the type is one of the following value types: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal`, `bool,` or any enumeration type.
 
-### 12.7.16 Nameof expressions
+### §expressions-nameof-expressions Nameof expressions
 
 A *nameof_expression* is used to obtain the name of a program entity as a constant string.
 

--- a/standard/grammar.md
+++ b/standard/grammar.md
@@ -627,7 +627,7 @@ type_parameter
     : Identifier
     ;
 
-// Source: §9.8 Unmanaged types
+// Source: Unmanaged types
 unmanaged_type
     : type
     ;
@@ -863,7 +863,7 @@ default_value_expression
     : 'default' '(' type ')'
     ;
 
-// Source: §12.7.16 Nameof expressions
+// Source: Nameof expressions
 nameof_expression
     : 'nameof' '(' named_entity ')'
     ;

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -280,7 +280,7 @@ Token
 
 ### 7.4.2 Unicode character escape sequences
 
-A Unicode escape sequence represents a Unicode code point. Unicode escape sequences are processed in identifiers ([§7.4.3](lexical-structure.md#743-identifiers)), character literals ([§7.4.5.5](lexical-structure.md#7455-character-literals)), regular string literals ([§7.4.5.6](lexical-structure.md#7456-string-literals)), and interpolated regular string literals (§interpolated-string-literals-new-clause). A Unicode escape sequence is not processed in any other location (for example, to form an operator, punctuator, or keyword).
+A Unicode escape sequence represents a Unicode code point. Unicode escape sequences are processed in identifiers ([§7.4.3](lexical-structure.md#743-identifiers)), character literals ([§7.4.5.5](lexical-structure.md#7455-character-literals)), and regular string literals ([§7.4.5.6](lexical-structure.md#7456-string-literals)). A Unicode escape sequence is not processed in any other location (for example, to form an operator, punctuator, or keyword).
 
 ```ANTLR
 Unicode_Escape_Sequence

--- a/standard/types.md
+++ b/standard/types.md
@@ -608,7 +608,7 @@ Because of this equivalence, the following holds:
 - The type `dynamic` is indistinguishable from `object` at run-time.
 - An expression of the type `dynamic` is referred to as a ***dynamic expression***.
 
-## 9.8 Unmanaged types
+## §unmanaged-types-new-clause Unmanaged types
 
 ```ANTLR
 unmanaged_type

--- a/tools/StandardAnchorTags/Program.cs
+++ b/tools/StandardAnchorTags/Program.cs
@@ -54,7 +54,7 @@ namespace StandardAnchorTags
             "bibliography.md"
         };
 
-        static async Task Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             bool dryRun = ((args.Length > 0) && (args[0].Contains("dryrun")));
             if (dryRun)
@@ -119,7 +119,9 @@ namespace StandardAnchorTags
                     Console.WriteLine($" -- {file}");
                     await fixup.ReplaceReferences(file);
                 }
-            } catch (InvalidOperationException e)
+                return fixup.ErrorCount;
+            }
+            catch (InvalidOperationException e)
             {
                 Console.WriteLine("\tError encountered:");
                 Console.WriteLine(e.Message.ToString());
@@ -127,6 +129,7 @@ namespace StandardAnchorTags
                 Console.WriteLine("1. Discard all changes from the section numbering tool");
                 Console.WriteLine("2. Fix the error noted above.");
                 Console.WriteLine("3. Run the tool again.");
+                return 1;
             }
         }
 

--- a/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
+++ b/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
@@ -13,6 +13,7 @@ namespace StandardAnchorTags
         private readonly IReadOnlyDictionary<string, SectionLink> linkMap;
         private readonly bool dryRun;
         private readonly string PathToFiles;
+        public int ErrorCount { get; private set; }
 
         public ReferenceUpdateProcessor(string pathToFiles, IReadOnlyDictionary<string, SectionLink> linkMap, bool dryRun)
         {
@@ -59,22 +60,30 @@ namespace StandardAnchorTags
             {
                 // Grab the section text:
                 string referenceText = line[sectionReferenceRange];
+                string linkText = referenceText;
                 if ((referenceText.Length > 1) &&
                     (!linkMap.ContainsKey(referenceText)))
                 {
-                    throw new InvalidOperationException($"Section reference [{referenceText}] not found at line {lineNumber} in {file}");
+                    var msg = $"Section reference [{referenceText}] not found at line {lineNumber} in {file}";
+                    if (dryRun)
+                    {
+                        ErrorCount++;
+                        Console.WriteLine(msg);
+                    }
+                    else
+                        throw new InvalidOperationException(msg);
+                } else
+                {
+                    linkText = linkMap[referenceText].FormattedMarkdownLink;
                 }
-                // Optionally expand the range for an existing link:
+                // expand the range for any existing link:
                 sectionReferenceRange = ExpandToIncludeExistingLink(line, sectionReferenceRange);
 
                 var textRangeToCopyUnchanged = new Range(index, sectionReferenceRange.Start);
                 // Copy text up to replacement:
                 returnedLine.Append(line[textRangeToCopyUnchanged]);
 
-                // Oddly, we have a few blank references in the standard:
-                returnedLine.Append(referenceText.Length > 1 
-                    ? linkMap[referenceText].FormattedMarkdownLink
-                    : referenceText);
+                returnedLine.Append(linkText);
                 index = sectionReferenceRange.End.Value;
             }
             // Copy remaining text
@@ -90,16 +99,21 @@ namespace StandardAnchorTags
             if (startIndex == -1) return default;
             int endIndex = startIndex + 1;
 
-            // Find the end:
-            // Special case the first character, because it could be an Annex:
-            if (line[endIndex] >= 'A' && line[endIndex] <= 'Z') endIndex++;
-
-            // Remaining must be 0..9, or .: (TODO: update with range pattern in C# 9.0 in time)
-            while ((endIndex < line.Length) &&
-                ((line[endIndex] >= '0' && line[endIndex] <= '9') || (line[endIndex] == '.')))
+            // The first character not in the set of:
+            // A..Z
+            // a..z
+            // 0..9
+            // .
+            // - 
+            // indicates the end of the link reference.
+            while (line[endIndex] switch
             {
-                endIndex++;
-            }
+                >= 'A' and <= 'Z' => true,
+                >= 'a' and <= 'z' => true,
+                >= '0' and <= '9' => true,
+                '.' or '-' => true,
+                _ => false,
+            }) endIndex++;
 
             // One final special case: If the last character is '.', it's not 
             // part of the section reference, it's the period at the end of a sentence:


### PR DESCRIPTION
See https://github.com/dotnet/csharpstandard/pull/335#issuecomment-862406985

I had missed a coding task to replace links to new sections.  I discovered this when merging #335. I expected links to be updated, and they weren't.  

I updated the code so that:

- In dry-run mode, any and all references to links that aren't in the section map are reported to standard out, and the GitHub action fails. That will fix any typos in links to new sections in the future. (Or an issue I found in this PR where we have a link to a section that will be added when we merge the interpolated strings PR).
- Add a non-zero return code in dry run mode so that any validation errors are caught before a PR is merged.
- Fix the code that looks for links to sections so that it successfully recognizes any links to a section added in the same PR.

In the standard text, I put the new clause keys back in the two clauses that were added. I used that as a test case locally to verify these fixes.

NOTE:  The GitHub action that runs when we merge a PR runs the section renumbering tool before the grammar extraction tool. That means the grammar annex contains text comments for the sections where the grammar was extracted from, but those are not live links. I think that's correct. Otherwise, we'd need to format those with the HTTP:// links because they are in an ANTLR block, and not parsed as markdown. That's why I removed the two clause numbers for the clauses that have been recently added. This PR removes the numbers and the section renumbering tool found those as errors.
