### PR TITLE
tools: Unescape backslashes in Markdown text

### DIFF
--- a/tools/MarkdownConverter/Spec/MarkdownUtilities.cs
+++ b/tools/MarkdownConverter/Spec/MarkdownUtilities.cs
@@ -1,15 +1,16 @@
 ﻿using FSharp.Markdown;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MarkdownConverter.Spec
 {
     internal static class MarkdownUtilities
     {
         internal static string UnescapeLiteral(MarkdownSpan.Literal literal) =>
-            literal.text.Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">").Replace("&reg;", "®");
+            literal.text
+                .Replace("&amp;", "&")
+                .Replace("&lt;", "<")
+                .Replace("&gt;", ">")
+                .Replace("&reg;", "®")
+                .Replace("\\<", "<")
+                .Replace("\\>", ">");
     }
 }


### PR DESCRIPTION
These were used in the titles for XML doc sections.

Fixes #397