### PR TITLE
Remove unnecessary heading

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1336,8 +1336,6 @@ Then:
 
 ### 11.7.4 Simple names
 
-#### 11.7.4.1 General
-
 A *simple_name* consists of an identifier, optionally followed by a type argument list:
 
 ```ANTLR


### PR DESCRIPTION
***Simple Names*** has only one child heading: General. 

I think that child heading can be removed.