### PR TITLE
update FP ref, drop 10646

### DIFF
--- a/standard/normative-references.md
+++ b/standard/normative-references.md
@@ -8,8 +8,6 @@ ISO 80000-2, *Quantities and units --- Part 2: Mathematical signs and symbols to
 
 ISO/IEC 2382, *Information technology --- Vocabulary*.
 
-ISO/IEC 10646 (all parts), *Information technology --- Universal Multiple-Octet Coded Character Set (UCS)*.
-
-ISO/IEC/IEEE 60559:2011, *Information technology -- Microprocessor Systems -- Floating-Point arithmetic*
+ISO/IEC 60559:2020, *Information technology -- Microprocessor Systems -- Floating-Point arithmetic*
 
 The Unicode Consortium. The Unicode Standard, https://www.unicode.org/standard/standard.html


### PR DESCRIPTION
Closes Issue #426.

Note that "IEEE" is no longer part of the official title. (IEEE has its own equivalent standard.)