### PR TITLE
The ANTLR-isation of the lexical grammar. The C# "lexical" grammar bo…

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -170,7 +170,7 @@ global_attribute_target_specifier
     ;
 
 global_attribute_target
-    : Identifier
+    : identifier
     ;
 
 attributes
@@ -187,8 +187,8 @@ attribute_target_specifier
     ;
 
 attribute_target
-    : Identifier
-    | Keyword
+    : identifier
+    | keyword
     ;
 
 attribute_list
@@ -222,7 +222,7 @@ named_argument_list
     ;
 
 named_argument
-    : Identifier '=' attribute_argument_expression
+    : identifier '=' attribute_argument_expression
     ;
 
 attribute_argument_expression
@@ -230,7 +230,7 @@ attribute_argument_expression
     ;
 ```
 
-For the production *global_attribute_target*, and in the text below, *Identifier* shall have a spelling equal to `assembly` or `module`, where equality is that defined in [§7.4.3](lexical-structure.md#743-identifiers). For the production *attribute_target*, and in the text below, *Identifier* shall have a spelling that is not equal to `assembly` or `module`, using the same definition of equality as above.
+For the production *global_attribute_target*, and in the text below, *identifier* shall have a spelling equal to `assembly` or `module`, where equality is that defined in [§7.4.3](lexical-structure.md#743-identifiers). For the production *attribute_target*, and in the text below, *identifier* shall have a spelling that is not equal to `assembly` or `module`, using the same definition of equality as above.
 
 An attribute consists of an *attribute_name* and an optional list of positional and named arguments. The positional arguments (if any) precede the named arguments. A positional argument consists of an *attribute_argument_expression*; a named argument consists of a name, followed by an equal sign, followed by an *attribute_argument_expression*, which, together, are constrained by the same rules as simple assignment. The order of named arguments is not significant.
 
@@ -303,7 +303,7 @@ By convention, attribute classes are named with a suffix of `Attribute`. An *att
   * The characters `Attribute` are appended to the right-most identifier in the *attribute_name* and the resulting string of tokens is resolved as a *type_name* ([§8.8](basic-concepts.md#88-namespace-and-type-names)) except any errors are suppressed. If this resolution is successful and results in a type derived from `System.Attribute` then the type is the result of this step.      
 If exactly one of the two steps above results in a type derived from `System.Attribute`, then that type is the result of the *attribute-name*. Otherwise a compile-time error occurs.
 
-*Example*: If an attribute class is found both with and without this suffix, an ambiguity is present, and a compile-time error results. If the *attribute_name* is spelled such that its right-most *Identifier* is a verbatim identifier ([§7.4.3](lexical-structure.md#743-identifiers)), then only an attribute without a suffix is matched, thus enabling such an ambiguity to be resolved. The example
+*Example*: If an attribute class is found both with and without this suffix, an ambiguity is present, and a compile-time error results. If the *attribute_name* is spelled such that its right-most *identifier* is a verbatim identifier ([§7.4.3](lexical-structure.md#743-identifiers)), then only an attribute without a suffix is matched, thus enabling such an ambiguity to be resolved. The example
 > ```csharp
 > using System;
 > [AttributeUsage(AttributeTargets.All)]
@@ -434,7 +434,7 @@ The compilation of an *attribute* with attribute class `T`, *positional_argumen
 * Follow the compile-time processing steps for compiling an *object_creation_expression* of the form new `T(P)`. These steps either result in a compile-time error, or determine an instance constructor `C` on `T` that can be invoked at run-time.
 * If `C` does not have public accessibility, then a compile-time error occurs.
 * For each *named_argument* `Arg` in `N`:
-  * Let `Name` be the *Identifier* of the *named_argument* `Arg`.
+  * Let `Name` be the *identifier* of the *named_argument* `Arg`.
   * `Name` shall identify a non-static read-write public field or property on `T`. If `T` has no such field or property, then a compile-time error occurs.
 * If any of the values within *positional_argument_list* `P` or one of the values within *named_argument_list* `N` is of type `System.String` and the value is not well-formed as defined by the Unicode Standard, it is implementation-defined whether the value compiled is equal to the run-time value retrieved ([§22.4.3](attributes.md#2243-run-time-retrieval-of-an-attribute-instance)). 
   > *Note*: As an example, a string which contains a high surrogate UTF-16 code unit which isn't immediately followed by a low surrogate code unit is not well-formed. *end note*
@@ -446,7 +446,7 @@ The attribute instance represented by `T`, `C`, `P`, and `N`, and associated wi
 
 - Follow the run-time processing steps for executing an *object_creation_expression* of the form `new T(P)`, using the instance constructor `C` and values as determined at compile-time. These steps either result in an exception, or produce an instance `O` of `T`.
 - For each *named_argument* `Arg` in `N`, in order:
-  - Let `Name` be the *Identifier* of the *named_argument* `Arg`. If `Name` does not identify a non-static public read-write field or property on `O`, then an exception is thrown.
+  - Let `Name` be the *identifier* of the *named_argument* `Arg`. If `Name` does not identify a non-static public read-write field or property on `O`, then an exception is thrown.
   - Let `Value` be the result of evaluating the *attribute_argument_expression* of `Arg`.
   - If `Name` identifies a field on `O`, then set this field to `Value`.
   - Otherwise, Name identifies a property on `O`. Set this property to Value.

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -665,8 +665,8 @@ type_name
     ;
     
 namespace_or_type_name
-    : Identifier type_argument_list?
-    | namespace_or_type_name '.' Identifier type_argument_list?
+    : identifier type_argument_list?
+    | namespace_or_type_name '.' identifier type_argument_list?
     | qualified_alias_member
     ;
 ```
@@ -722,8 +722,8 @@ A *namespace_or_type_name* is permitted to reference a static class ([§15.2.2.4
 Every namespace declaration and type declaration has an ***unqualified name*** determined as follows:
 
 -   For a namespace declaration, the unqualified name is the *qualified_identifier* specified in the declaration.
--   For a type declaration with no *type_parameter_list*, the unqualified name is the *Identifier* specified in the declaration.
--   For a type declaration with K type parameters, the unqualified name is the *Identifier* specified in the declaration, followed by the *generic_dimension_specifier* ([§12.7.12](expressions.md#12712-the-typeof-operator)) for K type parameters.
+-   For a type declaration with no *type_parameter_list*, the unqualified name is the *identifier* specified in the declaration.
+-   For a type declaration with K type parameters, the unqualified name is the *identifier* specified in the declaration, followed by the *generic_dimension_specifier* ([§12.7.12](expressions.md#12712-the-typeof-operator)) for K type parameters.
 
 ### 8.8.3 Fully qualified names
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -12,12 +12,12 @@ A *class_declaration* is a *type_declaration* ([§14.7](namespaces.md#147-type-d
 
 ```ANTLR
 class_declaration
-  : attributes? class_modifier* 'partial'? 'class' Identifier type_parameter_list?
+  : attributes? class_modifier* 'partial'? 'class' identifier type_parameter_list?
   class_base? type_parameter_constraints_clause* class_body ';'?
   ;
 ```
 
-A *class_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *class_modifier*s ([§15.2.2](classes.md#1522-class-modifiers)), followed by an optional `partial` modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword `class` and an *Identifier* that names the class, followed by an optional *type_parameter_list* ([§15.2.3](classes.md#1523-type-parameters)), followed by an optional *class_base* specification ([§15.2.4](classes.md#1524-class-base-specification)), followed by an optional set of *type_parameter_constraints_clause*s ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by a *class_body* ([§15.2.6](classes.md#1526-class-body)), optionally followed by a semicolon.
+A *class_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *class_modifier*s ([§15.2.2](classes.md#1522-class-modifiers)), followed by an optional `partial` modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword `class` and an *identifier* that names the class, followed by an optional *type_parameter_list* ([§15.2.3](classes.md#1523-type-parameters)), followed by an optional *class_base* specification ([§15.2.4](classes.md#1524-class-base-specification)), followed by an optional set of *type_parameter_constraints_clause*s ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by a *class_body* ([§15.2.6](classes.md#1526-class-body)), optionally followed by a semicolon.
 
 A class declaration shall not supply a *type_parameter_constraints_clause*s unless it also supplies a *type_parameter_list*.
 
@@ -1189,7 +1189,7 @@ constant_modifier
 
 A *constant_declaration* may include a set of *attributes* ([§22](attributes.md#22-attributes)), a `new` modifier ([§15.3.5](classes.md#1535-the-new-modifier)), and a valid combination of the four access modifiers ([§15.3.6](classes.md#1536-access-modifiers)). The attributes and modifiers apply to all of the members declared by the *constant_declaration*. Even though constants are considered static members, a *constant_declaration* neither requires nor allows a `static` modifier. It is an error for the same modifier to appear multiple times in a constant declaration.
 
-The *type* of a *constant_declaration* specifies the type of the members introduced by the declaration. The type is followed by a list of *constant_declarator*s ([§13.6.3](statements.md#1363-local-constant-declarations)), each of which introduces a new member. A *constant_declarator* consists of an *Identifier* that names the member, followed by an "`=`" token, followed by a *constant_expression* ([§12.20](expressions.md#1220-constant-expressions)) that gives the value of the member.
+The *type* of a *constant_declaration* specifies the type of the members introduced by the declaration. The type is followed by a list of *constant_declarator*s ([§13.6.3](statements.md#1363-local-constant-declarations)), each of which introduces a new member. A *constant_declarator* consists of an *identifier* that names the member, followed by an "`=`" token, followed by a *constant_expression* ([§12.20](expressions.md#1220-constant-expressions)) that gives the value of the member.
 
 The *type* specified in a constant declaration shall be `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal`, `bool`, `string`, an *enum_type*, or a *reference_type*. Each *constant_expression* shall yield a value of the target type or of a type that can be converted to the target type by an implicit conversion ([§11.2](conversions.md#112-implicit-conversions)).
 
@@ -1275,7 +1275,7 @@ variable_declarators
     ;
 
 variable_declarator
-    : Identifier ('=' variable_initializer)?
+    : identifier ('=' variable_initializer)?
     ;
 ```
 
@@ -1283,7 +1283,7 @@ variable_declarator
 
 A *field_declaration* may include a set of *attributes* ([§22](attributes.md#22-attributes)), a `new` modifier ([§15.3.5](classes.md#1535-the-new-modifier)), a valid combination of the four access modifiers ([§15.3.6](classes.md#1536-access-modifiers)), and a `static` modifier ([§15.5.2](classes.md#1552-static-and-instance-fields)). In addition, a *field_declaration* may include a `readonly` modifier ([§15.5.3](classes.md#1553-readonly-fields)) or a `volatile` modifier ([§15.5.4](classes.md#1554-volatile-fields)), but not both. The attributes and modifiers apply to all of the members declared by the *field_declaration*. It is an error for the same modifier to appear multiple times in a *field_declaration*.
 
-The *type* of a *field_declaration* specifies the type of the members introduced by the declaration. The type is followed by a list of *variable_declarator*s, each of which introduces a new member. A *variable_declarator* consists of an *Identifier* that names that member, optionally followed by an "`=`" token and a *variable_initializer* ([§15.5.6](classes.md#1556-variable-initializers)) that gives the initial value of that member.
+The *type* of a *field_declaration* specifies the type of the members introduced by the declaration. The type is followed by a list of *variable_declarator*s, each of which introduces a new member. A *variable_declarator* consists of an *identifier* that names that member, optionally followed by an "`=`" token and a *variable_initializer* ([§15.5.6](classes.md#1556-variable-initializers)) that gives the initial value of that member.
 
 The *type* of a field shall be at least as accessible as the field itself ([§8.5.5](basic-concepts.md#855-accessibility-constraints)).
 
@@ -1616,8 +1616,8 @@ return_type
     ;
 
 member_name
-    : Identifier
-    | interface_type '.' Identifier
+    : identifier
+    | interface_type '.' identifier
     ;
 
 method_body
@@ -1644,7 +1644,7 @@ A declaration has a valid combination of modifiers if all of the following are t
 
 The *return_type* of a method declaration specifies the type of the value computed and returned by the method. The *return_type* is `void` if the method does not return a value. If the declaration includes the `partial` modifier, then the return type shall be `void` ([§15.6.9](classes.md#1569-partial-methods)). If the declaration includes the `async` modifier then the return type shall be `void` or a *task type* ([§15.15.1](classes.md#15151-general)).
 
-A generic method is a method whose declaration includes a *type_parameter_list*. This specifies the type parameters for the method. The optional *type_parameter_constraints_clause*s specify the constraints for the type parameters. A *method_declaration* shall not have *type_parameter_constraints_clauses* unless it also has a *type_parameter_list*. A *method_declaration* for an explicit interface member implementation shall not have any *type_parameter_constraints_clause*s. A generic *method_declaration* for an explicit interface member implementation inherits any constraints from the constraints on the interface method. Similarly, a method declaration with the `override` modifier shall not have any *type_parameter_constraints_clause*s and the constraints of the method's type parameters are inherited from the virtual method being overridden.The *member_name* specifies the name of the method. Unless the method is an explicit interface member implementation ([§18.6.2](interfaces.md#1862-explicit-interface-member-implementations)), the *member_name* is simply an *Identifier*. For an explicit interface member implementation, the *member_name* consists of an *interface_type* followed by a "`.`" and an *Identifier*. In this case, the declaration shall include no modifiers other than (possibly) `extern` or `async`.
+A generic method is a method whose declaration includes a *type_parameter_list*. This specifies the type parameters for the method. The optional *type_parameter_constraints_clause*s specify the constraints for the type parameters. A *method_declaration* shall not have *type_parameter_constraints_clauses* unless it also has a *type_parameter_list*. A *method_declaration* for an explicit interface member implementation shall not have any *type_parameter_constraints_clause*s. A generic *method_declaration* for an explicit interface member implementation inherits any constraints from the constraints on the interface method. Similarly, a method declaration with the `override` modifier shall not have any *type_parameter_constraints_clause*s and the constraints of the method's type parameters are inherited from the virtual method being overridden.The *member_name* specifies the name of the method. Unless the method is an explicit interface member implementation ([§18.6.2](interfaces.md#1862-explicit-interface-member-implementations)), the *member_name* is simply an *identifier*. For an explicit interface member implementation, the *member_name* consists of an *interface_type* followed by a "`.`" and an *identifier*. In this case, the declaration shall include no modifiers other than (possibly) `extern` or `async`.
 
 The optional *formal_parameter_list* specifies the parameters of the method ([§15.6.2](classes.md#1562-method-parameters)).
 
@@ -1682,7 +1682,7 @@ fixed_parameters
     ;
 
 fixed_parameter
-    : attributes? parameter_modifier? type Identifier default_argument?
+    : attributes? parameter_modifier? type identifier default_argument?
     ;
 
 default_argument
@@ -1700,13 +1700,13 @@ parameter_mode_modifier
     ;
 
 parameter_array
-    : attributes? 'params' array_type Identifier
+    : attributes? 'params' array_type identifier
     ;
 ```
 
 The formal parameter list consists of one or more comma-separated parameters of which only the last may be a *parameter_array*.
 
-A *fixed_parameter* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)); an optional `ref`, `out`, or `this` modifier; a *type*; an *Identifier*; and an optional *default-argument*. Each *fixed_parameter* declares a parameter of the given type with the given name. The `this` modifier designates the method as an extension method and is only allowed on the first parameter of a static method in a non-generic, non-nested static class. Extension methods are further described in [§15.6.10](classes.md#15610-extension-methods). A *fixed_parameter* with a *default_argument* is known as an ***optional parameter***, whereas a *fixed_parameter* without a *default_argument* is a ***required parameter***. A required parameter may not appear after an optional parameter in a *formal_parameter_list*.
+A *fixed_parameter* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)); an optional `ref`, `out`, or `this` modifier; a *type*; an *identifier*; and an optional *default-argument*. Each *fixed_parameter* declares a parameter of the given type with the given name. The `this` modifier designates the method as an extension method and is only allowed on the first parameter of a static method in a non-generic, non-nested static class. Extension methods are further described in [§15.6.10](classes.md#15610-extension-methods). A *fixed_parameter* with a *default_argument* is known as an ***optional parameter***, whereas a *fixed_parameter* without a *default_argument* is a ***required parameter***. A required parameter may not appear after an optional parameter in a *formal_parameter_list*.
 
 A parameter with a `ref`, `out` or `this` modifier cannot have a *default_argument*. The *expression* in a *default_argument* shall be one of the following:
 
@@ -1718,7 +1718,7 @@ The *expression* shall be implicitly convertible by an identity or nullable conv
 
 If optional parameters occur in an implementing partial method declaration ([§15.6.9](classes.md#1569-partial-methods)), an explicit interface member implementation ([§18.6.2](interfaces.md#1862-explicit-interface-member-implementations)), a single-parameter indexer declaration ([§15.9](classes.md#159-indexers)), or in an operator declaration ([§15.10.1](classes.md#15101-general)) the compiler should give a warning, since these members can never be invoked in a way that permits arguments to be omitted.
 
-A *parameter_array* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), a `params` modifier, an *array_type*, and an *Identifier*. A parameter array declares a single parameter of the given array type with the given name. The *array_type* of a parameter array shall be a single-dimensional array type ([§17.2](arrays.md#172-array-types)). In a method invocation, a parameter array permits either a single argument of the given array type to be specified, or it permits zero or more arguments of the array element type to be specified. Parameter arrays are described further in [§15.6.2.5](classes.md#15625-parameter-arrays).
+A *parameter_array* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), a `params` modifier, an *array_type*, and an *identifier*. A parameter array declares a single parameter of the given array type with the given name. The *array_type* of a parameter array shall be a single-dimensional array type ([§17.2](arrays.md#172-array-types)). In a method invocation, a parameter array permits either a single argument of the given array type to be specified, or it permits zero or more arguments of the array element type to be specified. Parameter arrays are described further in [§15.6.2.5](classes.md#15625-parameter-arrays).
 
 A *parameter_array* may occur after an optional parameter, but cannot have a default value – the omission of arguments for a *parameter_array* would instead result in the creation of an empty array.
 
@@ -2586,7 +2586,7 @@ A *property_declaration* may include a set of *attributes* ([§22](attributes.md
 
 Property declarations are subject to the same rules as method declarations ([§15.6](classes.md#156-methods)) with regard to valid combinations of modifiers.
 
-The *type* of a property declaration specifies the type of the property introduced by the declaration, and the *member_name* ([§15.6.1](classes.md#1561-general)) specifies the name of the property. Unless the property is an explicit interface member implementation, the *member_name* is simply an *Identifier*. For an explicit interface member implementation ([§18.6.2](interfaces.md#1862-explicit-interface-member-implementations)), the *member_name* consists of an *interface_type* followed by a "`.`" and an *Identifier*.
+The *type* of a property declaration specifies the type of the property introduced by the declaration, and the *member_name* ([§15.6.1](classes.md#1561-general)) specifies the name of the property. Unless the property is an explicit interface member implementation, the *member_name* is simply an *identifier*. For an explicit interface member implementation ([§18.6.2](interfaces.md#1862-explicit-interface-member-implementations)), the *member_name* consists of an *interface_type* followed by a "`.`" and an *identifier*.
 
 The *type* of a property shall be at least as accessible as the property itself ([§8.5.5](basic-concepts.md#855-accessibility-constraints)).
 
@@ -3474,7 +3474,7 @@ binary_operator_declarator
 
 overloadable_binary_operator
   : '+'  | '-'  | '*'  | '/'  | '%'  | '&' | '|' | '^'  | '<<' 
-  | Right_Shift | '==' | '!=' | '>' | '<' | '>=' | '<='
+  | right_shift | '==' | '!=' | '>' | '<' | '>=' | '<='
   ;
 
 conversion_operator_declarator
@@ -3693,7 +3693,7 @@ constructor_modifier
   ;
 
 constructor_declarator
-  : Identifier '(' formal_parameter_list? ')' constructor_initializer?
+  : identifier '(' formal_parameter_list? ')' constructor_initializer?
   ;
 
 constructor_initializer
@@ -3711,7 +3711,7 @@ constructor_body
 
 A *constructor_declaration* may include a set of *attributes* ([§22](attributes.md#22-attributes)), a valid combination of the four access modifiers ([§15.3.6](classes.md#1536-access-modifiers)), and an `extern` ([§15.6.8](classes.md#1568-external-methods)) modifier. A constructor declaration is not permitted to include the same modifier multiple times.
 
-The *Identifier* of a *constructor_declarator* shall name the class in which the instance constructor is declared. If any other name is specified, a compile-time error occurs.
+The *identifier* of a *constructor_declarator* shall name the class in which the instance constructor is declared. If any other name is specified, a compile-time error occurs.
 
 The optional *formal_parameter_list* of an instance constructor is subject to the same rules as the *formal_parameter_list* of a method ([§15.6](classes.md#156-methods)). As the `this` modifier for parameters only applies to extension methods ([§15.6.10](classes.md#15610-extension-methods)), no parameter in a constructor's *formal_parameter_list* shall contain the `this` modifier. The formal parameter list defines the signature ([§8.6](basic-concepts.md#86-signatures-and-overloading)) of an instance constructor and governs the process whereby overload resolution ([§12.6.4](expressions.md#1264-overload-resolution)) selects a particular instance constructor in an invocation.
 
@@ -3903,7 +3903,7 @@ A ***static constructor*** is a member that implements the actions required to i
 
 ```ANTLR
 static_constructor_declaration
-  : attributes? static_constructor_modifiers Identifier '(' ')' static_constructor_body
+  : attributes? static_constructor_modifiers identifier '(' ')' static_constructor_body
   ;
 
 static_constructor_modifiers
@@ -3926,7 +3926,7 @@ static_constructor_body
 
 A *static_constructor_declaration* may include a set of *attributes* ([§22](attributes.md#22-attributes)) and an `extern` modifier ([§15.6.8](classes.md#1568-external-methods)).
 
-The *Identifier* of a *static_constructor_declaration* shall name the class in which the static constructor is declared. If any other name is specified, a compile-time error occurs.
+The *identifier* of a *static_constructor_declaration* shall name the class in which the static constructor is declared. If any other name is specified, a compile-time error occurs.
 
 When a static constructor declaration includes an `extern` modifier, the static constructor is said to be an ***external static constructor***. Because an external static constructor declaration provides no actual implementation, its *static_constructor_body* consists of a semicolon. For all other static constructor declarations, the *static_constructor_body* consists of a *block*, which specifies the statements to execute in order to initialize the class. This corresponds exactly to the *method_body* of a static method with a `void` return type ([§15.6.11](classes.md#15611-method-body)).
 
@@ -4030,9 +4030,9 @@ A ***finalizer*** is a member that implements the actions required to finalize a
 
 ```ANTLR
 finalizer_declaration
-    : attributes? '~' Identifier '(' ')' finalizer_body
-    | attributes? 'extern' unsafe_modifier? '~' Identifier '(' ')' finalizer_body
-    | attributes? unsafe_modifier 'extern'? '~' Identifier '(' ')' finalizer_body
+    : attributes? '~' identifier '(' ')' finalizer_body
+    | attributes? 'extern' unsafe_modifier? '~' identifier '(' ')' finalizer_body
+    | attributes? unsafe_modifier 'extern'? '~' identifier '(' ')' finalizer_body
     ;
 
 finalizer_body
@@ -4045,7 +4045,7 @@ finalizer_body
 
 A *finalizer_declaration* may include a set of *attributes* ([§22](attributes.md#22-attributes)).
 
-The *Identifier* of a *finalizer_declarator* shall name the class in which the finalizer is declared. If any other name is specified, a compile-time error occurs.
+The *identifier* of a *finalizer_declarator* shall name the class in which the finalizer is declared. If any other name is specified, a compile-time error occurs.
 
 When a finalizer declaration includes an `extern` modifier, the finalizer is said to be an ***external finalizer***. Because an external finalizer declaration provides no actual implementation, its *finalizer_body* consists of a semicolon. For all other finalizers, the *finalizer_body* consists of a *block*, which specifies the statements to execute in order to finalize an instance of the class. A *finalizer_body* corresponds exactly to the *method_body* of an instance method with a `void` return type ([§15.6.11](classes.md#15611-method-body)).
 

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -12,7 +12,7 @@ A *delegate_declaration* is a *type_declaration* ([§14.7](namespaces.md#147-typ
 
 ```ANTLR
 delegate_declaration
-    : attributes? delegate_modifier* 'delegate' return_type Identifier variant_type_parameter_list? '(' formal_parameter_list? ')' type_parameter_constraints_clause* ';'
+    : attributes? delegate_modifier* 'delegate' return_type identifier variant_type_parameter_list? '(' formal_parameter_list? ')' type_parameter_constraints_clause* ';'
     ;
     
 delegate_modifier
@@ -37,7 +37,7 @@ The `new` modifier is only permitted on delegates declared within another type, 
 
 The `public`, `protected`, `internal`, and `private` modifiers control the accessibility of the delegate type. Depending on the context in which the delegate declaration occurs, some of these modifiers might not be permitted ([§8.5.2](basic-concepts.md#852-declared-accessibility)).
 
-The delegate's type name is *Identifier*.
+The delegate's type name is *identifier*.
 
 The optional *formal_parameter_list* specifies the parameters of the delegate, and *return_type* indicates the return type of the delegate.
 

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -22,7 +22,7 @@ An enum declaration declares a new enum type. An enum declaration begins with th
 
 ```ANTLR
 enum_declaration
-    : attributes? enum_modifier* 'enum' Identifier enum_base? enum_body ';'?
+    : attributes? enum_modifier* 'enum' identifier enum_base? enum_body ';'?
     ;
 
 enum_base
@@ -87,7 +87,7 @@ enum_member_declarations
 
 ```ANTLR
 enum_member_declaration
-    : attributes? Identifier ('=' constant_expression)?
+    : attributes? identifier ('=' constant_expression)?
     ;
 ```
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -538,7 +538,7 @@ argument
     ;
 
 argument_name
-    : Identifier ':'
+    : identifier ':'
     ;
 
 argument_value
@@ -1104,7 +1104,7 @@ primary_expression
     ;
 
 primary_no_array_creation_expression
-    : Literal
+    : literal
     | simple_name
     | parenthesized_expression
     | member_access
@@ -1155,7 +1155,7 @@ A *simple_name* consists of an identifier, optionally followed by a type argumen
 
 ```ANTLR
 simple_name
-    : Identifier type_argument_list?
+    : identifier type_argument_list?
     ;
 ```
 
@@ -1199,13 +1199,13 @@ A *parenthesized_expression* is evaluated by evaluating the *expression* within 
 
 #### 12.7.5.1 General
 
-A *member_access* consists of a *primary_expression*, a *predefined_type*, or a *qualified_alias_member*, followed by a "`.`" token, followed by an *Identifier*, optionally followed by a *type_argument_list*.
+A *member_access* consists of a *primary_expression*, a *predefined_type*, or a *qualified_alias_member*, followed by a "`.`" token, followed by an *identifier*, optionally followed by a *type_argument_list*.
 
 ```ANTLR
 member_access
-    : primary_expression '.' Identifier type_argument_list?
-    | predefined_type '.' Identifier type_argument_list?
-    | qualified_alias_member '.' Identifier type_argument_list?
+    : primary_expression '.' identifier type_argument_list?
+    | predefined_type '.' identifier type_argument_list?
+    | qualified_alias_member '.' identifier type_argument_list?
     ;
 
 predefined_type
@@ -1341,10 +1341,10 @@ Once a method has been selected and validated at binding-time by the above steps
 In a method invocation ([§12.6.6.2](expressions.md#12662-invocations-on-boxed-instances)) of one of the forms
 
 ```csharp
-«expr» . «Identifier» ( )  
-«expr» . «Identifier» ( «args» )  
-«expr» . «Identifier» < «typeargs» > ( )  
-«expr» . «Identifier» < «typeargs» > ( «args» )
+«expr» . «identifier» ( )  
+«expr» . «identifier» ( «args» )  
+«expr» . «identifier» < «typeargs» > ( )  
+«expr» . «identifier» < «typeargs» > ( «args» )
 ```
 
 if the normal processing of the invocation finds no applicable methods, an attempt is made to process the construct as an extension method invocation. If «expr» or any of the «args» has compile-time type `dynamic`, extension methods will not apply.
@@ -1352,16 +1352,16 @@ if the normal processing of the invocation finds no applicable methods, an attem
 The objective is to find the best *type_name* `C`, so that the corresponding static method invocation can take place:
 
 ```csharp
-C . «Identifier» ( «expr» )  
-C . «Identifier» ( «expr» , «args» )  
-C . «Identifier» < «typeargs» > ( «expr» )  
-C . «Identifier» < «typeargs» > ( «expr» , «args» )
+C . «identifier» ( «expr» )  
+C . «identifier» ( «expr» , «args» )  
+C . «identifier» < «typeargs» > ( «expr» )  
+C . «identifier» < «typeargs» > ( «expr» , «args» )
 ```
 
 An extension method `Cᵢ.Mₑ` is ***eligible*** if:
 
 -   `Cᵢ` is a non-generic, non-nested class
--   The name of `Mₑ` is *Identifier*
+-   The name of `Mₑ` is *identifier*
 -   `Mₑ` is accessible and applicable when applied to the arguments as a static method as shown above
 -   An implicit identity, reference or boxing conversion exists from *expr* to the type of the first parameter of `Mₑ`.
 
@@ -1547,7 +1547,7 @@ A *base_access* consists of the keyword base followed by either a "`.`" token a
 
 ```ANTLR
 base_access
-    : 'base' '.' Identifier type_argument_list?
+    : 'base' '.' identifier type_argument_list?
     | 'base' '[' argument_list ']'
     ;
 ```
@@ -1682,7 +1682,7 @@ member_initializer_list
     ;
 
 member_initializer
-    : Identifier '=' initializer_value
+    : identifier '=' initializer_value
     ;
 
 initializer_value
@@ -2022,7 +2022,7 @@ member_declarator
     : simple_name
     | member_access
     | base_access
-    | Identifier '=' expression
+    | identifier '=' expression
     ;
 ```
 
@@ -2072,11 +2072,11 @@ The `Equals` and `GetHashcode` methods on anonymous types override the methods i
 
 A member declarator can be abbreviated to a simple name ([§12.7.3](expressions.md#1273-simple-names)), a member access ([§12.7.5](expressions.md#1275-member-access)) or a base access ([§12.7.9](expressions.md#1279-base-access)). This is called a ***projection initializer*** and is shorthand for a declaration of and assignment to a property with the same name. Specifically, member declarators of the forms
 
-`«Identifier»` and `«expr» . «Identifier»`
+`«identifier»` and `«expr» . «identifier»`
 
 are precisely equivalent to the following, respectively:
 
-`«identifer» = «Identifier»` and `«Identifier» = «expr» . «Identifier»`
+`«identifer» = «identifier»` and `«identifier» = «expr» . «identifier»`
 
 Thus, in a projection initializer the identifier selects both the value and the field or property to which the value is assigned. Intuitively, a projection initializer projects not just a value, but also the name of the value.
 
@@ -2092,9 +2092,9 @@ typeof_expression
     ;
 
 unbound_type_name
-    : Identifier generic_dimension_specifier?
-    | Identifier '::' Identifier generic_dimension_specifier?
-    | unbound_type_name '.' Identifier generic_dimension_specifier?
+    : identifier generic_dimension_specifier?
+    | identifier '::' identifier generic_dimension_specifier?
+    | unbound_type_name '.' identifier generic_dimension_specifier?
     ;
 
 generic_dimension_specifier
@@ -3358,7 +3358,7 @@ The `<<` and `>>` operators are used to perform bit-shifting operations.
 shift_expression
     : additive_expression
     | shift_expression '<<' additive_expression
-    | shift_expression Right_Shift additive_expression
+    | shift_expression right_shift additive_expression
     ;
 ```
 
@@ -4065,7 +4065,7 @@ explicit_anonymous_function_parameter_list
     ;
 
 explicit_anonymous_function_parameter
-    : anonymous_function_parameter_modifier? type Identifier
+    : anonymous_function_parameter_modifier? type identifier
     ;
 
 anonymous_function_parameter_modifier
@@ -4083,7 +4083,7 @@ implicit_anonymous_function_parameter_list
     ;
 
 implicit_anonymous_function_parameter
-    : Identifier
+    : identifier
     ;
 
 anonymous_function_body
@@ -4548,7 +4548,7 @@ query_expression
     ;
 
 from_clause
-    : 'from' type? Identifier 'in' expression
+    : 'from' type? identifier 'in' expression
     ;
 
 query_body
@@ -4570,7 +4570,7 @@ query_body_clause
     ;
 
 let_clause
-    : 'let' Identifier '=' expression
+    : 'let' identifier '=' expression
     ;
 
 where_clause
@@ -4578,11 +4578,11 @@ where_clause
     ;
 
 join_clause
-    : 'join' type? Identifier 'in' expression 'on' expression 'equals' expression
+    : 'join' type? identifier 'in' expression 'on' expression 'equals' expression
     ;
 
 join_into_clause
-    : 'join' type? Identifier 'in' expression 'on' expression 'equals' expression 'into' Identifier
+    : 'join' type? identifier 'in' expression 'on' expression 'equals' expression 'into' identifier
     ;
 
 orderby_clause
@@ -4616,7 +4616,7 @@ group_clause
     ;
 
 query_continuation
-    : 'into' Identifier query_body
+    : 'into' identifier query_body
     ;
 ```	
 
@@ -4627,7 +4627,7 @@ filter that excludes items from the result. Each `join` clause compares specifie
 
 Query expressions use a number of contextual keywords ([§7.4.4](lexical-structure.md#744-keywords)): `ascending`, `by`, `descending`, `equals`, `from`, `group`, `into`, `join`, `let`, `on`, `orderby`, `select` and `where`.
 
-To avoid ambiguities that could arise from the use of these identifiers both as keywords and simple names these identifiers are considered keywords anywhere within a query expression, unless they are prefixed with "`@`" ([§7.4.4](lexical-structure.md#744-keywords)) in which case they are considered identifiers. For this purpose, a query expression is any expression that starts with "`from` *Identifier*" followed by any token except "`;`", "`=`" or "`,`".
+To avoid ambiguities that could arise from the use of these identifiers both as keywords and simple names these identifiers are considered keywords anywhere within a query expression, unless they are prefixed with "`@`" ([§7.4.4](lexical-structure.md#744-keywords)) in which case they are considered identifiers. For this purpose, a query expression is any expression that starts with "`from` *identifier*" followed by any token except "`;`", "`=`" or "`,`".
 
 ### 12.17.3 Query expression translation
 
@@ -5224,7 +5224,7 @@ assignment
 
 assignment_operator
     : '=' | '+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<='
-    | Right_Shift_Assignment
+    | right_shift_assignment
     ;
 ```
 

--- a/standard/grammar.md
+++ b/standard/grammar.md
@@ -19,23 +19,23 @@ ASTERISK : '*' ;
 SLASH    : '/' ;
 
 // Source: §7.3.1 General
-Input
-    : Input_Section?
+input
+    : input_section?
     ;
 
-Input_Section
-    : Input_Section_Part+
+input_section
+    : input_section_part+
     ;
 
-Input_Section_Part
-    : Input_Element* New_Line
+input_section_part
+    : input_element* New_Line
     | Pp_Directive
     ;
 
-Input_Element
+input_element
     : Whitespace
     | Comment
-    | Token
+    | token
     ;
 
 // Source: §7.3.2 Line terminators
@@ -89,13 +89,13 @@ Whitespace
 
 // Source: §7.4.1 General
 Token
-    : Identifier
-    | Keyword
+    : identifier
+    | keyword
     | Integer_Literal
     | Real_Literal
     | Character_Literal
     | String_Literal
-    | Operator_Or_Punctuator
+    | operator_or_punctuator
     ;
 
 // Source: §7.4.2 Unicode character escape sequences
@@ -162,7 +162,7 @@ Formatting_Character
     ;
 
 // Source: §7.4.4 Keywords
-Keyword
+keyword
     : 'abstract' | 'as'       | 'base'       | 'bool'      | 'break'
     | 'byte'     | 'case'     | 'catch'      | 'char'      | 'checked'
     | 'class'    | 'const'    | 'continue'   | 'decimal'   | DEFAULT
@@ -182,7 +182,7 @@ Keyword
     ;
 
 // Source: §7.4.4 Keywords
-Contextual_Keyword
+contextual_keyword
     : 'add'    | 'alias'      | 'ascending' | 'async'   | 'await'
     | 'by'     | 'descending' | 'dynamic'   | 'equals'  | 'from'
     | 'get'    | 'global'     | 'group'     | 'into'    | 'join'
@@ -192,17 +192,17 @@ Contextual_Keyword
     ;
 
 // Source: §7.4.5.1 General
-Literal
-    : Boolean_Literal
+literal
+    : boolean_literal
     | Integer_Literal
     | Real_Literal
     | Character_Literal
     | String_Literal
-    | Null_Literal
+    | null_literal
     ;
 
 // Source: §7.4.5.2 Boolean literals
-Boolean_Literal
+boolean_literal
     : TRUE
     | FALSE
     ;
@@ -316,12 +316,12 @@ Quote_Escape_Sequence
     ;
 
 // Source: §7.4.5.7 The null literal
-Null_Literal
+null_literal
     : NULL
     ;
 
 // Source: §7.4.6 Operators and punctuators
-Operator_Or_Punctuator
+operator_or_punctuator
     : '{'  | '}'  | '['  | ']'  | '('   | ')'  | '.'  | ','  | ':'  | ';'
     | '+'  | '-'  | ASTERISK    | SLASH | '%'  | '&'  | '|'  | '^'  | '!'  | '~'
     | '='  | '<'  | '>'  | '?'  | '??'  | '::' | '++' | '--' | '&&' | '||'
@@ -333,7 +333,7 @@ Right_Shift
     : '>'  '>'
     ;
 
-Right_Shift_Assignment
+right_shift_assignment
     : '>' '>='
     ;
 
@@ -663,7 +663,7 @@ primary_expression
     ;
 
 primary_no_array_creation_expression
-    : Literal
+    : literal
     | simple_name
     | parenthesized_expression
     | member_access
@@ -933,7 +933,7 @@ additive_expression
 shift_expression
     : additive_expression
     | shift_expression '<<' additive_expression
-    | shift_expression Right_Shift additive_expression
+    | shift_expression right_shift additive_expression
     ;
 
 // Source: §12.11.1 General
@@ -1125,7 +1125,7 @@ assignment
 
 assignment_operator
     : '=' | '+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<='
-    | Right_Shift_Assignment
+    | right_shift_assignment
     ;
 
 // Source: §12.19 Expression
@@ -1834,7 +1834,7 @@ binary_operator_declarator
 
 overloadable_binary_operator
   : '+'  | '-'  | '*'  | '/'  | '%'  | '&' | '|' | '^'  | '<<' 
-  | Right_Shift | '==' | '!=' | '>' | '<' | '>=' | '<='
+  | right_shift | '==' | '!=' | '>' | '<' | '>=' | '<='
   ;
 
 conversion_operator_declarator
@@ -2123,7 +2123,7 @@ attribute_target_specifier
 
 attribute_target
     : Identifier
-    | Keyword
+    | keyword
     ;
 
 attribute_list

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -14,11 +14,11 @@ An *interface_declaration* is a *type_declaration* ([§14.7](namespaces.md#147-t
 
 ```ANTLR 
 interface_declaration
-    : attributes? interface_modifier* 'partial'? 'interface' Identifier variant_type_parameter_list? interface_base? type_parameter_constraints_clause* interface_body ';'?
+    : attributes? interface_modifier* 'partial'? 'interface' identifier variant_type_parameter_list? interface_base? type_parameter_constraints_clause* interface_body ';'?
     ;
 ```
 
-An *interface_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *interface_modifier*s ([§18.2.2](interfaces.md#1822-interface-modifiers)), followed by an optional partial modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword interface and an *Identifier* that names the interface, followed by an optional *variant_type_parameter_list* specification ([§18.2.3](interfaces.md#1823-variant-type-parameter-lists)), followed by an optional *interface_base* specification ([§18.2.4](interfaces.md#1824-base-interfaces)), followed by an optional *type_parameter_constraints_clause*s specification ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by an *interface_body* ([§18.3](interfaces.md#183-interface-body)), optionally followed by a semicolon.
+An *interface_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *interface_modifier*s ([§18.2.2](interfaces.md#1822-interface-modifiers)), followed by an optional partial modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword interface and an *identifier* that names the interface, followed by an optional *variant_type_parameter_list* specification ([§18.2.3](interfaces.md#1823-variant-type-parameter-lists)), followed by an optional *interface_base* specification ([§18.2.4](interfaces.md#1824-base-interfaces)), followed by an optional *type_parameter_constraints_clause*s specification ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by an *interface_body* ([§18.3](interfaces.md#183-interface-body)), optionally followed by a semicolon.
 
 An interface declaration shall not supply a *type_parameter_constraints_clause*s unless it also supplies a *type_parameter_list*.
 
@@ -230,11 +230,11 @@ Interface methods are declared using *interface_method_declaration*s:
 
 ```ANTLR
 interface_method_declaration
-    : attributes? 'new'? return_type Identifier type_parameter_list? '(' formal_parameter_list? ')' type_parameter_constraints_clause* ';'
+    : attributes? 'new'? return_type identifier type_parameter_list? '(' formal_parameter_list? ')' type_parameter_constraints_clause* ';'
     ;
 ```
 
-The *attributes*, *return_type*, *Identifier*, and *formal_parameter_list* of an interface method declaration have the same meaning as those of a method declaration in a class ([§15.6](classes.md#156-methods)). An interface method declaration is not permitted to specify a method body, and the declaration therefore always ends with a semicolon. An *interface_method_declaration* shall not have *type_parameter_constraints_clause*s unless it also has a *type_parameter_list*.
+The *attributes*, *return_type*, *identifier*, and *formal_parameter_list* of an interface method declaration have the same meaning as those of a method declaration in a class ([§15.6](classes.md#156-methods)). An interface method declaration is not permitted to specify a method body, and the declaration therefore always ends with a semicolon. An *interface_method_declaration* shall not have *type_parameter_constraints_clause*s unless it also has a *type_parameter_list*.
 
 All formal parameter types of an interface method shall be input-safe ([§18.2.3.2](interfaces.md#18232-variance-safety)), and the return type shall be either `void` or output-safe. In addition, any output or reference formal parameter types shall also be output-safe.
 
@@ -270,7 +270,7 @@ Interface properties are declared using *interface_property_declaration*s:
 
 ```ANTLR
 interface_property_declaration
-    : attributes? 'new'? type Identifier '{' interface_accessors '}'
+    : attributes? 'new'? type identifier '{' interface_accessors '}'
     ;
 ```
 
@@ -283,7 +283,7 @@ interface_accessors
     ;
 ```
 
-The *attributes*, *type*, and *Identifier* of an interface property declaration have the same meaning as those of a property declaration in a class ([§15.7](classes.md#157-properties)).
+The *attributes*, *type*, and *identifier* of an interface property declaration have the same meaning as those of a property declaration in a class ([§15.7](classes.md#157-properties)).
 
 The accessors of an interface property declaration correspond to the accessors of a class property declaration ([§15.7.3](classes.md#1573-accessors)), except that the accessor body shall always be a semicolon. Thus, the accessors simply indicate whether the property is read-write, read-only, or write-only.
 
@@ -295,11 +295,11 @@ Interface events are declared using *interface_event_declaration*s:
 
 ```ANTLR
 interface_event_declaration
-    : attributes? 'new'? 'event' type Identifier ';'
+    : attributes? 'new'? 'event' type identifier ';'
     ;
 ```
 
-The *attributes*, *type*, and *Identifier* of an interface event declaration have the same meaning as those of an event declaration in a class ([§15.8](classes.md#158-events)).
+The *attributes*, *type*, and *identifier* of an interface event declaration have the same meaning as those of an event declaration in a class ([§15.8](classes.md#158-events)).
 
 The type of an interface event shall be input-safe.
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -977,19 +977,15 @@ fragment PP_Expression
     ;
     
 fragment PP_Or_Expression
-    : PP_And_Expression
-    | PP_Or_Expression Whitespace? '||' Whitespace? PP_And_Expression
+    : PP_And_Expression (Whitespace? '||' Whitespace? PP_And_Expression)*
     ;
     
 fragment PP_And_Expression
-    : PP_Equality_Expression
-    | PP_And_Expression Whitespace? '&&' Whitespace? PP_Equality_Expression
+    : PP_Equality_Expression (Whitespace? '&&' Whitespace? PP_Equality_Expression)*
     ;
 
 fragment PP_Equality_Expression
-    : PP_Unary_Expression
-    | PP_Equality_Expression Whitespace? '==' Whitespace? PP_Unary_Expression
-    | PP_Equality_Expression Whitespace? '!=' Whitespace? PP_Unary_Expression
+    : PP_Unary_Expression (Whitespace? ('==' | '!=') Whitespace? PP_Unary_Expression)*
     ;
     
 fragment PP_Unary_Expression

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -28,11 +28,17 @@ All terminal characters are to be understood as the appropriate Unicode characte
 
 The lexical and syntactic grammars are presented in the ANTLR grammar tool’s Extended Backus-Naur form.
 
-While the ANTLR notation is used this Standard does not present a complete ANTLR-ready "reference grammar" for C#; writing a lexer and parser, either by hand or using a tool such as ANTLR, is outside the scope of a language specification. With that qualification, this Standard attempts to minmise the gap between the specified grammar and that required to build a lexer and parser in ANTLR with the notable exception of the preprocessor ([§7.5](lexical-structure.md#75-pre-processing-directives) which requires more substantial work to fit into the ANTLR model.
+While the ANTLR notation is used this Standard does not present a complete ANTLR-ready "reference grammar" for C#; writing a lexer and parser, either by hand or using a tool such as ANTLR, is outside the scope of a language specification. In particular three sections of the lexical grammar:
+
+- the lexical structure defined by the `Input` group of rules ([§7.3.1](lexical-structure.md#731-general));
+- the pre-processing directives defined by the `PP_Directive` group of rules ([§7.5](lexical-structure.md#75-pre-processing-directives)); and
+- rules used just by the above two groups: `Token`, `Any_Keyword` and `Any_Operator_Or_Punctuator` ([§7.4.1](lexical-structure.md#741-general))
+
+consist of lexical rules which do not define lexical tokens.
+
+> *Note*: In addition to the above three sections, where the rules are not ANTLR-ready, there are places where the C# lexical grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)) and syntactic grammar ([§7.2.4](lexical-structure.md#724-syntactic-grammar)) are not in exact correspondence with the ANTLR division into lexical and parser grammers. This mismatch means that some ANTLR parser rules are used when specifying the C# lexical grammar. *end note* 
 
 ANTLR distinguishes between lexical and syntactic, termed parser by ANTLR, grammars in its notation by starting lexical rules with an initial uppercase letter and parser rules with an initial lowercase letter.
-
-> *Note*: The C# lexical grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)) and syntactic grammar ([§7.2.4](lexical-structure.md#724-syntactic-grammar)) are not in exact correspondence with the ANTLR division into lexical and parser grammers. This small mismatch means that some ANTLR parser rules are used when specifying the C# lexical grammar. *end note* 
 
 ### 7.2.3 Lexical grammar
 
@@ -42,7 +48,7 @@ Many of the terminal symbols of the syntactic grammar are not defined explicitly
 
 The same behaviour is also used to simplify the lexical grammar, see [§7.3.1](lexical-structure.md#731-general).
 
-Every compilation unit in a C# program shall conform to the *input* production of the lexical grammar ([§7.3.1](lexical-structure.md#731-general)).
+Every compilation unit in a C# program shall conform to the *Input* production of the lexical grammar ([§7.3.1](lexical-structure.md#731-general)).
 
 ### 7.2.4 Syntactic grammar
 
@@ -109,30 +115,30 @@ Although these are lexer rules, these names are spelled in all-uppercase letters
 
 > *Note*: These convenience rules are exceptions to the usual practice of not providing explicit token names for tokens defined by literal strings. *end note*
 
-The *input* production defines the lexical structure of a C# compilation unit.
+The *Input* production defines the lexical structure of a C# compilation unit.
 
 ```ANTLR
-input
-    : input_section?
+fragment Input
+    : Input_Section?
     ;
 
-input_section
-    : input_section_part+
+fragment Input_Section
+    : Input_Section_Part+
     ;
 
-input_section_part
-    : input_element* New_Line
+fragment Input_Section_Part
+    : Input_Element* New_Line
     | PP_Directive
     ;
 
-input_element
+fragment Input_Element
     : Whitespace
     | Comment
-    | token
+    | Token
     ;
 ```
 
-> *Note*: The above grammar is described by ANTLR parsing rules, it defines the lexical structure of a C# compilation unit and not lexical tokens. *end note*
+> *Note*: The above grammar is described by ANTLR lexical rules, however it defines the lexical structure of a C# compilation unit and not lexical tokens. They are not ANTLR-ready, see [§7.2.2](lexical-structure.md#722-grammar-notation) *end note*
 
 Five basic elements make up the lexical structure of a C# compilation unit: Line terminators ([§7.3.2](lexical-structure.md#732-line-terminators)), white space ([§7.3.4](lexical-structure.md#734-white-space)), comments ([§7.3.3](lexical-structure.md#733-comments)), tokens ([§7.4](lexical-structure.md#74-tokens)), and pre-processing directives ([§7.5](lexical-structure.md#75-pre-processing-directives)). Of these basic elements, only tokens are significant in the syntactic grammar of a C# program ([§7.2.4](lexical-structure.md#724-syntactic-grammar)), except in the case of a `>` token being combined with another token to form a single operator ([§7.4.6](lexical-structure.md#746-operators-and-punctuators)).
 
@@ -285,18 +291,50 @@ Whitespace
 There are several kinds of ***tokens***: identifiers, keywords, literals, operators, and punctuators. White space and comments are not tokens, though they act as separators for tokens.
 
 ```ANTLR
-token
-    : identifier
-    | keyword
+fragment Token
+    : Simple_Identifier
+    | Any_Keyword
     | Integer_Literal
     | Real_Literal
     | Character_Literal
     | String_Literal
-    | operator_or_punctuator
+    | Any_Operator_Or_Punctuator
     ;
+
+fragment Any_Keyword
+    : 'abstract'   | 'add'       | 'alias'      | 'as'        | 'ascending'
+    | 'async'      | 'await'     | 'base'       | 'bool'      | 'break'
+    | 'by'         | 'byte'      | 'case'       | 'catch'     | 'char'
+    | 'checked'    | 'class'     | 'const'      | 'continue'  | 'decimal'
+    | DEFAULT      | 'delegate'  | 'descending' | 'do'        | 'double'
+    | 'dynamic'    | 'else'      | 'enum'       | 'equals'    | 'event'
+    | 'explicit'   | 'extern'    | 'false'      | 'finally'   | 'fixed'
+    | 'float'      | 'for'       | 'foreach'    | 'from'      | 'get'
+    | 'global'     | 'goto'      | 'group'      | 'if'        | 'implicit'
+    | 'in'         | 'int'       | 'interface'  | 'internal'  | 'into'
+    | 'is'         | 'join'      | 'let'        | 'lock'      | 'long'
+    | 'nameof'     | 'namespace' | 'on'         | 'orderby'   | 'override'
+    | 'params'     | 'partial'   | 'private'    | 'protected' | 'public'
+    | 'readonly'   | 'ref'       | 'remove'     | 'return'    | 'sbyte'
+    | 'sealed'     | 'select'    | 'set'        | 'short'     | 'sizeof'
+    | 'stackalloc' | 'static'    | 'string'     | 'struct'    | 'switch'
+    | 'this'       | 'throw'     | 'true'       | 'try'       | 'typeof'
+    | 'uint'       | 'ulong'     | 'unchecked'  | 'unsafe'    | 'ushort'
+    | 'using'      | 'value'     | 'var'        | 'virtual'   | 'void'
+    | 'volatile'   | 'where'     | 'while'      | 'yield'
+    ;
+
+fragment Any_Operator_Or_Punctuator
+    : '{'  | '}'  | '['  | ']'  | '('   | ')'  | '.'  | ','  | ':'  | ';'
+    | '+'  | '-'  | ASTERISK    | SLASH | '%'  | '&'  | '|'  | '^'  | '!'  | '~'
+    | '='  | '<'  | '>'  | '?'  | '??'  | '::' | '++' | '--' | '&&' | '||'
+    | '->' | '==' | '!=' | '<=' | '>='  | '+=' | '-=' | '*=' | '/=' | '%='
+    | '&=' | '|=' | '^=' | '<<' | '<<=' | '=>'
+    ;
+
 ```
 
-> *Note*: This is an ANTLR parser rule, it does not define a lexical token but rather the collection of token kinds. *end note*
+> *Note*: The above rules are described by ANTLR lexical rules, however they do not define lexical tokens. They are not ANTLR-ready, see [§7.2.2](lexical-structure.md#722-grammar-notation) *end note*
 
 ### 7.4.2 Unicode character escape sequences
 
@@ -848,7 +886,7 @@ The pre-processing directives provide the ability to skip conditionally sections
 
 > *Note*: The term "pre-processing directives" is used only for consistency with the C and C++ programming languages. In C#, there is no separate pre-processing step; pre-processing directives are processed as part of the lexical analysis phase. *end note*
 
-> *Note*: The pre-processor grammar, though defined using ANTLR lexical rules, does not define any lexical tokens in the language and is not “ANTLR ready”. Pre-processing involves processing the input and modifying the token stream produced by the lexer, this is not represented in this grammar and is part of compiler implementation and thus out of scope for this language specification. *end note*
+> *Note*: The pre-processor grammar, though defined using ANTLR lexical rules, does not define any lexical tokens in the language. Pre-processing involves processing the input and modifying the token stream produced by the lexer, this is not represented in this grammar and is part of compiler implementation and thus out of scope for this language specification. They are not ANTLR-ready, see [§7.2.2](lexical-structure.md#722-grammar-notation) *end note*
 
 ```ANTLR
 PP_Directive
@@ -909,10 +947,15 @@ Pre-processing directives are not tokens and are not part of the syntactic gramm
 The conditional compilation functionality provided by the `#if`, `#elif`, `#else`, and `#endif` directives is controlled through pre-processing expressions ([§7.5.3](lexical-structure.md#753-pre-processing-expressions)) and conditional compilation symbols.
 
 ```ANTLR
-Conditional_Symbol
-    : Identifier_Or_Keyword { IsNotTrueOrFalse() }?
+fragment Conditional_Symbol
+    : Basic_Identifier           // excluding TRUE and FALSE
+         { IsNotTrueOrFalse() }? // see note below
     ;
 ```
+
+> *Note* The ANTLR semantic predicate above: `IsNotTrueOrFalse`; is informative *only*. How a compiler enforces the restriction on the allowable
+*Basic_Identifier* values is an implementation issue. *end note*
+
 Two conditional compilation symbols are considered the same if they are identical after the following transformations are applied, in order:
 
 -   Each *Unicode_Escape_Sequence* is transformed into its corresponding Unicode character.
@@ -929,32 +972,32 @@ The namespace for conditional compilation symbols is distinct and separate from 
 Pre-processing expressions can occur in `#if` and `#elif` directives. The operators `!`, `==`, `!=`, `&&`, and `||` are permitted in pre-processing expressions, and parentheses may be used for grouping.
 
 ```ANTLR
-PP_Expression
+fragment PP_Expression
     : Whitespace? PP_Or_Expression Whitespace?
     ;
     
-PP_Or_Expression
+fragment PP_Or_Expression
     : PP_And_Expression
     | PP_Or_Expression Whitespace? '||' Whitespace? PP_And_Expression
     ;
     
-PP_And_Expression
+fragment PP_And_Expression
     : PP_Equality_Expression
     | PP_And_Expression Whitespace? '&&' Whitespace? PP_Equality_Expression
     ;
 
-PP_Equality_Expression
+fragment PP_Equality_Expression
     : PP_Unary_Expression
     | PP_Equality_Expression Whitespace? '==' Whitespace? PP_Unary_Expression
     | PP_Equality_Expression Whitespace? '!=' Whitespace? PP_Unary_Expression
     ;
     
-PP_Unary_Expression
+fragment PP_Unary_Expression
     : PP_Primary_Expression
     | '!' Whitespace? PP_Unary_Expression
     ;
     
-PP_Primary_Expression
+fragment PP_Primary_Expression
     : TRUE
     | FALSE
     | Conditional_Symbol
@@ -971,19 +1014,19 @@ Evaluation of a pre-processing expression always yields a Boolean value. The rul
 The definition directives are used to define or undefine conditional compilation symbols.
 
 ```ANTLR
-PP_Declaration
+fragment PP_Declaration
     : Whitespace? '#' Whitespace? 'define' Whitespace Conditional_Symbol PP_New_Line
     | Whitespace? '#' Whitespace? 'undef' Whitespace Conditional_Symbol PP_New_Line
     ;
 
-PP_New_Line
+fragment PP_New_Line
     : Whitespace? Single_Line_Comment? New_Line
     ;
 ```
 
 The processing of a `#define` directive causes the given conditional compilation symbol to become defined, starting with the source line that follows the directive. Likewise, the processing of a `#undef` directive causes the given conditional compilation symbol to become undefined, starting with the source line that follows the directive.
 
-Any `#define` and `#undef` directives in a compilation unit shall occur before the first *token* ([§7.4](lexical-structure.md#74-tokens)) in the compilation unit; otherwise a compile-time error occurs. In intuitive terms, `#define` and `#undef` directives shall precede any "real code" in the compilation unit.
+Any `#define` and `#undef` directives in a compilation unit shall occur before the first *Token* ([§7.4](lexical-structure.md#74-tokens)) in the compilation unit; otherwise a compile-time error occurs. In intuitive terms, `#define` and `#undef` directives shall precede any "real code" in the compilation unit.
 
 > *Example*: The example:
 > ```csharp
@@ -1037,41 +1080,41 @@ A `#undef` may "undefine" a conditional compilation symbol that is not defined.
 The conditional compilation directives are used to conditionally include or exclude portions of a compilation unit.
 
 ```ANTLR
-PP_Conditional
+fragment PP_Conditional
     : PP_If_Section PP_Elif_Section* PP_Else_Section? PP_Endif
     ;
 
-PP_If_Section
+fragment PP_If_Section
     : Whitespace? '#' Whitespace? 'if' Whitespace PP_Expression PP_New_Line Conditional_Section?
     ;
     
-PP_Elif_Section
+fragment PP_Elif_Section
     : Whitespace? '#' Whitespace? 'elif' Whitespace PP_Expression PP_New_Line Conditional_Section?
     ;
     
-PP_Else_Section
+fragment PP_Else_Section
     : Whitespace? '#' Whitespace? 'else' PP_New_Line Conditional_Section?
     ;
     
-PP_Endif
+fragment PP_Endif
     : Whitespace? '#' Whitespace? 'endif' PP_New_Line
     ;
     
-Conditional_Section
+fragment Conditional_Section
     : Input_Section
     | Skipped_Section_Part+
     ;
 
-Skipped_Section_Part
+fragment Skipped_Section_Part
     : Skipped_Characters? New_Line
     | PP_Directive
     ;
     
-Skipped_Characters
+fragment Skipped_Characters
     : Whitespace? Not_Number_Sign Input_Character*
     ;
 
-Not_Number_Sign
+fragment Not_Number_Sign
     : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029' | '#')   // any Input_Character except #
     ;
 ```
@@ -1162,12 +1205,12 @@ The remaining *Conditional_Section*s, if any, are processed as one or more *Skip
 The diagnostic directives are used to generate explicitly error and warning messages that are reported in the same way as other compile-time errors and warnings.
 
 ```ANTLR
-PP_Diagnostic
+fragment PP_Diagnostic
     : Whitespace? '#' Whitespace? 'error' PP_Message
     | Whitespace? '#' Whitespace? 'warning' PP_Message
     ;
 
-PP_Message
+fragment PP_Message
     : New_Line
     | Whitespace Input_Character* New_Line
     ;
@@ -1187,15 +1230,15 @@ PP_Message
 The region directives are used to mark explicitly regions of source code.
 
 ```ANTLR
-PP_Region
+fragment PP_Region
     : PP_Start_Region Conditional_Section? PP_End_Region
     ;
 
-PP_Start_Region
+fragment PP_Start_Region
     : Whitespace? '#' Whitespace? 'region' PP_Message
     ;
 
-PP_End_Region
+fragment PP_End_Region
     : Whitespace? '#' Whitespace? 'endregion' PP_Message
     ;
 ```
@@ -1224,22 +1267,22 @@ Line directives may be used to alter the line numbers and compilation unit names
 > *Note*: Line directives are most commonly used in meta-programming tools that generate C# source code from some other text input. *end note*
 
 ```ANTLR
-PP_Line
+fragment PP_Line
     : Whitespace? '#' Whitespace? 'line' Whitespace Line_Indicator PP_New_Line
     ;
 
-Line_Indicator
+fragment Line_Indicator
     : Decimal_Digit+ Whitespace Compilation_Unit_Name
     | Decimal_Digit+
     | DEFAULT
     | 'hidden'
     ;
     
-Compilation_Unit_Name
+fragment Compilation_Unit_Name
     : '"' Compilation_Unit_Name_Character+ '"'
     ;
     
-Compilation_Unit_Name_Character
+fragment Compilation_Unit_Name_Character
     : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029' | '#')   // any Input_Character except "
     ;
 ```
@@ -1263,11 +1306,11 @@ The `#pragma` preprocessing directive is used to specify contextual information 
 *end note*
 
 ```ANTLR
-PP_Pragma
+fragment PP_Pragma
     : Whitespace? '#' Whitespace? 'pragma' PP_Pragma_Text
     ;
 
-PP_Pragma_Text
+fragment PP_Pragma_Text
     : New_Line
     | Whitespace Input_Character* New_Line
     ;

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -32,7 +32,7 @@ While the ANTLR notation is used this Standard does not present a complete ANTLR
 
 ANTLR distinguishes between lexical and syntactic, termed parser by ANTLR, grammars in its notation by starting lexical rules with an initial uppercase letter and parser rules with an initial lowercase letter.
 
-*Note*: The C# lexical grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)) and syntactic grammar ([§7.2.4](lexical-structure.md#724-syntactic-grammar)) are not in exact correspondence with the ANTLR division into lexical and parser grammers. This small mismatch means that some ANTLR parser rules are used when specifying the C# lexical grammar. *end note* 
+> *Note*: The C# lexical grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)) and syntactic grammar ([§7.2.4](lexical-structure.md#724-syntactic-grammar)) are not in exact correspondence with the ANTLR division into lexical and parser grammers. This small mismatch means that some ANTLR parser rules are used when specifying the C# lexical grammar. *end note* 
 
 ### 7.2.3 Lexical grammar
 
@@ -105,7 +105,9 @@ ASTERISK : '*' ;
 SLASH    : '/' ;
 ```
 
-Although these are lexer rules, these names are spelled in all-uppercase letters to distinguish them from ordinary lexer rule names. (*Note*: These convenience rules are exceptions to the usual practice of not providing explicit token names for tokens defined by literal strings. *end note*)
+Although these are lexer rules, these names are spelled in all-uppercase letters to distinguish them from ordinary lexer rule names.
+
+> *Note*: These convenience rules are exceptions to the usual practice of not providing explicit token names for tokens defined by literal strings. *end note*
 
 The *input* production defines the lexical structure of a C# compilation unit.
 
@@ -144,7 +146,9 @@ The rules of the lexical grammar are ordered top-to-bottom, with the first match
 
 > *Example*: As keyword tokens are defined implicitly by literal strings in the grammar, and implicit rules are ordered before explicit ones, the rule `Available_Identifier` ([§7.4.3](lexical-structure.md#743-identifiers)) will never match a keyword. *end example*
 
-Some tokens are defined by a set of lexical rules; a main rule and one or more sub-rules. The latter are marked in the grammer by `fragment` to indicate the rule does defines part of another token. Fragment rules are not considered in the top-to-bottom ordering of lexical rules. (*Note*: In ANTLR `fragment` is a keyword which produces the same behaviour defined here. *end note*)
+Some tokens are defined by a set of lexical rules; a main rule and one or more sub-rules. The latter are marked in the grammer by `fragment` to indicate the rule does defines part of another token. Fragment rules are not considered in the top-to-bottom ordering of lexical rules.
+
+> *Note*: In ANTLR `fragment` is a keyword which produces the same behaviour defined here. *end note*
 
 ### 7.3.2 Line terminators
 
@@ -1054,7 +1058,7 @@ PP_Endif
     ;
     
 Conditional_Section
-    : input_section
+    : Input_Section
     | Skipped_Section_Part+
     ;
 
@@ -1080,7 +1084,7 @@ A *PP_Conditional* selects at most one of the contained *Conditional_Section*s f
 -   If all *PP_Expression*s yield `false`, and if a `#else` directive is present, the *Conditional_Section* of the `#else` directive is selected.
 -   Otherwise, no *Conditional_Section* is selected.
 
-The selected *Conditional_Section*, if any, is processed as a normal *input_section*: the source code contained in the section shall adhere to the lexical grammar; tokens are generated from the source code in the section; and pre-processing directives in the section have the prescribed effects.
+The selected *Conditional_Section*, if any, is processed as a normal *Input_Section*: the source code contained in the section shall adhere to the lexical grammar; tokens are generated from the source code in the section; and pre-processing directives in the section have the prescribed effects.
 
 The remaining *Conditional_Section*s, if any, are processed as one or more *Skipped_Section_Part*s: except for pre-processing directives, the source code in the section need not adhere to the lexical grammar; no tokens are generated from the source code in the section; and pre-processing directives in the section shall be lexically correct but are not otherwise processed. Within a *Conditional_Section* that is being processed as one or more *Skipped_Section_Part*s, any nested *Conditional_Section*s (contained in nested `#if...#endif` and `#region...#endregion` constructs) are also processed as one or more *Skipped_Section_Part*s.
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -26,23 +26,29 @@ All terminal characters are to be understood as the appropriate Unicode characte
 
 ### 7.2.2 Grammar notation
 
-The lexical and syntactic grammars are presented in Backus-Naur form using the notation of the ANTLR grammar tool.
+The lexical and syntactic grammars are presented in the ANTLR grammar tool’s Extended Backus-Naur form.
+
+While the ANTLR notation is used this Standard does not present a complete ANTLR-ready "reference grammar" for C#; writing a lexer and parser, either by hand or using a tool such as ANTLR, is outside the scope of a language specification. With that qualification, this Standard attempts to minmise the gap between the specified grammar and that required to build a lexer and parser in ANTLR with the notable exception of the preprocessor ([§7.5](lexical-structure.md#75-pre-processing-directives) which requires more substantial work to fit into the ANTLR model.
+
+ANTLR distinguishes between lexical and syntactic, termed parser by ANTLR, grammars in its notation by starting lexical rules with an initial uppercase letter and parser rules with an initial lowercase letter.
+
+*Note*: The C# lexical grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)) and syntactic grammar ([§7.2.4](lexical-structure.md#724-syntactic-grammar)) are not in exact correspondence with the ANTLR division into lexical and parser grammers. This small mismatch means that some ANTLR parser rules are used when specifying the C# lexical grammar. *end note* 
 
 ### 7.2.3 Lexical grammar
 
 The lexical grammar of C# is presented in [§7.3](lexical-structure.md#73-lexical-analysis), [§7.4](lexical-structure.md#74-tokens), and [§7.5](lexical-structure.md#75-pre-processing-directives). The terminal symbols of the lexical grammar are the characters of the Unicode character set, and the lexical grammar specifies how characters are combined to form tokens ([§7.4](lexical-structure.md#74-tokens)), white space ([§7.3.4](lexical-structure.md#734-white-space)), comments ([§7.3.3](lexical-structure.md#733-comments)), and pre-processing directives ([§7.5](lexical-structure.md#75-pre-processing-directives)).
 
-Every compilation unit in a C# program shall conform to the *Input* production of the lexical grammar ([§7.3.1](lexical-structure.md#731-general)).
+Many of the terminal symbols of the syntactic grammar are not defined explicitly as tokens in the lexical grammar. Rather advantage is taken of the ANTLR behaviour that literal strings in the grammar are extracted as implicit lexical tokens; this allows keywords, operators, etc. to be represented in the grammar by their literal representation rather than a token name.
 
-Using the ANTLR convention, lexer rule names are spelled with an initial uppercase letter.
+The same behaviour is also used to simplify the lexical grammar, see [§7.3.1](lexical-structure.md#731-general).
+
+Every compilation unit in a C# program shall conform to the *input* production of the lexical grammar ([§7.3.1](lexical-structure.md#731-general)).
 
 ### 7.2.4 Syntactic grammar
 
-The syntactic grammar of C# is presented in the clauses, subclauses, and annexes that follow this subclause. The terminal symbols of the syntactic grammar are the tokens defined by the lexical grammar, and the syntactic grammar specifies how tokens are combined to form C# programs.
+The syntactic grammar of C# is presented in the clauses, subclauses, and annexes that follow this subclause. The terminal symbols of the syntactic grammar are the tokens defined explicitly by the lexical grammar and implicitly by literal strings in the grammar itself ([§7.2.3](lexical-structure.md#723-lexical-grammar)). The syntactic grammar specifies how tokens are combined to form C# programs.
 
-Every compilation unit in a C# program shall conform to the *Compilation_Unit* production ([§14.2](namespaces.md#142-compilation-units)) of the syntactic grammar.
-
-Using the ANTLR convention, syntactic rule names are spelled with an initial lowercase letter.
+Every compilation unit in a C# program shall conform to the *compilation_unit* production ([§14.2](namespaces.md#142-compilation-units)) of the syntactic grammar.
 
 ### 7.2.5 Grammar ambiguities
 
@@ -99,30 +105,32 @@ ASTERISK : '*' ;
 SLASH    : '/' ;
 ```
 
-Although these are lexer rules, these names are spelled in all-uppercase letters to distinguish them from ordinary lexer rule names.
+Although these are lexer rules, these names are spelled in all-uppercase letters to distinguish them from ordinary lexer rule names. (*Note*: These convenience rules are exceptions to the usual practice of not providing explicit token names for tokens defined by literal strings. *end note*)
 
-The *Input* production defines the lexical structure of a C# compilation unit.
+The *input* production defines the lexical structure of a C# compilation unit.
 
 ```ANTLR
-Input
-    : Input_Section?
+input
+    : input_section?
     ;
 
-Input_Section
-    : Input_Section_Part+
+input_section
+    : input_section_part+
     ;
 
-Input_Section_Part
-    : Input_Element* New_Line
-    | Pp_Directive
+input_section_part
+    : input_element* New_Line
+    | PP_Directive
     ;
 
-Input_Element
+input_element
     : Whitespace
     | Comment
-    | Token
+    | token
     ;
 ```
+
+> *Note*: The above grammar is described by ANTLR parsing rules, it defines the lexical structure of a C# compilation unit and not lexical tokens. *end note*
 
 Five basic elements make up the lexical structure of a C# compilation unit: Line terminators ([§7.3.2](lexical-structure.md#732-line-terminators)), white space ([§7.3.4](lexical-structure.md#734-white-space)), comments ([§7.3.3](lexical-structure.md#733-comments)), tokens ([§7.4](lexical-structure.md#74-tokens)), and pre-processing directives ([§7.5](lexical-structure.md#75-pre-processing-directives)). Of these basic elements, only tokens are significant in the syntactic grammar of a C# program ([§7.2.4](lexical-structure.md#724-syntactic-grammar)), except in the case of a `>` token being combined with another token to form a single operator ([§7.4.6](lexical-structure.md#746-operators-and-punctuators)).
 
@@ -131,6 +139,12 @@ The lexical processing of a C# compilation unit consists of reducing the file i
 When several lexical grammar productions match a sequence of characters in a compilation unit, the lexical processing always forms the longest possible lexical element.
 
 > *Example*: The character sequence `//` is processed as the beginning of a single-line comment because that lexical element is longer than a single `/` token. *end example*
+
+The rules of the lexical grammar are ordered top-to-bottom, with the first matching rule determining the recognised token. Implicit rules ([§7.2.3](lexical-structure.md#723-lexical-grammar)) derived from literal strings in the grammar are ordered before the explicit rules. This ordering simplifies the grammar.
+
+> *Example*: As keyword tokens are defined implicitly by literal strings in the grammar, and implicit rules are ordered before explicit ones, the rule `Available_Identifier` ([§7.4.3](lexical-structure.md#743-identifiers)) will never match a keyword. *end example*
+
+Some tokens are defined by a set of lexical rules; a main rule and one or more sub-rules. The latter are marked in the grammer by `fragment` to indicate the rule does defines part of another token. Fragment rules are not considered in the top-to-bottom ordering of lexical rules. (*Note*: In ANTLR `fragment` is a keyword which produces the same behaviour defined here. *end note*)
 
 ### 7.3.2 Line terminators
 
@@ -148,7 +162,7 @@ For compatibility with source code editing tools that add end-of-file markers, a
 -   If the last character of the compilation unit is a Control-Z character (U+001A), this character is deleted.
 -   A carriage-return character (U+000D) is added to the end of the compilation unit if that compilation unit is non-empty and if the last character of the compilation unit is not a carriage return (U+000D), a line feed (U+000A), a next line character (U+0085), a line separator (U+2028), or a paragraph separator (U+2029). 
 
-> *Note*: The additional carriage-return allows a program to end in a *Pp_Directive* ([§7.5](lexical-structure.md#75-pre-processing-directives)) that does not have a terminating *New-Line*. *end note*
+> *Note*: The additional carriage-return allows a program to end in a *PP_Directive* ([§7.5](lexical-structure.md#75-pre-processing-directives)) that does not have a terminating *New-Line*. *end note*
 
 ### 7.3.3 Comments
 
@@ -192,15 +206,15 @@ Comment
     | Delimited_Comment
     ;
 
-Single_Line_Comment
+fragment Single_Line_Comment
     : '//' Input_Character*
     ;
 
-Input_Character
+fragment Input_Character
     : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029')   // anything but New_Line_Character
     ;
     
-New_Line_Character
+fragment New_Line_Character
     : '\u000D'  // carriage return
     | '\u000A'  // line feed
     | '\u0085'  // next line
@@ -208,16 +222,16 @@ New_Line_Character
     | '\u2029'  // paragraph separator
     ;
     
-Delimited_Comment
+fragment Delimited_Comment
     : '/*' Delimited_Comment_Section* ASTERISK+ '/'
     ;
     
-Delimited_Comment_Section
+fragment Delimited_Comment_Section
     : SLASH
     | ASTERISK* Not_Slash_Or_Asterisk
     ;
 
-Not_Slash_Or_Asterisk
+fragment Not_Slash_Or_Asterisk
     : ~('/' | '*')    // Any except SLASH or ASTERISK
     ;
 ```
@@ -267,23 +281,25 @@ Whitespace
 There are several kinds of ***tokens***: identifiers, keywords, literals, operators, and punctuators. White space and comments are not tokens, though they act as separators for tokens.
 
 ```ANTLR
-Token
-    : Identifier
-    | Keyword
+token
+    : identifier
+    | keyword
     | Integer_Literal
     | Real_Literal
     | Character_Literal
     | String_Literal
-    | Operator_Or_Punctuator
+    | operator_or_punctuator
     ;
 ```
+
+> *Note*: This is an ANTLR parser rule, it does not define a lexical token but rather the collection of token kinds. *end note*
 
 ### 7.4.2 Unicode character escape sequences
 
 A Unicode escape sequence represents a Unicode code point. Unicode escape sequences are processed in identifiers ([§7.4.3](lexical-structure.md#743-identifiers)), character literals ([§7.4.5.5](lexical-structure.md#7455-character-literals)), regular string literals ([§7.4.5.6](lexical-structure.md#7456-string-literals)), and interpolated regular string literals (§interpolated-string-literals-new-clause). A Unicode escape sequence is not processed in any other location (for example, to form an operator, punctuator, or keyword).
 
 ```ANTLR
-Unicode_Escape_Sequence
+fragment Unicode_Escape_Sequence
     : '\\u' Hex_Digit Hex_Digit Hex_Digit Hex_Digit
     | '\\U' Hex_Digit Hex_Digit Hex_Digit Hex_Digit Hex_Digit Hex_Digit Hex_Digit Hex_Digit
     ;
@@ -324,30 +340,41 @@ Multiple translations are not performed. For instance, the string literal `"\u00
 The rules for identifiers given in this subclause correspond exactly to those recommended by the Unicode Standard Annex 15 except that underscore is allowed as an initial character (as is traditional in the C programming language), Unicode escape sequences are permitted in identifiers, and the "`@`" character is allowed as a prefix to enable keywords to be used as identifiers.
 
 ```ANTLR
-Identifier
+identifier
+    : Simple_Identifier
+    | contextual_keyword
+    ;
+
+Simple_Identifier
     : Available_Identifier
-    | '@' Identifier_Or_Keyword
+    | Escaped_Identifier
     ;
 
-Available_Identifier
-    : Identifier_Or_Keyword { IsNotAKeyword() }?
+fragment Available_Identifier
+    : Basic_Identifier     // does not include keywords or contextual keywords,
+                           // see note below
     ;
 
-Identifier_Or_Keyword
+fragment Escaped_Identifier
+    : '@' Basic_Identifier // includes keywords and contextual keywords prefixed by '@',
+                           // see note below
+    ;
+
+fragment Basic_Identifier
     : Identifier_Start_Character Identifier_Part_Character*
     ;
 
-Identifier_Start_Character
+fragment Identifier_Start_Character
     : Letter_Character
     | Underscore_Character
     ;
 
-Underscore_Character
+fragment Underscore_Character
     : '_'           // underscore
     | '\\u005' [fF] // Unicode_Escape_Sequence for underscore
     ;
 
-Identifier_Part_Character
+fragment Identifier_Part_Character
     : Letter_Character
     | Decimal_Digit_Character
     | Connecting_Character
@@ -355,33 +382,52 @@ Identifier_Part_Character
     | Formatting_Character
     ;
 
-Letter_Character
-    : [\p{L}\p{Nl}]     // category Letter, all subcategories; category Number, subcategory letter
-    | Unicode_Escape_Sequence { IsLetterCharacter() }?
+fragment Letter_Character
+    : [\p{L}\p{Nl}]           // category Letter, all subcategories; category Number, subcategory letter
+    | Unicode_Escape_Sequence // only escapes for categories L & Nl allowed, see note below
+         { IsLetterCharacter() }?
     ;
 
-Combining_Character
-    : [\p{Mn}\p{Mc}]    // category Mark, subcategories non-spacing and spacing combining
-    | Unicode_Escape_Sequence { IsCombiningCharacter() }?
+fragment Combining_Character
+    : [\p{Mn}\p{Mc}]          // category Mark, subcategories non-spacing and spacing combining
+    | Unicode_Escape_Sequence // only escapes for categories Mn & Mc allowed, see note below
+         { IsCombiningCharacter() }?
     ;
 
-Decimal_Digit_Character
-    : [\p{Nd}]      // category Number, subcategory decimal digit
-    | Unicode_Escape_Sequence { IsDecimalDigitCharacter() }?
+fragment Decimal_Digit_Character
+    : [\p{Nd}]                // category Number, subcategory decimal digit
+    | Unicode_Escape_Sequence // only escapes for category Nd allowed, see note below
+         { IsDecimalDigitCharacter() }?
     ;
 
-Connecting_Character
-    : [\p{Pc}]      // category Punctuation, subcategory connector
-    | Unicode_Escape_Sequence { IsConnectingCharacter() }?
+fragment Connecting_Character
+    : [\p{Pc}]                // category Punctuation, subcategory connector
+    | Unicode_Escape_Sequence // only escapes for category Pc allowed, see note below
+         { IsConnectingCharacter() }?
     ;
 
-Formatting_Character
-    : [\p{Cf}]      // category Other, subcategory format
-    | Unicode_Escape_Sequence { IsFormattingCharacter() }?
+fragment Formatting_Character
+    : [\p{Cf}]                // category Other, subcategory format
+    | Unicode_Escape_Sequence // only escapes for category Cf allowed, see note below
+         { IsFormattingCharacter() }?
     ;
 ```
 
-> *Note*: For information on the Unicode character classes mentioned above, see *The Unicode Standard*. *end note*
+> *Note*:
+
+> 1. For information on the Unicode character classes mentioned above, see *The Unicode Standard*. *end note*
+
+> 2. The ANTLR semantic predicates above: `IsLetterCharacter`, `IsCombiningCharacter`, `IsDecimalDigitCharacter`, `IsConnectingCharacter` and `IsFormattingCharacter`; are informative *only*. How a compiler enforces the restriction on the allowable
+*Unicode_Escape_Sequence* values is an implementation issue. *end note*
+
+> 3. The explicit rules for identifiers depend on the implicit rules introduced by literal strings in the grammar:
+>> - Keywords and contextual keywords occur in the grammar as literal strings and from these implicit lexical token rules are created which are ordered before the explicit lexical rules ([§7.2.3](lexical-structure.md#723-lexical-grammar)).
+>> - Therefore fragment `Available_Identifier` will not match keywords or contextual keywords as the lexical rules for those precede it.
+>> - Fragment `Escaped_Identifier` will effectively include keywords and contextual keywords as part of the longer token starting with an `@`.
+>> - `identifier` is a parser rule, as are those for `keyword` and `contextual_keyword` ([§7.4.4](lexical-structure.md#744-keywords)), as they do not define a new token kinds but rather represent a grouping of other tokens.
+>> - `identifier` includes `contextual_keyword` ([§7.4.4](lexical-structure.md#744-keywords)) so that contextual keywords are treated as identifiers except where they explicitly occur in the parser grammar as contextual keywords.
+
+> *end note*
 
 > *Example*: Examples of valid identifiers include "`identifier1`", "`_identifier2`", and "`@if`". *end example*
 
@@ -426,7 +472,7 @@ Identifiers containing two consecutive underscore characters (`U+005F`) are rese
 A ***keyword*** is an identifier-like sequence of characters that is reserved, and cannot be used as an identifier except when prefaced by the `@` character.
 
 ```ANTLR
-Keyword
+keyword
     : 'abstract' | 'as'       | 'base'       | 'bool'      | 'break'
     | 'byte'     | 'case'     | 'catch'      | 'char'      | 'checked'
     | 'class'    | 'const'    | 'continue'   | 'decimal'   | DEFAULT
@@ -449,7 +495,7 @@ Keyword
 A ***contextual keyword*** is an identifier-like sequence of characters that has special meaning in certain contexts, but is not reserved, and can be used as an identifier outside of those contexts as well as when prefaced by the `@` character.
 
 ```ANTLR
-Contextual_Keyword
+contextual_keyword
     : 'add'    | 'alias'      | 'ascending' | 'async'   | 'await'
     | 'by'     | 'descending' | 'dynamic'   | 'equals'  | 'from'
     | 'get'    | 'global'     | 'group'     | 'into'    | 'join'
@@ -458,6 +504,8 @@ Contextual_Keyword
     | 'where'  | 'yield'
     ;
 ```
+
+> *Note*: The rules `keyword` and `contextual_keyword` are parser rules as they do not introduce new token kinds. Every keyword and contextual keyword is defined by an implicit lexical rule as they occur as literal strings in the grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)). *end note*
 
 In most cases, the syntactic location of contextual keywords is such that they can never be confused with ordinary identifier usage. For example, within a property declaration, the "`get`" and "`set`" identifiers have special meaning ([§15.7.3](classes.md#1573-accessors)). An identifier other than `get` or `set` is never permitted in these locations, so this use does not conflict with a use of these words as identifiers.
 
@@ -476,28 +524,33 @@ Just as with keywords, contextual keywords can be used as ordinary identifiers b
 A ***literal*** ([§12.7.2](expressions.md#1272-literals)) is a source-code representation of a value.
 
 ```ANTLR
-Literal
-    : Boolean_Literal
+literal
+    : boolean_literal
     | Integer_Literal
     | Real_Literal
     | Character_Literal
     | String_Literal
-    | Null_Literal
+    | null_literal
     ;
 ```
+
+> *Note*: `literal` is a parser rule as it groups other token kinds and does not introduce a new token kind. *end note*
+
 
 #### 7.4.5.2 Boolean literals
 
 There are two Boolean literal values: `true` and `false`.
 
 ```ANTLR
-Boolean_Literal
+boolean_literal
     : TRUE
     | FALSE
     ;
 ```
 
-The type of a *Boolean_Literal* is `bool`.
+> *Note*: `boolean_literal` is a parser rule as it groups other token kinds and does not introduce a new token kind. *end note*
+
+The type of a *boolean_literal* is `bool`.
 
 #### 7.4.5.3 Integer literals
 
@@ -509,23 +562,23 @@ Integer_Literal
     | Hexadecimal_Integer_Literal
     ;
 
-Decimal_Integer_Literal
+fragment Decimal_Integer_Literal
     : Decimal_Digit+ Integer_Type_Suffix?
     ;
     
-Decimal_Digit
+fragment Decimal_Digit
     : '0'..'9'
     ;
     
-Integer_Type_Suffix
+fragment Integer_Type_Suffix
     : 'U' | 'u' | 'L' | 'l' | 'UL' | 'Ul' | 'uL' | 'ul' | 'LU' | 'Lu' | 'lU' | 'lu'
     ;
     
-Hexadecimal_Integer_Literal
+fragment Hexadecimal_Integer_Literal
     : ('0x' | '0X') Hex_Digit+ Integer_Type_Suffix?
     ;
 
-Hex_Digit
+fragment Hex_Digit
     : '0'..'9' | 'A'..'F' | 'a'..'f'
     ;
 ```
@@ -558,15 +611,15 @@ Real_Literal
     | Decimal_Digit+ Real_Type_Suffix
     ;
 
-Exponent_Part
+fragment Exponent_Part
     : ('e' | 'E') Sign? Decimal_Digit+
     ;
 
-Sign
+fragment Sign
     : '+' | '-'
     ;
 
-Real_Type_Suffix
+fragment Real_Type_Suffix
     : 'F' | 'f' | 'D' | 'd' | 'M' | 'm'
     ;
 ```    
@@ -599,22 +652,22 @@ Character_Literal
     : '\'' Character '\''
     ;
     
-Character
+fragment Character
     : Single_Character
     | Simple_Escape_Sequence
     | Hexadecimal_Escape_Sequence
     | Unicode_Escape_Sequence
     ;
     
-Single_Character
+fragment Single_Character
     : ~['\\\u000D\u000A\u0085\u2028\u2029]     // anything but ', \, and New_Line_Character
     ;
     
-Simple_Escape_Sequence
+fragment Simple_Escape_Sequence
     : '\\\'' | '\\"' | '\\\\' | '\\0' | '\\a' | '\\b' | '\\f' | '\\n' | '\\r' | '\\t' | '\\v'
     ;
     
-Hexadecimal_Escape_Sequence
+fragment Hexadecimal_Escape_Sequence
     : '\\x' Hex_Digit Hex_Digit? Hex_Digit? Hex_Digit?
     ;
 ```
@@ -668,35 +721,35 @@ String_Literal
     | Verbatim_String_Literal
     ;
     
-Regular_String_Literal
+fragment Regular_String_Literal
     : '"' Regular_String_Literal_Character* '"'
     ;
     
-Regular_String_Literal_Character
+fragment Regular_String_Literal_Character
     : Single_Regular_String_Literal_Character
     | Simple_Escape_Sequence
     | Hexadecimal_Escape_Sequence
     | Unicode_Escape_Sequence
     ;
 
-Single_Regular_String_Literal_Character
+fragment Single_Regular_String_Literal_Character
     : ~["\\\u000D\u000A\u0085\u2028\u2029]     // anything but ", \, and New_Line_Character
     ;
 
-Verbatim_String_Literal
+fragment Verbatim_String_Literal
     : '@"' Verbatim_String_Literal_Character* '"'
     ;
     
-Verbatim_String_Literal_Character
+fragment Verbatim_String_Literal_Character
     : Single_Verbatim_String_Literal_Character
     | Quote_Escape_Sequence
     ;
     
-Single_Verbatim_String_Literal_Character
+fragment Single_Verbatim_String_Literal_Character
     : ~["]     // anything but quotation mark (U+0022)
     ;
     
-Quote_Escape_Sequence
+fragment Quote_Escape_Sequence
     : '""'
     ;
 ```
@@ -742,12 +795,14 @@ Each string literal does not necessarily result in a new string instance. When t
 #### 7.4.5.7 The null literal
 
 ```ANTLR
-Null_Literal
+null_literal
     : NULL
     ;
 ```
 
-A *Null_Literal* represents a `null` value. It does not have a type, but can be converted to any reference type or nullable value type through a null literal conversion ([§11.2.6](conversions.md#1126-null-literal-conversions)).
+> *Note*: `null_literal` is a parser rule as it does not introduce a new token kind. *end note*
+
+A *null_literal* represents a `null` value. It does not have a type, but can be converted to any reference type or nullable value type through a null literal conversion ([§11.2.6](conversions.md#1126-null-literal-conversions)).
 
 ### 7.4.6 Operators and punctuators
 
@@ -758,7 +813,7 @@ There are several kinds of operators and punctuators. Operators are used in expr
 Punctuators are for grouping and separating.
 
 ```ANTLR
-Operator_Or_Punctuator
+operator_or_punctuator
     : '{'  | '}'  | '['  | ']'  | '('   | ')'  | '.'  | ','  | ':'  | ';'
     | '+'  | '-'  | ASTERISK    | SLASH | '%'  | '&'  | '|'  | '^'  | '!'  | '~'
     | '='  | '<'  | '>'  | '?'  | '??'  | '::' | '++' | '--' | '&&' | '||'
@@ -766,18 +821,20 @@ Operator_Or_Punctuator
     | '&=' | '|=' | '^=' | '<<' | '<<=' | '=>'
     ;
     
-Right_Shift
+right_shift
     : '>'  '>'
     ;
 
-Right_Shift_Assignment
+right_shift_assignment
     : '>' '>='
     ;
 ```
 
-*Right_Shift* is made up of the two tokens `>` and `>`. Similarly, *Right_Shift_Assignment* is made up of the two tokens `>` and `>=`. Unlike other productions in the syntactic grammar, no characters of any kind (not even whitespace) are allowed between the two tokens in each of these productions. These productions are treated specially in order to enable the correct handling of *type_parameter_lists* ([§15.2.3](classes.md#1523-type-parameters)). 
+> *Note*: `right_shift` and `right_shift_assignment` are parser rules as they do not introduce a new token kind but represent a sequence of two tokens. The `operator_or_punctuator` rule exists for descriptive purposes only and is not used elsewhere in the grammar. *end note*
 
-> *Note*: Prior to the addition of generics to C#, `>>` and `>>=` were both single tokens. However, the syntax for generics uses the `<` and `>` characters to delimit type parameters and type arguments. It is often desirable to use nested constructed types, such as `List<Dictionary<string`, `int>>`. Rather than requiring the programmer to separate the `>` and `>` by a space, the definition of the two *Operator_Or_Punctuator*s was changed.
+*right_shift* is made up of the two tokens `>` and `>`. Similarly, *right_shift_assignment* is made up of the two tokens `>` and `>=`. Unlike other productions in the syntactic grammar, no characters of any kind (not even whitespace) are allowed between the two tokens in each of these productions. These productions are treated specially in order to enable the correct handling of *type_parameter_lists* ([§15.2.3](classes.md#1523-type-parameters)). 
+
+> *Note*: Prior to the addition of generics to C#, `>>` and `>>=` were both single tokens. However, the syntax for generics uses the `<` and `>` characters to delimit type parameters and type arguments. It is often desirable to use nested constructed types, such as `List<Dictionary<string`, `int>>`. Rather than requiring the programmer to separate the `>` and `>` by a space, the definition of the two *operator_or_punctuator*s was changed.
 
 ## 7.5 Pre-processing directives
 
@@ -787,14 +844,16 @@ The pre-processing directives provide the ability to skip conditionally sections
 
 > *Note*: The term "pre-processing directives" is used only for consistency with the C and C++ programming languages. In C#, there is no separate pre-processing step; pre-processing directives are processed as part of the lexical analysis phase. *end note*
 
+> *Note*: The pre-processor grammar, though defined using ANTLR lexical rules, does not define any lexical tokens in the language and is not “ANTLR ready”. Pre-processing involves processing the input and modifying the token stream produced by the lexer, this is not represented in this grammar and is part of compiler implementation and thus out of scope for this language specification. *end note*
+
 ```ANTLR
-Pp_Directive
-    : Pp_Declaration
-    | Pp_Conditional
-    | Pp_Line
-    | Pp_Diagnostic
-    | Pp_Region
-    | Pp_Pragma
+PP_Directive
+    : PP_Declaration
+    | PP_Conditional
+    | PP_Line
+    | PP_Diagnostic
+    | PP_Region
+    | PP_Pragma
     ;
 ```
 
@@ -866,36 +925,36 @@ The namespace for conditional compilation symbols is distinct and separate from 
 Pre-processing expressions can occur in `#if` and `#elif` directives. The operators `!`, `==`, `!=`, `&&`, and `||` are permitted in pre-processing expressions, and parentheses may be used for grouping.
 
 ```ANTLR
-Pp_Expression
-    : Whitespace? Pp_Or_Expression Whitespace?
+PP_Expression
+    : Whitespace? PP_Or_Expression Whitespace?
     ;
     
-Pp_Or_Expression
-    : Pp_And_Expression
-    | Pp_Or_Expression Whitespace? '||' Whitespace? Pp_And_Expression
+PP_Or_Expression
+    : PP_And_Expression
+    | PP_Or_Expression Whitespace? '||' Whitespace? PP_And_Expression
     ;
     
-Pp_And_Expression
-    : Pp_Equality_Expression
-    | Pp_And_Expression Whitespace? '&&' Whitespace? Pp_Equality_Expression
+PP_And_Expression
+    : PP_Equality_Expression
+    | PP_And_Expression Whitespace? '&&' Whitespace? PP_Equality_Expression
     ;
 
-Pp_Equality_Expression
-    : Pp_Unary_Expression
-    | Pp_Equality_Expression Whitespace? '==' Whitespace? Pp_Unary_Expression
-    | Pp_Equality_Expression Whitespace? '!=' Whitespace? Pp_Unary_Expression
+PP_Equality_Expression
+    : PP_Unary_Expression
+    | PP_Equality_Expression Whitespace? '==' Whitespace? PP_Unary_Expression
+    | PP_Equality_Expression Whitespace? '!=' Whitespace? PP_Unary_Expression
     ;
     
-Pp_Unary_Expression
-    : Pp_Primary_Expression
-    | '!' Whitespace? Pp_Unary_Expression
+PP_Unary_Expression
+    : PP_Primary_Expression
+    | '!' Whitespace? PP_Unary_Expression
     ;
     
-Pp_Primary_Expression
+PP_Primary_Expression
     : TRUE
     | FALSE
     | Conditional_Symbol
-    | '(' Whitespace? Pp_Expression Whitespace? ')'
+    | '(' Whitespace? PP_Expression Whitespace? ')'
     ;
 ```
 
@@ -908,19 +967,19 @@ Evaluation of a pre-processing expression always yields a Boolean value. The rul
 The definition directives are used to define or undefine conditional compilation symbols.
 
 ```ANTLR
-Pp_Declaration
-    : Whitespace? '#' Whitespace? 'define' Whitespace Conditional_Symbol Pp_New_Line
-    | Whitespace? '#' Whitespace? 'undef' Whitespace Conditional_Symbol Pp_New_Line
+PP_Declaration
+    : Whitespace? '#' Whitespace? 'define' Whitespace Conditional_Symbol PP_New_Line
+    | Whitespace? '#' Whitespace? 'undef' Whitespace Conditional_Symbol PP_New_Line
     ;
 
-Pp_New_Line
+PP_New_Line
     : Whitespace? Single_Line_Comment? New_Line
     ;
 ```
 
 The processing of a `#define` directive causes the given conditional compilation symbol to become defined, starting with the source line that follows the directive. Likewise, the processing of a `#undef` directive causes the given conditional compilation symbol to become undefined, starting with the source line that follows the directive.
 
-Any `#define` and `#undef` directives in a compilation unit shall occur before the first *Token* ([§7.4](lexical-structure.md#74-tokens)) in the compilation unit; otherwise a compile-time error occurs. In intuitive terms, `#define` and `#undef` directives shall precede any "real code" in the compilation unit.
+Any `#define` and `#undef` directives in a compilation unit shall occur before the first *token* ([§7.4](lexical-structure.md#74-tokens)) in the compilation unit; otherwise a compile-time error occurs. In intuitive terms, `#define` and `#undef` directives shall precede any "real code" in the compilation unit.
 
 > *Example*: The example:
 > ```csharp
@@ -974,34 +1033,34 @@ A `#undef` may "undefine" a conditional compilation symbol that is not defined.
 The conditional compilation directives are used to conditionally include or exclude portions of a compilation unit.
 
 ```ANTLR
-Pp_Conditional
-    : Pp_If_Section Pp_Elif_Section* Pp_Else_Section? Pp_Endif
+PP_Conditional
+    : PP_If_Section PP_Elif_Section* PP_Else_Section? PP_Endif
     ;
 
-Pp_If_Section
-    : Whitespace? '#' Whitespace? 'if' Whitespace Pp_Expression Pp_New_Line Conditional_Section?
+PP_If_Section
+    : Whitespace? '#' Whitespace? 'if' Whitespace PP_Expression PP_New_Line Conditional_Section?
     ;
     
-Pp_Elif_Section
-    : Whitespace? '#' Whitespace? 'elif' Whitespace Pp_Expression Pp_New_Line Conditional_Section?
+PP_Elif_Section
+    : Whitespace? '#' Whitespace? 'elif' Whitespace PP_Expression PP_New_Line Conditional_Section?
     ;
     
-Pp_Else_Section
-    : Whitespace? '#' Whitespace? 'else' Pp_New_Line Conditional_Section?
+PP_Else_Section
+    : Whitespace? '#' Whitespace? 'else' PP_New_Line Conditional_Section?
     ;
     
-Pp_Endif
-    : Whitespace? '#' Whitespace? 'endif' Pp_New_Line
+PP_Endif
+    : Whitespace? '#' Whitespace? 'endif' PP_New_Line
     ;
     
 Conditional_Section
-    : Input_Section
+    : input_section
     | Skipped_Section_Part+
     ;
 
 Skipped_Section_Part
     : Skipped_Characters? New_Line
-    | Pp_Directive
+    | PP_Directive
     ;
     
 Skipped_Characters
@@ -1015,13 +1074,13 @@ Not_Number_Sign
 
 > *Note*: As indicated by the syntax, conditional compilation directives shall be written as sets consisting of, in order, a `#if` directive, zero or more `#elif` directives, zero or one `#else` directive, and a `#endif` directive. Between the directives are conditional sections of source code. Each section is controlled by the immediately preceding directive. A conditional section may itself contain nested conditional compilation directives provided these directives form complete sets. *end note*
 
-A *Pp_Conditional* selects at most one of the contained *Conditional_Section*s for normal lexical processing:
+A *PP_Conditional* selects at most one of the contained *Conditional_Section*s for normal lexical processing:
 
--   The *Pp_Expression*s of the `#if` and `#elif` directives are evaluated in order until one yields `true`. If an expression yields `true`, the *Conditional_Section* of the corresponding directive is selected.
--   If all *Pp_Expression*s yield `false`, and if a `#else` directive is present, the *Conditional_Section* of the `#else` directive is selected.
+-   The *PP_Expression*s of the `#if` and `#elif` directives are evaluated in order until one yields `true`. If an expression yields `true`, the *Conditional_Section* of the corresponding directive is selected.
+-   If all *PP_Expression*s yield `false`, and if a `#else` directive is present, the *Conditional_Section* of the `#else` directive is selected.
 -   Otherwise, no *Conditional_Section* is selected.
 
-The selected *Conditional_Section*, if any, is processed as a normal *Input_Section*: the source code contained in the section shall adhere to the lexical grammar; tokens are generated from the source code in the section; and pre-processing directives in the section have the prescribed effects.
+The selected *Conditional_Section*, if any, is processed as a normal *input_section*: the source code contained in the section shall adhere to the lexical grammar; tokens are generated from the source code in the section; and pre-processing directives in the section have the prescribed effects.
 
 The remaining *Conditional_Section*s, if any, are processed as one or more *Skipped_Section_Part*s: except for pre-processing directives, the source code in the section need not adhere to the lexical grammar; no tokens are generated from the source code in the section; and pre-processing directives in the section shall be lexically correct but are not otherwise processed. Within a *Conditional_Section* that is being processed as one or more *Skipped_Section_Part*s, any nested *Conditional_Section*s (contained in nested `#if...#endif` and `#region...#endregion` constructs) are also processed as one or more *Skipped_Section_Part*s.
 
@@ -1099,12 +1158,12 @@ The remaining *Conditional_Section*s, if any, are processed as one or more *Skip
 The diagnostic directives are used to generate explicitly error and warning messages that are reported in the same way as other compile-time errors and warnings.
 
 ```ANTLR
-Pp_Diagnostic
-    : Whitespace? '#' Whitespace? 'error' Pp_Message
-    | Whitespace? '#' Whitespace? 'warning' Pp_Message
+PP_Diagnostic
+    : Whitespace? '#' Whitespace? 'error' PP_Message
+    | Whitespace? '#' Whitespace? 'warning' PP_Message
     ;
 
-Pp_Message
+PP_Message
     : New_Line
     | Whitespace Input_Character* New_Line
     ;
@@ -1117,26 +1176,26 @@ Pp_Message
 > #endif
 > class Test {...}
 > ```
-> produces a compile-time error ("A build can't be both debug and retail") if the conditional compilation symbols `Debug` and `Retail` are both defined. Note that a *Pp_Message* can contain arbitrary text; specifically, it need not contain well-formed tokens, as shown by the single quote in the word `can't`. *end example*
+> produces a compile-time error ("A build can't be both debug and retail") if the conditional compilation symbols `Debug` and `Retail` are both defined. Note that a *PP_Message* can contain arbitrary text; specifically, it need not contain well-formed tokens, as shown by the single quote in the word `can't`. *end example*
 
 ### 7.5.7 Region directives
 
 The region directives are used to mark explicitly regions of source code.
 
 ```ANTLR
-Pp_Region
-    : Pp_Start_Region Conditional_Section? Pp_End_Region
+PP_Region
+    : PP_Start_Region Conditional_Section? PP_End_Region
     ;
 
-Pp_Start_Region
-    : Whitespace? '#' Whitespace? 'region' Pp_Message
+PP_Start_Region
+    : Whitespace? '#' Whitespace? 'region' PP_Message
     ;
 
-Pp_End_Region
-    : Whitespace? '#' Whitespace? 'endregion' Pp_Message
+PP_End_Region
+    : Whitespace? '#' Whitespace? 'endregion' PP_Message
     ;
 ```
-No semantic meaning is attached to a region; regions are intended for use by the programmer or by automated tools to mark a section of source code. The message specified in a `#region` or `#endregion` directive likewise has no semantic meaning; it merely serves to identify the region. Matching `#region` and `#endregion` directives may have different *Pp_Message*s.
+No semantic meaning is attached to a region; regions are intended for use by the programmer or by automated tools to mark a section of source code. The message specified in a `#region` or `#endregion` directive likewise has no semantic meaning; it merely serves to identify the region. Matching `#region` and `#endregion` directives may have different *PP_Message*s.
 
 The lexical processing of a region:
 
@@ -1161,8 +1220,8 @@ Line directives may be used to alter the line numbers and compilation unit names
 > *Note*: Line directives are most commonly used in meta-programming tools that generate C# source code from some other text input. *end note*
 
 ```ANTLR
-Pp_Line
-    : Whitespace? '#' Whitespace? 'line' Whitespace Line_Indicator Pp_New_Line
+PP_Line
+    : Whitespace? '#' Whitespace? 'line' Whitespace Line_Indicator PP_New_Line
     ;
 
 Line_Indicator
@@ -1200,16 +1259,16 @@ The `#pragma` preprocessing directive is used to specify contextual information 
 *end note*
 
 ```ANTLR
-Pp_Pragma
-    : Whitespace? '#' Whitespace? 'pragma' Pp_Pragma_Text
+PP_Pragma
+    : Whitespace? '#' Whitespace? 'pragma' PP_Pragma_Text
     ;
 
-Pp_Pragma_Text
+PP_Pragma_Text
     : New_Line
     | Whitespace Input_Character* New_Line
     ;
 ```
 
-The *Input_Character*s in the *Pp_Pragma-Text* are interpreted by the compiler in an implementation-defined manner. The information supplied in a `#pragma` directive shall not change program semantics. A `#pragma` directive shall only change compiler behavior that is outside the scope of this language specification. If the compiler cannot interpret the *Input_Character*s, the compiler can produce a warning; however, it shall not produce a compile-time error.
+The *Input_Character*s in the *PP_Pragma-Text* are interpreted by the compiler in an implementation-defined manner. The information supplied in a `#pragma` directive shall not change program semantics. A `#pragma` directive shall only change compiler behavior that is outside the scope of this language specification. If the compiler cannot interpret the *Input_Character*s, the compiler can produce a warning; however, it shall not produce a compile-time error.
 
-> *Note*: *Pp_Pragma_Text* can contain arbitrary text; specifically, it need not contain well-formed tokens. *end note*
+> *Note*: *PP_Pragma_Text* can contain arbitrary text; specifically, it need not contain well-formed tokens. *end note*

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -26,7 +26,7 @@ All terminal characters are to be understood as the appropriate Unicode characte
 
 ### 7.2.2 Grammar notation
 
-The lexical and syntactic grammars are presented in the ANTLR grammar tool’s Extended Backus-Naur form.
+The lexical and syntactic grammars are presented in the ANTLR grammar tool's Extended Backus-Naur form.
 
 While the ANTLR notation is used this Standard does not present a complete ANTLR-ready "reference grammar" for C#; writing a lexer and parser, either by hand or using a tool such as ANTLR, is outside the scope of a language specification. In particular three sections of the lexical grammar:
 
@@ -44,9 +44,9 @@ ANTLR distinguishes between lexical and syntactic, termed parser by ANTLR, gramm
 
 The lexical grammar of C# is presented in [§7.3](lexical-structure.md#73-lexical-analysis), [§7.4](lexical-structure.md#74-tokens), and [§7.5](lexical-structure.md#75-pre-processing-directives). The terminal symbols of the lexical grammar are the characters of the Unicode character set, and the lexical grammar specifies how characters are combined to form tokens ([§7.4](lexical-structure.md#74-tokens)), white space ([§7.3.4](lexical-structure.md#734-white-space)), comments ([§7.3.3](lexical-structure.md#733-comments)), and pre-processing directives ([§7.5](lexical-structure.md#75-pre-processing-directives)).
 
-Many of the terminal symbols of the syntactic grammar are not defined explicitly as tokens in the lexical grammar. Rather advantage is taken of the ANTLR behaviour that literal strings in the grammar are extracted as implicit lexical tokens; this allows keywords, operators, etc. to be represented in the grammar by their literal representation rather than a token name.
+Many of the terminal symbols of the syntactic grammar are not defined explicitly as tokens in the lexical grammar. Rather advantage is taken of the ANTLR behavior that literal strings in the grammar are extracted as implicit lexical tokens; this allows keywords, operators, etc. to be represented in the grammar by their literal representation rather than a token name.
 
-The same behaviour is also used to simplify the lexical grammar, see [§7.3.1](lexical-structure.md#731-general).
+The same behavior is also used to simplify the lexical grammar, see [§7.3.1](lexical-structure.md#731-general).
 
 Every compilation unit in a C# program shall conform to the *Input* production of the lexical grammar ([§7.3.1](lexical-structure.md#731-general)).
 
@@ -152,9 +152,9 @@ The rules of the lexical grammar are ordered top-to-bottom, with the first match
 
 > *Example*: As keyword tokens are defined implicitly by literal strings in the grammar, and implicit rules are ordered before explicit ones, the rule `Available_Identifier` ([§7.4.3](lexical-structure.md#743-identifiers)) will never match a keyword. *end example*
 
-Some tokens are defined by a set of lexical rules; a main rule and one or more sub-rules. The latter are marked in the grammer by `fragment` to indicate the rule does defines part of another token. Fragment rules are not considered in the top-to-bottom ordering of lexical rules.
+Some tokens are defined by a set of lexical rules; a main rule and one or more sub-rules. The latter are marked in the grammar by `fragment` to indicate the rule does defines part of another token. Fragment rules are not considered in the top-to-bottom ordering of lexical rules.
 
-> *Note*: In ANTLR `fragment` is a keyword which produces the same behaviour defined here. *end note*
+> *Note*: In ANTLR `fragment` is a keyword which produces the same behavior defined here. *end note*
 
 ### 7.3.2 Line terminators
 
@@ -199,7 +199,7 @@ A ***single-line comment*** begins with the characters `//` and extends to the 
 > *Example*: The example
 > ```csharp
 > // Hello, world program
-> //     This program writes “hello, world” to the console
+> //     This program writes "hello, world" to the console
 > //
 > class Hello // any name will do for this class
 > {
@@ -459,15 +459,15 @@ fragment Formatting_Character
 
 > 1. For information on the Unicode character classes mentioned above, see *The Unicode Standard*. *end note*
 
-> 2. The ANTLR semantic predicates above: `IsLetterCharacter`, `IsCombiningCharacter`, `IsDecimalDigitCharacter`, `IsConnectingCharacter` and `IsFormattingCharacter`; are informative *only*. How a compiler enforces the restriction on the allowable
+> 2. The ANTLR semantic predicates above (`IsLetterCharacter`, `IsCombiningCharacter`, `IsDecimalDigitCharacter`, `IsConnectingCharacter` and `IsFormattingCharacter`) are informative *only*. How a compiler enforces the restriction on the allowable
 *Unicode_Escape_Sequence* values is an implementation issue. *end note*
 
 > 3. The explicit rules for identifiers depend on the implicit rules introduced by literal strings in the grammar:
->> - Keywords and contextual keywords occur in the grammar as literal strings and from these implicit lexical token rules are created which are ordered before the explicit lexical rules ([§7.2.3](lexical-structure.md#723-lexical-grammar)).
->> - Therefore fragment `Available_Identifier` will not match keywords or contextual keywords as the lexical rules for those precede it.
->> - Fragment `Escaped_Identifier` will effectively include keywords and contextual keywords as part of the longer token starting with an `@`.
->> - `identifier` is a parser rule, as are those for `keyword` and `contextual_keyword` ([§7.4.4](lexical-structure.md#744-keywords)), as they do not define a new token kinds but rather represent a grouping of other tokens.
->> - `identifier` includes `contextual_keyword` ([§7.4.4](lexical-structure.md#744-keywords)) so that contextual keywords are treated as identifiers except where they explicitly occur in the parser grammar as contextual keywords.
+>    - Keywords and contextual keywords occur in the grammar as literal strings and from these implicit lexical token rules are created which are ordered before the explicit lexical rules ([§7.2.3](lexical-structure.md#723-lexical-grammar)).
+>    - Therefore fragment `Available_Identifier` will not match keywords or contextual keywords as the lexical rules for those precede it.
+>    - Fragment `Escaped_Identifier` will effectively include keywords and contextual keywords as part of the longer token starting with an `@`.
+>    - `identifier` is a parser rule, as are `keyword` and `contextual_keyword` ([§7.4.4](lexical-structure.md#744-keywords)), as they do not define a new token kinds but rather represent a grouping of other tokens.
+>    - `identifier` includes `contextual_keyword` ([§7.4.4](lexical-structure.md#744-keywords)) so that contextual keywords are treated as identifiers except where they explicitly occur in the parser grammar as contextual keywords.
 
 > *end note*
 
@@ -547,7 +547,7 @@ contextual_keyword
     ;
 ```
 
-> *Note*: The rules `keyword` and `contextual_keyword` are parser rules as they do not introduce new token kinds. Every keyword and contextual keyword is defined by an implicit lexical rule as they occur as literal strings in the grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)). *end note*
+> *Note*: The rules `keyword` and `contextual_keyword` are parser rules as they do not introduce new token kinds. All keywords and contextual keywords are defined by implicit lexical rules as they occur as literal strings in the grammar ([§7.2.3](lexical-structure.md#723-lexical-grammar)). *end note*
 
 In most cases, the syntactic location of contextual keywords is such that they can never be confused with ordinary identifier usage. For example, within a property declaration, the "`get`" and "`set`" identifiers have special meaning ([§15.7.3](classes.md#1573-accessors)). An identifier other than `get` or `set` is never permitted in these locations, so this use does not conflict with a use of these words as identifiers.
 
@@ -876,7 +876,7 @@ right_shift_assignment
 
 *right_shift* is made up of the two tokens `>` and `>`. Similarly, *right_shift_assignment* is made up of the two tokens `>` and `>=`. Unlike other productions in the syntactic grammar, no characters of any kind (not even whitespace) are allowed between the two tokens in each of these productions. These productions are treated specially in order to enable the correct handling of *type_parameter_lists* ([§15.2.3](classes.md#1523-type-parameters)). 
 
-> *Note*: Prior to the addition of generics to C#, `>>` and `>>=` were both single tokens. However, the syntax for generics uses the `<` and `>` characters to delimit type parameters and type arguments. It is often desirable to use nested constructed types, such as `List<Dictionary<string`, `int>>`. Rather than requiring the programmer to separate the `>` and `>` by a space, the definition of the two *operator_or_punctuator*s was changed.
+> *Note*: Prior to the addition of generics to C#, `>>` and `>>=` were both single tokens. However, the syntax for generics uses the `<` and `>` characters to delimit type parameters and type arguments. It is often desirable to use nested constructed types, such as `List<Dictionary<string, int>>`. Rather than requiring the programmer to separate the `>` and `>` by a space, the definition of the two *operator_or_punctuator*s was changed.
 
 ## 7.5 Pre-processing directives
 
@@ -953,7 +953,7 @@ fragment Conditional_Symbol
     ;
 ```
 
-> *Note* The ANTLR semantic predicate above: `IsNotTrueOrFalse`; is informative *only*. How a compiler enforces the restriction on the allowable
+> *Note* The ANTLR semantic predicate above (`IsNotTrueOrFalse`) is informative *only*. How a compiler enforces the restriction on the allowable
 *Basic_Identifier* values is an implementation issue. *end note*
 
 Two conditional compilation symbols are considered the same if they are identical after the following transformations are applied, in order:

--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -45,7 +45,7 @@ namespace_declaration
     ;
 
 qualified_identifier
-    : Identifier ('.' Identifier)*
+    : identifier ('.' identifier)*
     ;
 
 namespace_body
@@ -103,13 +103,13 @@ An *extern_alias_directive* introduces an identifier that serves as an alias for
 
 ```ANTLR
 extern_alias_directive
-    : 'extern' 'alias' Identifier ';'
+    : 'extern' 'alias' identifier ';'
     ;
 ```
 
 The scope of an *extern_alias_directive* extends over the *using_directive*s, *global_attributes* and *namespace_member_declaration*s of its immediately containing *compilation_unit* or *namespace_body*.
 
-Within a compilation unit or namespace body that contains an *extern_alias_directive*, the identifier introduced by the *extern_alias_directive* can be used to reference the aliased namespace. It is a compile-time error for the *Identifier* to be the word `global`.
+Within a compilation unit or namespace body that contains an *extern_alias_directive*, the identifier introduced by the *extern_alias_directive* can be used to reference the aliased namespace. It is a compile-time error for the *identifier* to be the word `global`.
 
 Within C# source code, a type is declared a member of a single namespace. However, a namespace hierarchy referenced by an extern alias may contain types that are also members of other namespaces. For example, if `A` and `B` are extern aliases, the names `A::X`,`B::C.Y` and `global::D.Z` may, depending on the external specification supported by the particular compiler, all refer to the same type.
 
@@ -148,7 +148,7 @@ A *using_alias_directive* introduces an identifier that serves as an alias for a
 
 ```ANTLR
 using_alias_directive
-    : 'using' Identifier '=' namespace_or_type_name ';'
+    : 'using' identifier '=' namespace_or_type_name ';'
     ;
 ```
 
@@ -499,7 +499,7 @@ A *qualified_alias_member* provides explicit access to the global namespace and 
 
 ```ANTLR
 qualified_alias_member
-    : Identifier '::' Identifier type_argument_list?
+    : identifier '::' identifier type_argument_list?
     ;
 ```
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -194,11 +194,11 @@ A *labeled_statement* permits a statement to be prefixed by a label. Labeled sta
 
 ```ANTLR
 labeled_statement
-    : Identifier ':' statement
+    : identifier ':' statement
     ;
 ```
 
-A labeled statement declares a label with the name given by the *Identifier*. The scope of a label is the whole block in which the label is declared, including any nested blocks. It is a compile-time error for two labels with the same name to have overlapping scopes.
+A labeled statement declares a label with the name given by the *identifier*. The scope of a label is the whole block in which the label is declared, including any nested blocks. It is a compile-time error for two labels with the same name to have overlapping scopes.
 
 A label can be referenced from `goto` statements ([§13.10.4](statements.md#13104-the-goto-statement)) within the scope of the label. 
 
@@ -253,8 +253,8 @@ local_variable_declarators
     ;
 
 local_variable_declarator
-    : Identifier
-    | Identifier '=' local_variable_initializer
+    : identifier
+    | identifier '=' local_variable_initializer
     ;
 
 local_variable_initializer
@@ -266,7 +266,7 @@ local_variable_initializer
 
 *stackalloc_initializer* ([§23.9](unsafe-code.md#239-stack-allocation)) is only available in unsafe code ([§23](unsafe-code.md#23-unsafe-code)).
 
-The *local_variable_type* of a *local_variable_declaration* either directly specifies the type of the variables introduced by the declaration, or indicates with the identifier `var` that the type should be inferred based on an initializer. The type is followed by a list of *local_variable_declarator*s, each of which introduces a new variable. A *local_variable_declarator* consists of an *Identifier* that names the variable, optionally followed by an "`=`" token and a *local_variable_initializer* that gives the initial value of the variable.
+The *local_variable_type* of a *local_variable_declaration* either directly specifies the type of the variables introduced by the declaration, or indicates with the identifier `var` that the type should be inferred based on an initializer. The type is followed by a list of *local_variable_declarator*s, each of which introduces a new variable. A *local_variable_declarator* consists of an *identifier* that names the variable, optionally followed by an "`=`" token and a *local_variable_initializer* that gives the initial value of the variable.
 
 In the context of a local variable declaration, the identifier `var` acts as a contextual keyword ([§7.4.4](lexical-structure.md#744-keywords)).When the *local_variable_type* is specified as `var` and no type named `var` is in scope, the declaration is an ***implicitly typed local variable declaration***, whose type is inferred from the type of the associated initializer expression. Implicitly typed local variable declarations are subject to the following restrictions:
 
@@ -342,11 +342,11 @@ constant_declarators
     ;
 
 constant_declarator
-    : Identifier '=' constant_expression
+    : identifier '=' constant_expression
     ;
 ```
 
-The *type* of a *local_constant_declaration* specifies the type of the constants introduced by the declaration. The type is followed by a list of *constant_declarator*s, each of which introduces a new constant. A *constant_declarator* consists of an *Identifier* that names the constant, followed by an "`=`" token, followed by a *constant_expression* ([§12.20](expressions.md#1220-constant-expressions)) that gives the value of the constant.
+The *type* of a *local_constant_declaration* specifies the type of the constants introduced by the declaration. The type is followed by a list of *constant_declarator*s, each of which introduces a new constant. A *constant_declarator* consists of an *identifier* that names the constant, followed by an "`=`" token, followed by a *constant_expression* ([§12.20](expressions.md#1220-constant-expressions)) that gives the value of the constant.
 
 The *type* and *constant_expression* of a local constant declaration shall follow the same rules as those of a constant member declaration ([§15.4](classes.md#154-constants)).
 
@@ -734,11 +734,11 @@ The `foreach` statement enumerates the elements of a collection, executing an em
 
 ```ANTLR
 foreach_statement
-    : 'foreach' '(' local_variable_type Identifier 'in' expression ')' embedded_statement
+    : 'foreach' '(' local_variable_type identifier 'in' expression ')' embedded_statement
     ;
 ```
 
-The *local_variable_type* and *Identifier* of a `foreach` statement declare the ***iteration variable*** of the statement. If the `var` identifier is given as the *local_variable_type*, and no type named var is in scope, the iteration variable is said to be an ***implicitly typed iteration variable***, and its type is taken to be the iteration type of the `foreach` statement, as specified below. The iteration variable corresponds to a read-only local variable with a scope that extends over the embedded statement. During execution of a `foreach` statement, the iteration variable represents the collection element for which an iteration is currently being performed. A compile-time error occurs if the embedded statement attempts to modify the iteration variable (via assignment or the `++` and `--` operators) or pass the iteration variable as a `ref` or `out` parameter.
+The *local_variable_type* and *identifier* of a `foreach` statement declare the ***iteration variable*** of the statement. If the `var` identifier is given as the *local_variable_type*, and no type named var is in scope, the iteration variable is said to be an ***implicitly typed iteration variable***, and its type is taken to be the iteration type of the `foreach` statement, as specified below. The iteration variable corresponds to a read-only local variable with a scope that extends over the embedded statement. During execution of a `foreach` statement, the iteration variable represents the collection element for which an iteration is currently being performed. A compile-time error occurs if the embedded statement attempts to modify the iteration variable (via assignment or the `++` and `--` operators) or pass the iteration variable as a `ref` or `out` parameter.
 
 In the following, for brevity, `IEnumerable`, `IEnumerator`, `IEnumerable<T>` and `IEnumerator<T>` refer to the corresponding types in the namespaces `System.Collections` and `System.Collections.Generic`.
 
@@ -975,13 +975,13 @@ The `goto` statement transfers control to a statement that is marked by a label.
 
 ```ANTLR
 goto_statement
-    : 'goto' Identifier ';'
+    : 'goto' identifier ';'
     | 'goto' 'case' constant_expression ';'
     | 'goto' 'default' ';'
     ;
 ```
 
-The target of a `goto` *Identifier* statement is the labeled statement with the given label. If a label with the given name does not exist in the current function member, or if the `goto` statement is not within the scope of the label, a compile-time error occurs. 
+The target of a `goto` *identifier* statement is the labeled statement with the given label. If a label with the given name does not exist in the current function member, or if the `goto` statement is not within the scope of the label, a compile-time error occurs. 
 
 > *Note*: This rule permits the use of a `goto` statement to transfer control *out of* a nested scope, but not *into* a nested scope. In the example
 > ```csharp
@@ -1095,7 +1095,7 @@ catch_clause
     ;
 
 exception_specifier
-    : '(' type Identifier? ')'
+    : '(' type identifier? ')'
     ;
     
 finally_clause
@@ -1111,7 +1111,7 @@ There are three possible forms of `try` statements:
 
 When a `catch` clause specifies a *type*, the type shall be `System.Exception` or a type that derives from `System.Exception`. When a `catch` clause specifies a *type_parameter* it shall be a type parameter type whose effective base class is or derives from `System.Exception`.
 
-When a `catch` clause specifies both a *class_type* and an *Identifier*, an ***exception variable*** of the given name and type is declared. The exception variable corresponds to a local variable with a scope that extends over the `catch` block. During execution of the `catch` block, the exception variable represents the exception currently being handled. For purposes of definite assignment checking, the exception variable is considered definitely assigned in its entire scope.
+When a `catch` clause specifies both a *class_type* and an *identifier*, an ***exception variable*** of the given name and type is declared. The exception variable corresponds to a local variable with a scope that extends over the `catch` block. During execution of the `catch` block, the exception variable represents the exception currently being handled. For purposes of definite assignment checking, the exception variable is considered definitely assigned in its entire scope.
 
 Unless a `catch` clause includes an exception variable name, it is impossible to access the exception object in the `catch` block.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -16,12 +16,12 @@ A *struct_declaration* is a *type_declaration* ([§14.7](namespaces.md#147-type-
 
 ```ANTLR
 struct_declaration
-    : attributes? struct_modifier* 'partial'? 'struct' Identifier type_parameter_list?
+    : attributes? struct_modifier* 'partial'? 'struct' identifier type_parameter_list?
       struct_interfaces? type_parameter_constraints_clause* struct_body ';'?
     ;
 ```
 
-A *struct_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *struct_modifier*s ([§16.2.2](structs.md#1622-struct-modifiers)), followed by an optional partial modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword `struct` and an *Identifier* that names the struct, followed by an optional *type_parameter_list* specification ([§15.2.3](classes.md#1523-type-parameters)), followed by an optional *struct_interfaces* specification ([§16.2.4](structs.md#1624-struct-interfaces)), followed by an optional *type_parameter_constraints-clauses* specification ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by a *struct_body* ([§16.2.5](structs.md#1625-struct-body)), optionally followed by a semicolon.
+A *struct_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *struct_modifier*s ([§16.2.2](structs.md#1622-struct-modifiers)), followed by an optional partial modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword `struct` and an *identifier* that names the struct, followed by an optional *type_parameter_list* specification ([§15.2.3](classes.md#1523-type-parameters)), followed by an optional *struct_interfaces* specification ([§16.2.4](structs.md#1624-struct-interfaces)), followed by an optional *type_parameter_constraints-clauses* specification ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by a *struct_body* ([§16.2.5](structs.md#1625-struct-body)), optionally followed by a semicolon.
 
 A struct declaration shall not supply a *type_parameter_constraints_clauses* unless it also supplies a *type_parameter_list*.
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -528,7 +528,7 @@ A type parameter is an identifier designating a value type or reference type tha
 
 ```ANTLR
 type_parameter
-    : Identifier
+    : identifier
     ;
 ```
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -421,7 +421,7 @@ finally *finally_block*
 
 For a `foreach` statement *stmt* of the form:
 
-`foreach (` *type* *Identifier* `in` *expr* `)` *embedded_statement*
+`foreach (` *type* *identifier* `in` *expr* `)` *embedded_statement*
 
 - The definite assignment state of *v* at the beginning of *expr* is the same as the state of *v* at the beginning of *stmt*.
 - The definite assignment state of *v* on the control flow transfer to *embedded_statement* or to the end point of *stmt* is the same as the state of *v* at the end of *expr*.


### PR DESCRIPTION
…th tokenises and parses the input and this

requires using both lexical and parser ANTLR rules while producing a lexer which produces a token stream and
not some AST of the input!

In this stage of ANTLR-isation the pre-processor is not tackled; the pre-processor definition is a context-free
grammar which is atypical for a lexical grammar and defining it with lexical rules does not produce the expected
result... That said the semantics of the pre-processor can be acheived in an ANTLR lexical grammar which includes
predicates/actions and that will be explored in a subsequent stage. The grammar in this stage can be used along
with a factored syntactical grammar to lex & parse C# source which does not include pre-processor constructs.

The majority of changes are to lexical-structure.md, many of the other files are only altered as the lexical
rule *Identifier* has been replaced by the parser rule *identifier*.

I will add some comments within the PR to explain why it is the way it is...