### PR TITLE
Finalizers aren't required

### DIFF
--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -781,7 +781,7 @@ C# employs automatic memory management, which frees developers from manually all
 
 The garbage collector maintains information about object usage, and uses this information to make memory management decisions, such as where in memory to locate a newly created object, when to relocate an object, and when an object is no longer in use or inaccessible.
 
-Like other languages that assume the existence of a garbage collector, C# is designed so that the garbage collector might implement a wide range of memory management policies. C# requires that finalizers be run at some time between the time an object is eligible and the time that the application exits, but specifies neither a time constraint within that span, nor an order in which finalizers are run.
+Like other languages that assume the existence of a garbage collector, C# is designed so that the garbage collector might implement a wide range of memory management policies. C# specifies neither a time constraint within that span, nor an order in which finalizers are run. Whether or not finalizers are run as part of application termination is implementation-specific (§7.2).
 
 The behavior of the garbage collector can be controlled, to some degree, via static methods on the class `System.GC`. This class can be used to request a collection to occur, finalizers to be run (or not run), and so forth.
 


### PR DESCRIPTION
Fixes dotnet/docs#28397

We'd agreed to the principle of this change, and changed 7.2 earlier. This text still had the requirements that finalizers must run before application exit.