### PR TITLE
Interpolated strings

### DIFF
--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -35,6 +35,7 @@ The following conversions are classified as implicit conversions:
 - Identity conversions
 - Implicit numeric conversions
 - Implicit enumeration conversions
+- Implicit interpolated string conversions
 - Implicit reference conversions
 - Boxing conversions
 - Implicit dynamic conversions
@@ -87,6 +88,11 @@ There are no predefined implicit conversions to the `char` type, so values of th
 ### 11.2.4 Implicit enumeration conversions
 
 An implicit enumeration conversion permits a *constant_expression* ([§12.20](expressions.md#1220-constant-expressions)) with any integer type and the value zero to be converted to any *enum_type* and to any *nullable_value_type* whose underlying type is an *enum_type*. In the latter case the conversion is evaluated by converting to the underlying *enum_type* and wrapping the result ([§9.3.11](types.md#9311-nullable-value-types)).
+
+### §implicit-interpolated-string-conversions Implicit interpolated string conversions
+
+An implicit interpolated string conversion permits an *interpolated_string_expression* (§interpolated-string-expressions) to be converted to `System.IFormattable` or `System.FormattableString` (which implements `System.IFormattable`).
+When this conversion is applied, a string value is not composed from the interpolated string. Instead an instance of `System.FormattableString` is created, as further described in §interpolated-string-expressions.
 
 ### 11.2.5 Implicit nullable conversions
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1153,11 +1153,11 @@ A *primary_expression* that consists of a *literal* ([§7.4.5](lexical-structure
 
 ### §interpolated-string-expressions Interpolated string expressions
 
-An *interpolated_string_expression* consists of a `$` character immediately followed by text within `"` characters. Within the quoted text there are zero or more **_interpolations_** delimited by `{` and `}` characters, each of which encloses an *expression* and optional formatting specifications.
+An *interpolated_string_expression* consists of a `$` character immediately followed by text within `"` characters. Within the quoted text there are zero or more ***interpolations*** delimited by `{` and `}` characters, each of which encloses an *expression* and optional formatting specifications.
 
 Interpolated string expressions have two forms; regular (*interpolated_regular_string_expression*)
 and verbatim (*interpolated_verbatim_string_expression*); which are lexically similar to, but differ semantically from, the two forms of string
-literals ([§7.4.5.6](lexical-structure.md#7456-string-literals)).
+literals (§7.4.5.6).
 
 ```ANTLR
 interpolated_string_expression
@@ -1185,6 +1185,7 @@ Interpolated_Regular_String_Start
     ;
 
 // the following three lexical rules are context sensitive, see details below
+
 Interpolated_Regular_String_Mid
     : Interpolated_Regular_String_Element+
     ;
@@ -1207,8 +1208,8 @@ fragment Interpolated_Regular_String_Element
     ;
 
 fragment Interpolated_Regular_String_Character
-    // Any character except " (U+0022), \\ (U+005C), { (U+007B), } (U+007D), and New_Line_Character
-    : ~["\\{}\u000D\u000A\u0085\u2028\u2029]
+    : ~["\\{}\u000D\u000A\u0085\u2028\u2029]    // Any character except " (U+0022), \\ (U+005C),
+                                                //  { (U+007B), } (U+007D), and New_Line_Character
     ;
 
 // interpolated verbatim string expressions
@@ -1227,6 +1228,7 @@ Interpolated_Verbatim_String_Start
     ;
 
 // the following three lexical rules are context sensitive, see details below
+
 Interpolated_Verbatim_String_Mid
     : Interpolated_Verbatim_String_Element+
     ;
@@ -1247,8 +1249,7 @@ fragment Interpolated_Verbatim_String_Element
     ;
 
 fragment Interpolated_Verbatim_String_Character
-    // Any character except " (U+0022), { (U+007B) and } (U+007D)
-    : ~["{}]
+    : ~["{}]    // Any character except " (U+0022), { (U+007B) and } (U+007D)
     ;
 
 // lexical fragments used by both regular and verbatim interpolated strings
@@ -1267,26 +1268,26 @@ Six of the lexical rules defined above are *context sensitive* as follows:
 | Rule | Contextual Requirements |
 | :--- | :---------------------- |
 | *Interpolated_Regular_String_Mid* | Only recognised after an *Interpolated_Regular_String_Start*, between any following interpolations, and before the corresponding *Interpolated_Regular_String_End*. |
-| *Regular_Interpolation_Format* | Only recognised immediately before the closing delimiter (`}`) of a *regular_interpolation*. |
+| *Regular_Interpolation_Format* | Only recognised within a *regular_interpolation* and when the starting colon (:) is not nested within any kind of bracket (parentheses/braces/square). |
 | *Interpolated_Regular_String_End* | Only recognised after an *Interpolated_Regular_String_Start* and only if any intervening tokens are either *Interpolated_Regular_String_Mid*s or tokens that can be part of *regular_interpolation*s, including tokens for any *interpolated_regular_string_expression*s contained within such interpolations. |
 | *Interpolated_Verbatim_String_Mid* *Verbatim_Interpolation_Format* *Interpolated_Verbatim_String_End* | Recognition of these three rules follows that of the corresponding rules above with each mentioned *regular* grammar rule replaced by the corresponding *verbatim* one. |
 
-*Note:* The above rules are context sensitive as their definitions overlap with those of
+> *Note:* The above rules are context sensitive as their definitions overlap with those of
 other tokens in the language. *end note*
 
-*Note:* The above grammar is not ANTLR-ready due to the context sensitive lexical rules. As with
-other lexer generators ANTLR supports context sensitive lexical rule, for example using its *lexical modes*,
+> *Note:* The above grammar is not ANTLR-ready due to the context sensitive lexical rules. As with
+other lexer generators ANTLR supports context sensitive lexical rules, for example using its *lexical modes*,
 but this is an implementation detail and therefore not part of this Standard. *end note*
 
 An *interpolated_string_expression* is classified as a value. If it is immediately converted to `System.IFormattable` or `System.FormattableString` with an implicit interpolated string conversion (§implicit-interpolated-string-conversions), the interpolated string expression has that type. Otherwise, it has the type `string`.
 
-*Note:* The differences between the possible types an *interpolated_string_expression* may be determined from the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). *end note*
+> *Note:* The differences between the possible types an *interpolated_string_expression* may be determined from the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). *end note*
 
-The meaning on an interpolation, both *regular_interpolation* and *verbatim_interpolation*, is to format the value of the *expression* as a `string` either according to the format specified by the *Regular_Interpolation_Format* or *Verbatim_Interpolation_Format*, or according to a default format for the type of *expression*. The formatted string is then modified by the *interpolation_minimum_width*, if any, to produce the final `string` to be interpolated into the *interpolated_string_expression*.
+The meaning of an interpolation, both *regular_interpolation* and *verbatim_interpolation*, is to format the value of the *expression* as a `string` either according to the format specified by the *Regular_Interpolation_Format* or *Verbatim_Interpolation_Format*, or according to a default format for the type of *expression*. The formatted string is then modified by the *interpolation_minimum_width*, if any, to produce the final `string` to be interpolated into the *interpolated_string_expression*.
 
-*Note:* How the default format for a type is determined is detailed in the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). Descriptions of standard formats, which are identical for *Regular_Interpolation_Format* and *Verbatim_Interpolation_Format*, may be found in the documentation for `System.IFormattable` ([§C.4](standard-library.md#c4-format-specifications)) and in other types in the standard library ([§C](standard-library.md#annex-c-standard-library)). *end note*
+> *Note:* How the default format for a type is determined is detailed in the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). Descriptions of standard formats, which are identical for *Regular_Interpolation_Format* and *Verbatim_Interpolation_Format*, may be found in the documentation for `System.IFormattable` ([§C.4](standard-library.md#c4-format-specifications)) and in other types in the standard library ([§C](standard-library.md#annex-c-standard-library)). *end note*
 
-In an *interpolation_minimum_width* the *constant_expression* shall have an implicit conversion to `int` and it termed the *alignment*, the *field width* is the absolute value of the alignment:
+In an *interpolation_minimum_width* the *constant_expression* shall have an implicit conversion to `int`. Let the *field width* be the absolute value of this *constant_expression* and the *alignment* be the sign (positive or negative) of the value of this *constant_expression*:
 
 - If the value of field width is less than or equal to the length of the formatted string the formatted string is not modified.
 - Otherwise the formatted string is padded with white space characters so that its length is equal to field width:
@@ -1321,7 +1322,9 @@ This example uses the following format specification features:
 
  - the `X` format specification which formats integers as uppercase hexadecimal,
  - the default format for a `string` value is the value itself,
- - positive alignment values that right-justify within the specified field width, and
+ - positive alignment values that right-justify within the specified minimum field width,
+ - negative alignment values that left-justify within the specified minimum field width,
+ - defined constants for the *interpolation_minimum_width*, and
  - that `{{` and `}}` are formatted as `{` and `}` respectively.
 
 Given:
@@ -1329,6 +1332,7 @@ Given:
 ```csharp
 string text = "red";
 int number = 14;
+const int width = -4;
 ```
 
 Then:
@@ -1338,6 +1342,7 @@ Then:
 | `$"{text}"`                          | `string.Format("{0}", text)`                                  | `"red"`      |
 | `$"{{text}}"`                        | `string.Format("{{text}})`                                    | `"{text}"`   |
 | `$"{ text , 4 }"`                    | `string.Format("{0,4}", text)`                                | `" red"`     |
+| `$"{ text , width }"`                | `string.Format("{0,-4}", text)`                               | `"red "`     |
 | `$"{number:X}"`                      | `string.Format("{0:X}", number)`                              | `"E"`        |
 | `$"{text + '?'} {number % 3}"`       | `string.Format("{0} {1}", text + '?', number % 3)`            | `"red? 2"`   |
 | `$"{text + $"[{number}]"}"`          | `string.Format("{0}", text + string.Format("[{0}]", number))` | `"red[14]"`  |

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1106,6 +1106,7 @@ primary_expression
 
 primary_no_array_creation_expression
     : literal
+    | interpolated_string_expression
     | simple_name
     | parenthesized_expression
     | member_access
@@ -1149,6 +1150,200 @@ object o = (new int[3])[1];
 ### 12.7.2 Literals
 
 A *primary_expression* that consists of a *literal* ([§7.4.5](lexical-structure.md#745-literals)) is classified as a value.
+
+### §interpolated-string-expressions Interpolated string expressions
+
+An *interpolated_string_expression* consists of a `$` character immediately followed by text within `"` characters. Within the quoted text there are zero or more **_interpolations_** delimited by `{` and `}` characters, each of which encloses an *expression* and optional formatting specifications.
+
+Interpolated string expressions have two forms; regular (*interpolated_regular_string_expression*)
+and verbatim (*interpolated_verbatim_string_expression*); which are lexically similar to, but differ semantically from, the two forms of string
+literals ([§7.4.5.6](lexical-structure.md#7456-string-literals)).
+
+```ANTLR
+interpolated_string_expression
+    : interpolated_regular_string_expression
+    | interpolated_verbatim_string_expression
+    ;
+
+// interpolated regular string expressions
+
+interpolated_regular_string_expression
+    : Interpolated_Regular_String_Start Interpolated_Regular_String_Mid?
+      ('{' regular_interpolation '}' Interpolated_Regular_String_Mid?)* Interpolated_Regular_String_End
+    ;
+
+regular_interpolation
+    : expression (',' interpolation_minimum_width)? Regular_Interpolation_Format?
+    ;
+
+interpolation_minimum_width
+    : constant_expression
+    ;
+
+Interpolated_Regular_String_Start
+    : '$"'
+    ;
+
+// the following three lexical rules are context sensitive, see details below
+Interpolated_Regular_String_Mid
+    : Interpolated_Regular_String_Element+
+    ;
+
+Regular_Interpolation_Format
+    : ':' Interpolated_Regular_String_Element+
+    ;
+
+Interpolated_Regular_String_End
+    : '"'
+    ;
+
+fragment Interpolated_Regular_String_Element
+    : Interpolated_Regular_String_Character
+    | Simple_Escape_Sequence
+    | Hexadecimal_Escape_Sequence
+    | Unicode_Escape_Sequence
+    | Open_Brace_Escape_Sequence
+    | Close_Brace_Escape_Sequence
+    ;
+
+fragment Interpolated_Regular_String_Character
+    // Any character except " (U+0022), \\ (U+005C), { (U+007B), } (U+007D), and New_Line_Character
+    : ~["\\{}\u000D\u000A\u0085\u2028\u2029]
+    ;
+
+// interpolated verbatim string expressions
+
+interpolated_verbatim_string_expression
+    : Interpolated_Verbatim_String_Start Interpolated_Verbatim_String_Mid?
+      ('{' verbatim_interpolation '}' Interpolated_Verbatim_String_Mid?)* Interpolated_Verbatim_String_End
+    ;
+
+verbatim_interpolation
+    : expression (',' interpolation_minimum_width)? Verbatim_Interpolation_Format?
+    ;
+
+Interpolated_Verbatim_String_Start
+    : '$@"'
+    ;
+
+// the following three lexical rules are context sensitive, see details below
+Interpolated_Verbatim_String_Mid
+    : Interpolated_Verbatim_String_Element+
+    ;
+
+Verbatim_Interpolation_Format
+    : ':' Interpolated_Verbatim_String_Element+
+    ;
+
+Interpolated_Verbatim_String_End
+    : '"'
+    ;
+
+fragment Interpolated_Verbatim_String_Element
+    : Interpolated_Verbatim_String_Character
+    | Quote_Escape_Sequence
+    | Open_Brace_Escape_Sequence
+    | Close_Brace_Escape_Sequence
+    ;
+
+fragment Interpolated_Verbatim_String_Character
+    // Any character except " (U+0022), { (U+007B) and } (U+007D)
+    : ~["{}]
+    ;
+
+// lexical fragments used by both regular and verbatim interpolated strings
+
+fragment Open_Brace_Escape_Sequence
+    : '{{'
+    ;
+
+fragment Close_Brace_Escape_Sequence
+    : '}}'
+    ;
+```
+
+Six of the lexical rules defined above are *context sensitive* as follows:
+
+| Rule | Contextual Requirements |
+| :--- | :---------------------- |
+| *Interpolated_Regular_String_Mid* | Only recognised after an *Interpolated_Regular_String_Start*, between any following interpolations, and before the corresponding *Interpolated_Regular_String_End*. |
+| *Regular_Interpolation_Format* | Only recognised immediately before the closing delimiter (`}`) of a *regular_interpolation*. |
+| *Interpolated_Regular_String_End* | Only recognised after an *Interpolated_Regular_String_Start* and only if any intervening tokens are either *Interpolated_Regular_String_Mid*s or tokens that can be part of *regular_interpolation*s, including tokens for any *interpolated_regular_string_expression*s contained within such interpolations. |
+| *Interpolated_Verbatim_String_Mid* *Verbatim_Interpolation_Format* *Interpolated_Verbatim_String_End* | Recognition of these three rules follows that of the corresponding rules above with each mentioned *regular* grammar rule replaced by the corresponding *verbatim* one. |
+
+*Note:* The above rules are context sensitive as their definitions overlap with those of
+other tokens in the language. *end note*
+
+*Note:* The above grammar is not ANTLR-ready due to the context sensitive lexical rules. As with
+other lexer generators ANTLR supports context sensitive lexical rule, for example using its *lexical modes*,
+but this is an implementation detail and therefore not part of this Standard. *end note*
+
+An *interpolated_string_expression* is classified as a value. If it is immediately converted to `System.IFormattable` or `System.FormattableString` with an implicit interpolated string conversion (§implicit-interpolated-string-conversions), the interpolated string expression has that type. Otherwise, it has the type `string`.
+
+*Note:* The differences between the possible types an *interpolated_string_expression* may be determined from the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). *end note*
+
+The meaning on an interpolation, both *regular_interpolation* and *verbatim_interpolation*, is to format the value of the *expression* as a `string` either according to the format specified by the *Regular_Interpolation_Format* or *Verbatim_Interpolation_Format*, or according to a default format for the type of *expression*. The formatted string is then modified by the *interpolation_minimum_width*, if any, to produce the final `string` to be interpolated into the *interpolated_string_expression*.
+
+*Note:* How the default format for a type is determined is detailed in the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). Descriptions of standard formats, which are identical for *Regular_Interpolation_Format* and *Verbatim_Interpolation_Format*, may be found in the documentation for `System.IFormattable` ([§C.4](standard-library.md#c4-format-specifications)) and in other types in the standard library ([§C](standard-library.md#annex-c-standard-library)). *end note*
+
+In an *interpolation_minimum_width* the *constant_expression* shall have an implicit conversion to `int` and it termed the *alignment*, the *field width* is the absolute value of the alignment:
+
+- If the value of field width is less than or equal to the length of the formatted string the formatted string is not modified.
+- Otherwise the formatted string is padded with white space characters so that its length is equal to field width:
+  - If the alignment is positive the formatted string is right-aligned by prepending the padding,
+  - Otherwise it is left-aligned by appending the padding.
+
+The overall meaning of an *interpolated_string_expression*, including the above formatting and padding of interpolations, is defined by a conversion of the expression to a method invocation: if the type of the expression is `System.IFormattable` or `System.FormattableString` that method is `System.Runtime.CompilerServices.FormattableStringFactory.Create` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)) which returns a value of type `System.FormattableString`; otherwise the type must be `string` and the method is `string.Format` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) which returns a value of type `string`. 
+
+In both cases, the argument list of the call consists of a *format string literal* with *format specifications* for each interpolation, and an argument for each expression corresponding to the format specifications.
+
+The format string literal is constructed as follows, where `N` is the number of interpolations in the *interpolated_string_expression*. The format string literal consists of, in order:
+
+  - The characters of the *Interpolated_Regular_String_Start* or *Interpolated_Verbatim_String_Start*
+  - The characters of the *Interpolated_Regular_String_Mid* or *Interpolated_Verbatim_String_Mid*, if any
+  - Then if `N ≥ 1` for each number `I` from `0` to `N-1`:
+    - A placeholder specification:
+      - A left brace (`{`) character
+      - The decimal representation of `I`
+      - Then, if the corresponding *regular_interpolation* or *verbatim_interpolation* has a *interpolation_minimum_width*, a comma (`,`) followed by the decimal representation of the value of the *constant_expression*
+      - The characters of the *Regular_Interpolation_Format* or *Verbatim_Interpolation_Format*, if any, of the corresponding *regular_interpolation* or *verbatim_interpolation*
+      - A right brace (`}`) character
+    - The characters of the *Interpolated_Regular_String_Mid* or *Interpolated_Verbatim_String_Mid* immediately following the corresponding interpolation, if any
+  - Finally the characters of the *Interpolated_Regular_String_End* or *Interpolated_Verbatim_String_End*.
+
+The subsequent arguments are the *expression*s from the interpolations, if any, in order.
+
+When an *interpolated_string_expression* contains multiple interpolations, the expressions in those interpolations are evaluated in textual order from the left to right.
+
+*Example*:
+
+This example uses the following format specification features:
+
+ - the `X` format specification which formats integers as uppercase hexadecimal,
+ - the default format for a `string` value is the value itself,
+ - positive alignment values that right-justify within the specified field width, and
+ - that `{{` and `}}` are formatted as `{` and `}` respectively.
+
+Given:
+
+```csharp
+string text = "red";
+int number = 14;
+```
+
+Then:
+
+| Interpolated String Expression       | Equivalent Meaning As `string`                                | Value        |
+| :----------------------------------- | :------------------------------------------------------------ | :----------- |
+| `$"{text}"`                          | `string.Format("{0}", text)`                                  | `"red"`      |
+| `$"{{text}}"`                        | `string.Format("{{text}})`                                    | `"{text}"`   |
+| `$"{ text , 4 }"`                    | `string.Format("{0,4}", text)`                                | `" red"`     |
+| `$"{number:X}"`                      | `string.Format("{0:X}", number)`                              | `"E"`        |
+| `$"{text + '?'} {number % 3}"`       | `string.Format("{0} {1}", text + '?', number % 3)`            | `"red? 2"`   |
+| `$"{text + $"[{number}]"}"`          | `string.Format("{0}", text + string.Format("[{0}]", number))` | `"red[14]"`  |
+| `$"{(number==0?"Zero":"Non-zero")}"` | `string.Format("{0}", (number==0?"Zero":"Non-zero"))`         | `"Non-zero"` |
+
+*end example*
 
 ### 12.7.3 Simple names
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -407,7 +407,7 @@ fragment Formatting_Character
 
 > *Note*:
 
-> 1. For information on the Unicode character classes mentioned above, see *The Unicode Standard*. *end note*
+> 1. For information on the Unicode character classes mentioned above, see *The Unicode Standard*.
 
 > 2. The fragment `Available_Identifier` requires the exclusion of keywords and contextual keywords. If the grammar in this Standard is processed with ANTLR then this exclusion is handled automatically by the semantics of ANTLR:
 >    - Keywords and contextual keywords occur in the grammar as literal strings.

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -294,7 +294,7 @@ token
 
 ### 7.4.2 Unicode character escape sequences
 
-A Unicode escape sequence represents a Unicode code point. Unicode escape sequences are processed in identifiers ([§7.4.3](lexical-structure.md#743-identifiers)), character literals ([§7.4.5.5](lexical-structure.md#7455-character-literals)), and regular string literals ([§7.4.5.6](lexical-structure.md#7456-string-literals)). A Unicode escape sequence is not processed in any other location (for example, to form an operator, punctuator, or keyword).
+A Unicode escape sequence represents a Unicode code point. Unicode escape sequences are processed in identifiers ([§7.4.3](lexical-structure.md#743-identifiers)), character literals ([§7.4.5.5](lexical-structure.md#7455-character-literals)), regular string literals ([§7.4.5.6](lexical-structure.md#7456-string-literals)), and interpolated regular string expressions (§interpolated-string-expressions). A Unicode escape sequence is not processed in any other location (for example, to form an operator, punctuator, or keyword).
 
 ```ANTLR
 fragment Unicode_Escape_Sequence

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -662,13 +662,11 @@ The meaning of the formats, as used in interpolated string expressions (§interp
 A *format* is a string that describes the appearance of an object when
 it is converted to a string. Either standard or custom formats can be used. A
 standard format takes the form *Axx*, where *A* is a single
-alphabetic character called the *format specifier*
-, and *xx* is an integer between zero and 99 inclusive, called the *precision specifier*. The format specifier controls the type
+alphabetic character called the *format specifier*, and *xx* is an integer between zero and 99 inclusive, called the *precision specifier*. The format specifier controls the type
 of formatting applied to the value being represented as a string. The
 *precision specifier* controls the number 
 of significant digits or decimal places in the string, if applicable. [*Note:* For the list of standard format specifiers, see the
-table below. Note that a given data type, such as `System.Int32`
-, might not support one
+table below. Note that a given data type, such as `System.Int32`, might not support one
 or more of the standard format specifiers.]
 
 [*Note:* When a format includes symbols that vary by culture, such as the currency
@@ -734,11 +732,11 @@ the value is negative, and is supplied by the <code>System.Globalization.NumberF
 <p>Exactly one non-zero decimal digit (<em>m</em>) precedes the decimal separator (‘.’), which
 is supplied by the <code>System.Globalization.NumberFormatInfo.NumberDecimalSeparator</code>
 property.</p>
-<p> The precision specifier determines the number of decimal places
+<p>The precision specifier determines the number of decimal places
 (<em>dddddd</em>) in the string. If the precision specifier
 is omitted, six decimal places are included in the
 string.</p>
-<p> The exponent
+<p>The exponent
 (<em>+/-xxx</em>) 
 consists of either a positive or negative number symbol followed by a
 minimum of three digits (<em>xxx</em>). The exponent is
@@ -757,11 +755,11 @@ form:</p>
 <p>At least one non-zero decimal digit (<em>m</em>) precedes the decimal separator (‘.’), which is
 supplied by the <code>System.Globalization.NumberFormatInfo.NumberDecimalSeparator</code>
 property.</p>
-<p> A
+<p>A
 negative number symbol sign (‘-’) precedes <em>m</em> only if the value is negative. This symbol is
 supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code>
 property.</p>
-<p> The precision specifier determines the number of decimal places
+<p>The precision specifier determines the number of decimal places
 (<em>dd...d</em>) in the string. If the precision specifier is omitted,
 <code>System.Globalization.NumberFormatInfo.NumberDecimalDigits</code> determines the number of decimal 
 places in the string. Results are rounded to the nearest representable
@@ -771,10 +769,10 @@ value when necessary.</p></td>
 <td><p><code>G</code></p>
 <p><code>g</code></p></td>
 <td><p><strong>General Format:</strong> The string is formatted in either fixed-point format (‘F’ or ‘f’) or scientific format (‘E’ or ‘e’).</p>
-<p> For integral types:</p>
-<p> Values are formatted using fixed-point format if
+<p>For integral types:</p>
+<p>Values are formatted using fixed-point format if
 <em>exponent</em> &lt; precision specifier, where <em>exponent </em> is the exponent of the value in scientific format. For all other values, scientific format is used.</p>
-<p> If the precision specifier is omitted, a default
+<p>If the precision specifier is omitted, a default
 precision equal to the field width required
 to display the
 maximum value for the data
@@ -787,8 +785,7 @@ follows:</p>
 <p>For Single, Decimal and Double
 types:</p>
 <p>Values are formatted using fixed-point format
-if <em>exponent</em>
-≥ -4 and <em>exponent</em> &lt; precision specifier, where <em>exponent</em> is
+if <em>exponent</em> ≥ -4 and <em>exponent</em> &lt; precision specifier, where <em>exponent</em> is
 the exponent of the value in scientific format. For all other values,
 scientific format is used. Results
 are rounded to the nearest representable value when necessary.</p>
@@ -813,10 +810,9 @@ prefixes the scientific format exponent.</li></ul></p></td>
 <p><code>n</code></p></td>
 <td><p><strong>Number Format:</strong> Used for strings in the following form:</p>
 <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-]<em>d,ddd,ddd.dd...d</em></p>
-<p> The representation of negative values is
+<p>The representation of negative values is
 determined by the <code>System.Globalization.NumberFormatInfo.NumberNegativePattern</code> property. If the pattern includes a negative number
-symbol (‘-’), this symbol is supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code>
-property.</p>
+symbol (‘-’), this symbol is supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code> property.</p>
 <p>At least one non-zero decimal digit (<em>d</em>) precedes
 the decimal separator (‘.’), which is supplied by the <code>System.Globalization.NumberFormatInfo.NumberDecimalSeparator</code> property. Digits between the decimal
 point and the most significant digit in the value are grouped using the
@@ -852,8 +848,7 @@ specified with <code>System.Double</code> or <code>System.Single</code>.) Used t
 representation of a floating-point value is such that parsing the string
 does not result in a loss of precision when compared to the original
 value. If the maximum precision of the data type (7 for <code>System.Single</code>, and 15 for
-<code>System.Double</code>) would result in a loss of precision, the precision 
-is increased by
+<code>System.Double</code>) would result in a loss of precision, the precision is increased by
 two decimal places. If a precision specifier is supplied with this format specifier,
 it is ignored. This format is otherwise identical to the fixed-point
 format.</td>
@@ -871,8 +866,7 @@ letters are used in the hexadecimal representation.</td>
 </tr>
 </table>
 
-If the numerical value is a `System.Single` or `System.Double` with a value of
-`NaN`,
+If the numerical value is a `System.Single` or `System.Double` with a value of `NaN`,
 `PositiveInfinity`, or `NegativeInfinity`, the format 
 specifier is ignored, and one of the following is returned: `System.Globalization.NumberFormatInfo.NaNSymbol`, `System.Globalization.NumberFormatInfo.PositiveInfinitySymbol`, or `System.Globalization.NumberFormatInfo.NegativeInfinitySymbol`.
 
@@ -973,7 +967,6 @@ exponent. The ‘E’, ‘E-’, ‘e’, or ‘e-’ formats indicate that a ne
 precedes negative exponents; no symbol is precedes positive exponents. The
 positive number symbol is supplied by the <code>System.Globalization.NumberFormatInfo.PositiveSign</code> property. The negative number symbol
 is supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code>
-
 property.</td>
 </tr>
 <tr>

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -187,6 +187,13 @@ namespace System
 
 namespace System
 {
+    public interface IFormattable
+    {
+    }
+}
+
+namespace System
+{
     public sealed class IndexOutOfRangeException : Exception
     {
         public IndexOutOfRangeException ();
@@ -377,7 +384,6 @@ namespace System
     {
         public int Length { get; }
         public char this [int index] { get; }
-        // See note below.
         public static string Format(string format, params object[] args);
     }
 }
@@ -533,10 +539,6 @@ namespace System.Threading
 }
 ```
 
-> *Note*: The `Format` method in the `String` class is not defined
-> in ISO/IEC 23271. It is included in this section as the `String`
-> class itself and other members shown *are* defined in ISO/IEC 23271.
-
 ## C.3 Standard Library Types not defined in ISO/IEC 23271
 
 The following types, including the members listed, must be defined in a conforming standard library. (These types might be defined in a future edition of ISO/IEC 23271.) It is expected that many of these types will have more members available than are listed.
@@ -637,14 +639,6 @@ namespace System.Runtime.CompilerServices
 
 namespace System
 {
-    public interface IFormattable
-    {
-    }
-}
-
-
-namespace System
-{
     public class FormattableString : IFormattable
     {
     }
@@ -658,3 +652,400 @@ namespace System.Runtime.CompilerServices
     }
 }
 ```
+
+## C.4 Format Specifications
+
+The meaning of the formats, as used in interpolated string expressions (§interpolated-string-expressions), are defined in ISO/IEC 23271:2012. For convenience the following text is copied from the description of `System.IFormatable`.
+
+**This text is informative.**
+
+A *format* is a string that describes the appearance of an object when
+it is converted to a string. Either standard or custom formats can be used. A
+standard format takes the form *Axx*, where *A* is a single
+alphabetic character called the *format specifier*
+, and *xx* is an integer between zero and 99 inclusive, called the *precision specifier*. The format specifier controls the type
+of formatting applied to the value being represented as a string. The
+*precision specifier* controls the number 
+of significant digits or decimal places in the string, if applicable. [*Note:* For the list of standard format specifiers, see the
+table below. Note that a given data type, such as `System.Int32`
+, might not support one
+or more of the standard format specifiers.]
+
+[*Note:* When a format includes symbols that vary by culture, such as the currency
+symbol included by the ‘C’ and ‘c’ formats, a formatting object supplies the
+actual characters used in the string representation. A method might include a
+parameter to pass a `System.IFormatProvider` object that supplies a
+formatting object, or the method might use the default formatting object, which
+contains the symbol definitions for the current culture. The current culture
+typically uses the same set of symbols used system-wide by default. In the Base
+Class Library, the formatting object for system-supplied numeric types is a
+`System.Globalization.NumberFormatInfo` instance. For `System.DateTime` instances, a 
+`System.Globalization.DateTimeFormatInfo` is
+used.]
+
+The following table describes the standard format specifiers and associated formatting
+object members that are used with numeric data types in the Base Class
+Library.
+
+<table>
+<tr>
+<th>Format Specifier</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><p><code>C</code></p>
+<p><code>c</code></p></td>
+<td><p><strong>Currency Format:</strong> Used for strings containing a monetary value. The <code>System.Globalization.NumberFormatInfo.CurrencySymbol</code>, <code>System.Globalization.NumberFormatInfo.CurrencyGroupSizes</code>, <code>System.Globalization.NumberFormatInfo.CurrencyGroupSeparator</code>, and <code>System.Globalization.NumberFormatInfo.CurrencyDecimalSeparator</code> members of a <code>System.Globalization.NumberFormatInfo</code>
+supply the currency symbol, size and separator for digit groupings, and
+decimal separator, respectively.</p>
+<p><code>System.Globalization.NumberFormatInfo.CurrencyNegativePattern</code> and <code>System.Globalization.NumberFormatInfo.CurrencyPositivePattern</code> determine the symbols used to represent negative
+and positive values. For example, a negative value can be prefixed with a
+minus sign, or enclosed in parentheses.</p>
+<p>If the precision specifier is omitted, <code>System.Globalization.NumberFormatInfo.CurrencyDecimalDigits</code> determines the number of decimal places in the
+string. Results are rounded to the nearest representable value when
+necessary.</p></td>
+</tr>
+<tr>
+<td><p><code>D</code></p>
+<p><code>d</code></p></td>
+<td><p><strong>Decimal Format:</strong> (This format is valid only
+when specified with integral data types.) Used for strings containing
+integer values. Negative numbers are prefixed with the negative number
+symbol specified by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code>
+property.</p>
+<p>The precision specifier determines the
+minimum number of digits that appear in the string. If the specified
+precision requires more digits than the value contains, the string is
+left-padded with zeros. If the precision specifier specifies fewer digits
+than are in the value, the precision specifier is
+ignored.</p></td>
+</tr>
+<tr>
+<td><p><code>E</code></p>
+<p><code>e</code></p></td>
+<td><p><strong>Scientific (Engineering) Format:</strong> Used for strings in
+one of the following forms:</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-]<em>m.dddddd</em>E<em>+xxx</em></p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-]<em>m.dddddd</em>E<em>-xxx</em></p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-]<em>m.dddddd</em>e<em>+xxx</em></p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-]<em>m.dddddd</em>e<em>-xxx</em></p>
+<p>The negative number symbol (‘-’) appears only if
+the value is negative, and is supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code> property.</p>
+<p>Exactly one non-zero decimal digit (<em>m</em>) precedes the decimal separator (‘.’), which
+is supplied by the <code>System.Globalization.NumberFormatInfo.NumberDecimalSeparator</code>
+property.</p>
+<p> The precision specifier determines the number of decimal places
+(<em>dddddd</em>) in the string. If the precision specifier
+is omitted, six decimal places are included in the
+string.</p>
+<p> The exponent
+(<em>+/-xxx</em>) 
+consists of either a positive or negative number symbol followed by a
+minimum of three digits (<em>xxx</em>). The exponent is
+left-padded with zeros, if necessary. The case of the format specifier
+(‘E’ or ‘e’) determines the case used for the exponent prefix (E or e) in
+the string. Results are rounded to the nearest representable value when
+necessary. The positive number symbol is supplied by the <code>System.Globalization.NumberFormatInfo.PositiveSign</code>
+property.</p></td>
+</tr>
+<tr>
+<td><p><code>F</code></p>
+<p><code>f</code></p></td>
+<td><p><strong>Fixed-Point Format:</strong> Used for strings in the following
+form:</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"[-]<em>m.dd...d</em>"</p>
+<p>At least one non-zero decimal digit (<em>m</em>) precedes the decimal separator (‘.’), which is
+supplied by the <code>System.Globalization.NumberFormatInfo.NumberDecimalSeparator</code>
+property.</p>
+<p> A
+negative number symbol sign (‘-’) precedes <em>m</em> only if the value is negative. This symbol is
+supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code>
+property.</p>
+<p> The precision specifier determines the number of decimal places
+(<em>dd...d</em>) in the string. If the precision specifier is omitted,
+<code>System.Globalization.NumberFormatInfo.NumberDecimalDigits</code> determines the number of decimal 
+places in the string. Results are rounded to the nearest representable
+value when necessary.</p></td>
+</tr>
+<tr>
+<td><p><code>G</code></p>
+<p><code>g</code></p></td>
+<td><p><strong>General Format:</strong> The string is formatted in either fixed-point format (‘F’ or ‘f’) or scientific format (‘E’ or ‘e’).</p>
+<p> For integral types:</p>
+<p> Values are formatted using fixed-point format if
+<em>exponent</em> &lt; precision specifier, where <em>exponent </em> is the exponent of the value in scientific format. For all other values, scientific format is used.</p>
+<p> If the precision specifier is omitted, a default
+precision equal to the field width required
+to display the
+maximum value for the data
+type is used, which results in the value being formatted in
+fixed-point format. The default precisions for integral types are as
+follows:</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<code>System.Int16</code>, <code>System.UInt16</code> : 5</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<code>System.Int32</code>, <code>System.UInt32</code> : 10</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<code>System.Int64</code>, <code>System.UInt64</code> : 19</p>
+<p>For Single, Decimal and Double
+types:</p>
+<p>Values are formatted using fixed-point format
+if <em>exponent</em>
+≥ -4 and <em>exponent</em> &lt; precision specifier, where <em>exponent</em> is
+the exponent of the value in scientific format. For all other values,
+scientific format is used. Results
+are rounded to the nearest representable value when necessary.</p>
+<p>If the precision specifier is omitted, the following default precisions are used:</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<code>System.Single</code> : 7</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<code>System.Double</code> : 15</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<code>System.Decimal</code> : 29</p>
+<p>For all types:</p>
+<ul><li>The
+number of digits that appear in the result (not including the exponent)
+will not exceed the value of the precision specifier; values are rounded
+as necessary.</li>
+<li>The
+decimal point and any trailing zeros after the decimal point are removed
+whenever possible.</li>
+<li>The
+case of the format specifier (‘G’ or ‘g’) determines whether ‘E’ or ‘e’
+prefixes the scientific format exponent.</li></ul></p></td>
+</tr>
+<tr>
+<td><p><code>N</code></p>
+<p><code>n</code></p></td>
+<td><p><strong>Number Format:</strong> Used for strings in the following form:</p>
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-]<em>d,ddd,ddd.dd...d</em></p>
+<p> The representation of negative values is
+determined by the <code>System.Globalization.NumberFormatInfo.NumberNegativePattern</code> property. If the pattern includes a negative number
+symbol (‘-’), this symbol is supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code>
+property.</p>
+<p>At least one non-zero decimal digit (<em>d</em>) precedes
+the decimal separator (‘.’), which is supplied by the <code>System.Globalization.NumberFormatInfo.NumberDecimalSeparator</code> property. Digits between the decimal
+point and the most significant digit in the value are grouped using the
+group size specified by the <code>System.Globalization.NumberFormatInfo.NumberGroupSizes</code> property. The group separator (‘,’)
+is inserted between each digit group, and is supplied by the <code>System.Globalization.NumberFormatInfo.NumberGroupSeparator</code>
+property.</p>
+<p>The precision specifier determines the number of
+decimal places (<em>dd...d</em>). If the precision specifier is omitted,
+<code>System.Globalization.NumberFormatInfo.NumberDecimalDigits</code> determines the number of decimal places in the
+string. Results are rounded to the nearest representable value when
+necessary.</p></td>
+</tr>
+<tr>
+<td><p><code>P</code></p>
+<p><code>p</code></p></td>
+<td><p><strong>Percent Format:</strong> Used for strings containing a
+percentage. The <code>System.Globalization.NumberFormatInfo.PercentSymbol</code>, <code>System.Globalization.NumberFormatInfo.PercentGroupSizes</code>, <code>System.Globalization.NumberFormatInfo.PercentGroupSeparator</code>, and <code>System.Globalization.NumberFormatInfo.PercentDecimalSeparator</code> members of a <code>System.Globalization.NumberFormatInfo</code>
+supply the percent symbol, size and separator for digit groupings, and
+decimal separator, respectively.</p>
+<p><code>System.Globalization.NumberFormatInfo.PercentNegativePattern</code> and <code>System.Globalization.NumberFormatInfo.PercentPositivePattern</code> determine the symbols used to represent negative
+and positive values. For example, a negative value can be prefixed with a
+minus sign, or enclosed in parentheses.</p>
+<p>If no precision is specified, the number of decimal places in the
+result is determined by <code>System.Globalization.NumberFormatInfo.PercentDecimalDigits</code>. Results are rounded to the nearest representable
+value when necessary.</p>
+<p>The result is scaled by 100 (.99 becomes 99%).</p></td>
+</tr>
+<tr>
+<td><p><code>R</code></p>
+<p><code>r</code></p></td>
+<td><strong>Round trip Format:</strong> (This format is valid only when
+specified with <code>System.Double</code> or <code>System.Single</code>.) Used to ensure that the precision of the string
+representation of a floating-point value is such that parsing the string
+does not result in a loss of precision when compared to the original
+value. If the maximum precision of the data type (7 for <code>System.Single</code>, and 15 for
+<code>System.Double</code>) would result in a loss of precision, the precision 
+is increased by
+two decimal places. If a precision specifier is supplied with this format specifier,
+it is ignored. This format is otherwise identical to the fixed-point
+format.</td>
+</tr>
+<tr>
+<td><p><code>X</code></p>
+<p><code>x</code></p></td>
+<td><strong>Hexadecimal Format:</strong> (This format is valid only when
+specified with integral data types.) Used for string representations of numbers in Base
+16. The precision determines the minimum number of digits in
+the string. If the precision specifies more digits than the number contains,
+the number is left-padded with zeros. The case of the format specifier
+(‘X’ or ‘x’) determines whether upper case or lower case
+letters are used in the hexadecimal representation.</td>
+</tr>
+</table>
+
+If the numerical value is a `System.Single` or `System.Double` with a value of
+`NaN`,
+`PositiveInfinity`, or `NegativeInfinity`, the format 
+specifier is ignored, and one of the following is returned: `System.Globalization.NumberFormatInfo.NaNSymbol`, `System.Globalization.NumberFormatInfo.PositiveInfinitySymbol`, or `System.Globalization.NumberFormatInfo.NegativeInfinitySymbol`.
+
+A custom format is any string specified as a format that
+is not in the form of a standard format string (Axx) described above. The
+following table describes the characters that are used in constructing custom
+formats.
+
+<table>
+<tr>
+<th>Format Specifier</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><code>0</code> (zero)</td>
+<td><p><strong>Zero placeholder:</strong>
+If
+the value being formatted has a digit in the position where a ‘0’ appears in the custom format, then that digit is copied to the output string;
+otherwise a zero is stored in that position in the output string. The
+position of the leftmost ‘0’ before the decimal separator and the
+rightmost ‘0’ after the decimal separator determine the range of digits
+that are always present in the output string.</p>
+<p>The number of Zero and/or Digit placeholders after
+the decimal separator determines the number of digits that appear after
+the decimal separator. Values are rounded as necessary.</p></td>
+</tr>
+<tr>
+<td><code>#</code></td>
+<td><p><strong>Digit placeholder:</strong>
+If the value being formatted has a digit in
+the position where a ‘#’ appears in the custom format, then that digit
+is copied to the output string; otherwise, nothing is stored in that
+position in the output string. Note that this specifier never stores the
+‘0’ character if it is not a significant digit, even if ‘0’ is the only
+digit in the string. (It does display the ‘0’ character in the output string
+if it is a significant digit.)</p>
+<p>The number of Zero and/or Digit
+placeholders after the decimal separator determines the number of digits that appear after the decimal
+separator. Values are rounded as necessary.</p></td>
+</tr>
+<tr>
+<td><code>.</code> (period)</td>
+<td><strong>Decimal separator:</strong>
+The left most ‘.’
+character in the format string determines the location of the
+decimal separator in the formatted value; any additional ‘.’ characters are
+ignored. The <code>System.Globalization.NumberFormatInfo.NumberDecimalSeparator</code> property determines
+the symbol used as the decimal
+separator.</td>
+</tr>
+<tr>
+<td><code>,</code> (comma)</td>
+<td><p><strong>Group separator and number scaling:</strong>
+The ‘,’ character serves two purposes. First,
+if the custom format contains this character between two Zero or Digit placeholders (0 or #)
+and to the left of the decimal separator if one is present,
+then the output will have group separators inserted between each group of digits
+to the left of the decimal separator. The <code>System.Globalization.NumberFormatInfo.NumberGroupSeparator</code>
+and <code>System.Globalization.NumberFormatInfo.NumberGroupSizes</code>
+properties determine the symbol used as the group separator and
+the number of digits in each group, respectively.</p>
+<p>If
+the format
+string contains one or more ‘,’ characters immediately to the left of
+the decimal separator, then the number will be scaled. The scale factor is
+determined by the number of group separator characters immediately to the
+left of the decimal separator. If there are x characters, then the value is
+divided by 1000<sup>X</sup> before it is formatted. For example, the format string ‘0,,’
+will divide a value by one million. Note that the presence of the ‘,’
+character to indicate scaling does not insert group separators in the
+output string. Thus, to scale a number by 1 million and insert group
+separators, use a custom format similar to "#,##0,,".</p></td>
+</tr>
+<tr>
+<td><code>%</code> (percent)</td>
+<td><strong>Percentage placeholder:</strong>
+The presence of a ‘%’ character
+in a custom format causes a number to be multiplied by 100
+before it is formatted. The percent symbol is inserted in the output string
+at the location where the ‘%’ appears in the format string. The <code>System.Globalization.NumberFormatInfo.PercentSymbol</code> property determines
+the percent
+symbol.</td>
+</tr>
+<tr>
+<td><p><code>E0</code></p>
+<p><code>E+0</code></p>
+<p><code>E-0</code></p>
+<p><code>e0</code></p>
+<p><code>e+0</code></p>
+<p><code>e-0</code></p></td>
+<td><strong>Engineering format:</strong> If any of the strings ‘E’, ‘E+’, ‘E-’, ‘e’, ‘e+’, or ‘e-’ are present
+in a custom format and is followed immediately by at least one ‘0’
+character, then the value is formatted using scientific notation. The number
+of ‘0’ characters following the exponent prefix (E or e) determines the
+minimum number of digits in the exponent. The ‘E+’ and ‘e+’ formats indicate
+that a positive or negative number symbol always precedes the
+exponent. The ‘E’, ‘E-’, ‘e’, or ‘e-’ formats indicate that a negative number symbol
+precedes negative exponents; no symbol is precedes positive exponents. The
+positive number symbol is supplied by the <code>System.Globalization.NumberFormatInfo.PositiveSign</code> property. The negative number symbol
+is supplied by the <code>System.Globalization.NumberFormatInfo.NegativeSign</code>
+
+property.</td>
+</tr>
+<tr>
+<td><code>\</code> (backslash)</td>
+<td><strong>Escape character:</strong> In some languages, such as C#, the
+backslash character causes the next character in the custom format to be interpreted
+as an escape sequence. It is used with C language
+formatting sequences, such as "\n" (newline). In some languages, the escape character
+itself is required to be preceded by an escape character
+when used as a literal. Otherwise, the compiler interprets the character as
+an escape sequence. This escape character is not required to be
+supported in all programming languages.</td>
+</tr>
+<tr>
+<td><p><code>'ABC'</code></p>
+<p><code>"ABC"</code></p></td>
+<td><strong>Literal string:</strong> Characters enclosed in single or double quotes are
+copied to the output string literally, and do not affect formatting.</td>
+</tr>
+<tr>
+<td><code>;</code> (semicolon)</td>
+<td><strong>Section separator:</strong> The ‘;’ character is used to separate sections for
+positive, negative, and zero numbers in the format string. (This feature
+is described in detail below.)</td>
+</tr>
+<tr>
+<td>Other</td>
+<td><strong>All other characters:</strong> All other characters are stored in the output
+string as literals in the position in which they
+appear.</td>
+</tr>
+</table>
+
+Note that for fixed-point format strings (strings not containing an ‘E0’,
+‘E+0’, ‘E-0’, ‘e0’, ‘e+0’, or ‘e-0’), numbers are rounded to as many decimal
+places as there are Zero or Digit placeholders to the right of the decimal
+separator. If the custom format does not contain a decimal separator, the number is
+rounded to the nearest integer. If the number has more digits than there are
+Zero or Digit placeholders to the left of the decimal separator, the extra
+digits are copied to the output string immediately before the first Zero or
+Digit placeholder.
+
+A custom format can contain
+up to three sections separated by section separator characters, to specify different formatting for
+positive, negative, and zero values. The sections are interpreted as follows:
+
+- **One section**: The
+custom format applies to all values (positive, negative and zero). Negative
+values include a negative sign.</term>
+
+- **Two sections**: The
+first section applies to positive values and zeros, and the second section
+applies to negative values. If the value to be formatted is negative, but
+becomes zero after rounding according to the format in the second section,
+then the resulting zero is formatted according to the first section. Negative
+values do not include a negative sign to allow full control over
+representations of negative values. For example, a negative can be represented
+in parenthesis using a custom format similar to "####.####;(####.####)".</term>
+
+- **Three sections**:
+The first section applies to positive values, the second section
+applies to negative values, and the third section applies to zeros. The
+second section can be empty (nothing appears between the semicolons), in which case the
+first section applies to all nonzero values, and negative values include a
+negative sign. If the number to be formatted is nonzero, but becomes zero
+after rounding according to the format in the first or second section, then
+the resulting zero is formatted according to the third section.</term>
+
+The `System.Enum` and `System.DateTime` types also support using format specifiers to
+format string representations of values. The meaning of a specific format specifier varies
+according to the kind of data (numeric, date/time, enumeration) being formatted. See
+`System.Enum` and `System.Globalization.DateTimeFormatInfo` for a comprehensive list of
+the format specifiers supported by each type.
+
+**End of informative text.**

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -665,21 +665,11 @@ standard format takes the form *Axx*, where *A* is a single
 alphabetic character called the *format specifier*, and *xx* is an integer between zero and 99 inclusive, called the *precision specifier*. The format specifier controls the type
 of formatting applied to the value being represented as a string. The
 *precision specifier* controls the number 
-of significant digits or decimal places in the string, if applicable. [*Note:* For the list of standard format specifiers, see the
-table below. Note that a given data type, such as `System.Int32`, might not support one
-or more of the standard format specifiers.]
+of significant digits or decimal places in the string, if applicable. 
 
-[*Note:* When a format includes symbols that vary by culture, such as the currency
-symbol included by the ‘C’ and ‘c’ formats, a formatting object supplies the
-actual characters used in the string representation. A method might include a
-parameter to pass a `System.IFormatProvider` object that supplies a
-formatting object, or the method might use the default formatting object, which
-contains the symbol definitions for the current culture. The current culture
-typically uses the same set of symbols used system-wide by default. In the Base
-Class Library, the formatting object for system-supplied numeric types is a
-`System.Globalization.NumberFormatInfo` instance. For `System.DateTime` instances, a 
-`System.Globalization.DateTimeFormatInfo` is
-used.]
+> *Note:* For the list of standard format specifiers, see the table below. Note that a given data type, such as `System.Int32`, might not support one or more of the standard format specifiers. *end note*
+
+> *Note:* When a format includes symbols that vary by culture, such as the currencysymbol included by the ‘C’ and ‘c’ formats, a formatting object supplies the actual characters used in the string representation. A method might include a parameter to pass a `System.IFormatProvider` object that supplies a formatting object, or the method might use the default formatting object, which contains the symbol definitions for the current culture. The current culture typically uses the same set of symbols used system-wide by default. In the Base Class Library, the formatting object for system-supplied numeric types is a `System.Globalization.NumberFormatInfo` instance. For `System.DateTime` instances, a `System.Globalization.DateTimeFormatInfo` is used. *end note*
 
 The following table describes the standard format specifiers and associated formatting
 object members that are used with numeric data types in the Base Class


### PR DESCRIPTION
…e a first draft.

Once the decision on how much of the ANLTR language we would use was made the grammar
was fairly straghtforward.

The prose describing the feature is more of a challenge as it is a language-level
surfacing of features of the Standard Library, and those features are either defined
in another Standard or not defined in any Standard but which we pretend are…

So the challenge is how much of the semantics should be included somewhere in this
Standard: what is a `FormattableString` vs. a `string` for the result type of an
*interpolated_string_expression*; what is the field width, what is the format, etc.?

This draft punts on some of these (e.g. the first one), includes details (e.g. for the the second
one), and even a new *informative* appendix, §C.4 (for the third one).

Is this balance right?

Well that depends on how we view our aim here…