### PR TITLE
tools: Handle format strings tables in Word converter

### DIFF
--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -672,6 +672,7 @@ The following table describes the standard format specifiers and associated form
 object members that are used with numeric data types in the Base Class
 Library.
 
+<!-- Custom Word conversion: format_strings_1 -->
 <table>
 <tr>
 <th>Format Specifier</th>
@@ -862,6 +863,7 @@ is not in the form of a standard format string (Axx) described above. The
 following table describes the characters that are used in constructing custom
 formats.
 
+<!-- Custom Word conversion: format_strings_2 -->
 <table>
 <tr>
 <th>Format Specifier</th>

--- a/tools/MarkdownConverter/Converter/MarkdownSourceConverter.cs
+++ b/tools/MarkdownConverter/Converter/MarkdownSourceConverter.cs
@@ -899,6 +899,8 @@ namespace MarkdownConverter.Converter
             "addition" => TableHelpers.CreateAdditionTable(),
             "subtraction" => TableHelpers.CreateSubtractionTable(),
             "function_members" => TableHelpers.CreateFunctionMembersTable(block.code),
+            "format_strings_1" => new[] { new Paragraph(new Run(new Text("FIXME: Replace with first format strings table"))) },
+            "format_strings_2" => new[] { new Paragraph(new Run(new Text("FIXME: Replace with second format strings table"))) },
             _ => HandleInvalidCustomBlock(customBlockId)
         };
 


### PR DESCRIPTION
The current plan is for Rex to copy/paste the tables from the
ECMA-335 documents (where they originated) into the Word document
before submission to ECMA. We may be able to do something better
later, but this is enough to unblock the converter for now.