### PR TITLE
Add create permissions for this action

### DIFF
--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -16,6 +16,9 @@ on:
 jobs:
   create-pull-request-for-sections-and-grammar:
     runs-on: ubuntu-18.04
+    permissions:
+      contents: write
+      pull-requests: write    
     env:
       DOTNET_NOLOGO: true
 


### PR DESCRIPTION
This action creates a new branch and opens a PR to merge that branch into the current default.

The default `permissions` for GitHub actions are `read` for the repo contents. This adds `write` for contents, and `write` for pull requests to push the branch and create a new PR.