### PR TITLE
Update section 11.7.3 to be more accurate and specific about expression tree conversions

### DIFF
--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -643,7 +643,7 @@ Given a user-defined conversion operator that converts from a non-nullable value
 
 ### 11.7.1 General
 
-An *anonymous_method_expression* or *lambda_expression* is classified as an anonymous function ([§12.16](expressions.md#1216-anonymous-function-expressions)). The expression does not have a type, but can be implicitly converted to a compatible delegate type. Some lambda expressions may also be implicitly converted to a compatible expression-tree type.
+An *anonymous_method_expression* or *lambda_expression* is classified as an anonymous function ([§12.16](expressions.md#1216-anonymous-function-expressions)). The expression does not have a type, but can be implicitly converted to a compatible delegate type. Some lambda expressions may also be implicitly converted to a compatible expression tree type.
 
 For the purpose of brevity, this subclause uses the short form for the task types `Task` and `Task<T>` ([§15.15.1](classes.md#15151-general)).
 
@@ -717,13 +717,6 @@ Specifically, an anonymous function `F` is compatible with a delegate type `D`
 
 A lambda expression `F` is compatible with an expression tree type `Expression<D>` if `F` is compatible with the delegate type `D`. This does not apply to anonymous methods, only lambda expressions.
 
-Certain lambda expressions cannot be converted to expression tree types: Even though the conversion *exists*, it fails at compile-time. This is the case if the lambda expression:
-
-- Has a *block* body
-- Contains simple or compound assignment operators
-- Contains a dynamically bound expression
-- Is async
-
 Anonymous functions may influence overload resolution, and participate in type inference. See [§12.6](expressions.md#126-function-members) for further details.
 
 ### 11.7.2 Evaluation of anonymous function conversions to delegate types
@@ -753,9 +746,27 @@ static void F(double[] a, double[] b) {
 ```
 Since the two anonymous function delegates have the same (empty) set of captured outer variables, and since the anonymous functions are semantically identical, the compiler is permitted to have the delegates refer to the same target method. Indeed, the compiler is permitted to return the very same delegate instance from both anonymous function expressions.
 
-### 11.7.3 Evaluation of anonymous function conversions to expression tree types
+### 11.7.3 Evaluation of lambda expression conversions to expression tree types
 
-Conversion of an anonymous function to an expression-tree type produces an expression tree ([§9.6](types.md#96-expression-tree-types)). More precisely, evaluation of the anonymous-function conversion produces an object structure that represents the structure of the anonymous function itself. The precise structure of the expression tree, as well as the exact process for creating it, are implementation-defined.
+Conversion of a lambda expression to an expression tree type produces an expression tree ([§9.6](types.md#96-expression-tree-types)). More precisely, evaluation of the lambda expression conversion produces an object structure that represents the structure of the lambda expression itself.
+
+Not every lambda expression can be converted to expression tree types. The conversion to a compatible delegate type always *exists*, but it may fail at compile-time for implementation-specific reasons.
+
+> *Note*: Common reasons for a lambda expression to fail to convert to an expression tree type include:
+>
+> - It has a block body
+> - It has the `async` modifier
+> - It contains an assignment operator
+> - It contains an `out` or `ref` parameter
+> - It contains a dynamically bound expression
+>
+> *end note*
+
+The following aspects of conversions from lambda expressions to expression trees are implementation-specific:
+
+- The precise structure of the expression tree
+- The exact process for creating it
+- The rules for which lambda expressions can be successfully converted into expression trees, and for which expression tree types.
 
 ## 11.8 Method group conversions
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -762,12 +762,6 @@ Not every lambda expression can be converted to expression tree types. The conve
 >
 > *end note*
 
-The following aspects of conversions from lambda expressions to expression trees are implementation-specific:
-
-- The precise structure of the expression tree
-- The exact process for creating it
-- The rules for which lambda expressions can be successfully converted into expression trees, and for which expression tree types.
-
 ## 11.8 Method group conversions
 
 An implicit conversion exists from a method group ([§12.2](expressions.md#122-expression-classifications)) to a compatible delegate type ([§20.4](delegates.md#204-delegate-compatibility)). If `D` is a delegate type, and `E` is an expression that is classified as a method group, then `D` is compatible with `E` if and only if `E` contains at least one method that is applicable in its normal form ([§12.6.4.2](expressions.md#12642-applicable-function-member)) to any argument list ([§12.6.2](expressions.md#1262-argument-lists)) having types and modifiers matching the parameter types and modifiers of `D`, as described in the following.

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -577,9 +577,6 @@ namespace System.Linq.Expressions
 {
     public sealed class Expression<TDelegate>
     {
-        // See Section 12.7.3 for details on what
-        // Delegate types (TDelegate) must be supported,
-        // and which may be omitted.
         public TDelegate Compile ();
     }
 }

--- a/standard/types.md
+++ b/standard/types.md
@@ -551,11 +551,9 @@ As a type, type parameters are purely a compile-time construct. At run-time, eac
 
 ***Expression trees*** permit lambda expressions to be represented as data structures instead of executable code. Expression trees are values of ***expression tree types*** of the form `System.Linq.Expressions.Expression<TDelegate>`, where `TDelegate` is any delegate type. For the remainder of this specification we will refer to these types using the shorthand `Expression<TDelegate>`.
 
-If a conversion exists from a lambda expression to a delegate type `D`, a conversion also exists to the expression tree type `Expression<TDelegate>`. Whereas the conversion of a lambda expression to a delegate type generates a delegate that references executable code for the lambda expression, conversion to an expression tree type creates an expression tree representation of the lambda expression.
+If a conversion exists from a lambda expression to a delegate type `D`, a conversion also exists to the expression tree type `Expression<TDelegate>`. Whereas the conversion of a lambda expression to a delegate type generates a delegate that references executable code for the lambda expression, conversion to an expression tree type creates an expression tree representation of the lambda expression. More details of this conversion are provided in [§11.7.3](conversions.md#1173-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
 
-Expression trees are efficient in-memory data representations of lambda expressions and make the structure of the lambda expression transparent and explicit.
-
-Just like a delegate type `D`, `Expression<TDelegate>` is said to have parameter and return types, which are the same as those of `D`.
+Expression trees are in-memory data representations of lambda expressions and make the structure of the lambda expression transparent and explicit.
 
 > *Example*: The following program represents a lambda expression both as executable code and as an expression tree. Because a conversion exists to `Func<int,int>`, a conversion also exists to `Expression<Func<int,int>>`:
 > ```csharp
@@ -564,25 +562,20 @@ Just like a delegate type `D`, `Expression<TDelegate>` is said to have parameter
 > ```
 > Following these assignments, the delegate `del` references a method that returns `x + 1`, and the expression tree exp references a data structure that describes the expression `x => x + 1`. *end example*
 
-The exact definition of the generic type `Expression<TDelegate>` as well as the precise rules for constructing an expression tree when a lambda expression is converted to an expression tree type, are implementation dependent.
-
-Two things are important to make explicit:
-
-- Not all lambda expressions can be converted to expression trees. For instance, lambda expressions with statement bodies, and lambda expressions containing assignment expressions cannot be represented. In these cases, a conversion still exists, but it will fail at compile-time.
-- `Expression<TDelegate>` offers an instance method Compile which produces a delegate of type `TDelegate`:
+`Expression<TDelegate>` offers an instance method `Compile` which produces a delegate of type `TDelegate`:
 
   ```csharp
   Func<int,int> del2 = exp.Compile();
   ```
 
-  Invoking this delegate causes the code represented by the expression tree to be executed. Thus, given the definitions above, `del` and `del2` are equivalent, and the following two statements will have the same effect:
+Invoking this delegate causes the code represented by the expression tree to be executed. Thus, given the definitions above, `del` and `del2` are equivalent, and the following two statements will have the same effect:
 
   ```csharp
   int i1 = del(1);
   int i2 = del2(1);
   ```
 
-  After executing this code, `i1` and `i2` will both have the value `2`.
+After executing this code, `i1` and `i2` will both have the value `2`.
 
 ## 9.7 The dynamic type
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -568,7 +568,7 @@ The exact definition of the generic type `Expression<TDelegate>` as well as the 
 
 Two things are important to make explicit:
 
-- Not all lambda expressions can be converted to expression trees. For instance, lambda expressions with statement bodies, and lambda expressions containing assignment expressions cannot be represented. In these cases, a conversion still exists, but it will fail at compile-time. These exceptions are detailed in [§11.7.3](conversions.md#1173-evaluation-of-anonymous-function-conversions-to-expression-tree-types)).
+- Not all lambda expressions can be converted to expression trees. For instance, lambda expressions with statement bodies, and lambda expressions containing assignment expressions cannot be represented. In these cases, a conversion still exists, but it will fail at compile-time.
 - `Expression<TDelegate>` offers an instance method Compile which produces a delegate of type `TDelegate`:
 
   ```csharp

--- a/standard/types.md
+++ b/standard/types.md
@@ -553,8 +553,6 @@ As a type, type parameters are purely a compile-time construct. At run-time, eac
 
 If a conversion exists from a lambda expression to a delegate type `D`, a conversion also exists to the expression tree type `Expression<TDelegate>`. Whereas the conversion of a lambda expression to a delegate type generates a delegate that references executable code for the lambda expression, conversion to an expression tree type creates an expression tree representation of the lambda expression. More details of this conversion are provided in [§11.7.3](conversions.md#1173-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
 
-Expression trees are in-memory data representations of lambda expressions and make the structure of the lambda expression transparent and explicit.
-
 > *Example*: The following program represents a lambda expression both as executable code and as an expression tree. Because a conversion exists to `Func<int,int>`, a conversion also exists to `Expression<Func<int,int>>`:
 > ```csharp
 > Func<int,int> del = x => x + 1;             // Code
@@ -562,11 +560,11 @@ Expression trees are in-memory data representations of lambda expressions and ma
 > ```
 > Following these assignments, the delegate `del` references a method that returns `x + 1`, and the expression tree exp references a data structure that describes the expression `x => x + 1`. *end example*
 
-`Expression<TDelegate>` offers an instance method `Compile` which produces a delegate of type `TDelegate`:
+`Expression<TDelegate>` provides an instance method `Compile` which produces a delegate of type `TDelegate`:
 
-  ```csharp
-  Func<int,int> del2 = exp.Compile();
-  ```
+```csharp
+Func<int,int> del2 = exp.Compile();
+```
 
 Invoking this delegate causes the code represented by the expression tree to be executed. Thus, given the definitions above, `del` and `del2` are equivalent, and the following two statements will have the same effect:
 
@@ -576,6 +574,15 @@ Invoking this delegate causes the code represented by the expression tree to be 
   ```
 
 After executing this code, `i1` and `i2` will both have the value `2`.
+
+The API surface provided by `Expression<TDelegate>` is implementation-specific beyond the requirement for a `Compile` method described above.
+
+> *Note*: While the details of the API provided for expression trees are implementation-specific, it is expected that an implementation will:
+>
+> - Enable code to inspect and respond to the structure of an expression tree created as the result of a conversion from a lambda expression
+> - Enable expression trees to be created programatically within user code
+>
+> *end note*
 
 ## 9.7 The dynamic type
 


### PR DESCRIPTION
Expression tree conversions are implementation-defined, so it
doesn't make sense to refer to 11.7.3 for more details (or to fail
to do so properly due to using the wrong number, as is the case in
the standard library).

Fixes #341