### PR TITLE
update all tools to .NET 6

### DIFF
--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -21,10 +21,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Run section renumbering dry run
       run: |

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -26,10 +26,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Set up JDK 15
       uses: actions/setup-java@v1

--- a/.github/workflows/word-converter.yaml
+++ b/.github/workflows/word-converter.yaml
@@ -21,10 +21,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Run converter
       run: |

--- a/tools/GetGrammar/GetGrammar.csproj
+++ b/tools/GetGrammar/GetGrammar.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tools/MarkdownConverter/MarkdownConverter.csproj
+++ b/tools/MarkdownConverter/MarkdownConverter.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="csharp2colorized" Version="1.0.3" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
-    <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Formatting" Version="3.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.1.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.15.0" />
+    <PackageReference Include="FSharp.Core" Version="6.0.1" />
+    <PackageReference Include="FSharp.Formatting" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tools/StandardAnchorTags/StandardAnchorTags.csproj
+++ b/tools/StandardAnchorTags/StandardAnchorTags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
.NET 5 is non-LTS, so it will lose support soon. So, move to .NET 6 while we have time.

I updated most of the dependencies. The F# Formatter has breaking changes starting in version 5, so I kept it to version 4. In a separate PR, while looking at the code to understand it, I'll consider tackling those changes.