### PR TITLE
format annex D

### DIFF
--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -35,13 +35,15 @@ In a *Delimited_Doc_Comment*, if the first non-*Whitespace* character on the sec
 **Example:**
 
 ```csharp
-/// <summary>Class <c>Point</c> models a point in a two-dimensional
-/// plane.</summary>
-///
+/// <summary>
+/// Class <c>Point</c> models a point in a two-dimensional plane.
+/// </summary>
 public class Point
 {
-   /// <summary>method <c>draw</c> renders the point.</summary>
-   void draw() {...}
+    /// <summary>
+    /// method <c>draw</c> renders the point.
+    /// </summary>
+    void draw() {...}
 }
 ```
 
@@ -96,12 +98,12 @@ This tag provides a mechanism to indicate that a fragment of text within a descr
 **Example:**
 
 ```csharp
-/// <summary>Class <c>Point</c> models a point in a two-dimensional
-/// plane.</summary>
-
+/// <summary>
+/// Class <c>Point</c> models a point in a two-dimensional plane.
+/// </summary>
 public class Point
 {
-   // ...
+    // ...
 }
 ```
 
@@ -116,9 +118,10 @@ This tag is used to set one or more lines of source code or program output in so
 **Example:**
 
 ```csharp
-/// <summary>This method changes the point's location by
-/// the given x- and y-offsets.
-/// <example>For example:
+/// <summary>
+/// This method changes the point's location by the given x- and y-offsets.
+/// <example>
+/// For example:
 /// <code>
 /// Point p = new Point(3,5);
 /// p.Translate(-1,3);
@@ -126,10 +129,10 @@ This tag is used to set one or more lines of source code or program output in so
 /// results in <c>p</c>'s having the value (2,8).
 /// </example>
 /// </summary>
-
-public void Translate(int xor, int yor) {
-   X += xor;
-   Y += yor;
+public void Translate(int xor, int yor)
+{
+    X += xor;
+    Y += yor;
 }
 ```
 
@@ -163,15 +166,16 @@ where
 ```csharp
 public class DataBaseOperations
 {
-   /// <exception cref="MasterFileFormatCorruptException"></exception>
-   /// <exception cref="MasterFileLockedOpenException"></exception>
-   public static void ReadRecord(int flag) {
-      if (flag == 1)
-         throw new MasterFileFormatCorruptException();
-      else if (flag == 2)
-         throw new MasterFileLockedOpenException();
-      // ...
-   }
+    /// <exception cref="MasterFileFormatCorruptException"></exception>
+    /// <exception cref="MasterFileLockedOpenException"></exception>
+    public static void ReadRecord(int flag)
+    {
+        if (flag == 1)
+            throw new MasterFileFormatCorruptException();
+        else if (flag == 2)
+            throw new MasterFileLockedOpenException();
+         // ...
+    }
 }
 ```
 
@@ -202,16 +206,16 @@ and the external file “docs.xml” had the following contents:
 ```xml
 <?xml version="1.0"?>
 <extradoc>
-   <class name="IntList">
-      <summary>
-         Contains a list of integers.
-      </summary>
-   </class>
-   <class name="StringList">
-      <summary>
-         Contains a list of integers.
-      </summary>
-   </class>
+    <class name="IntList">
+        <summary>
+            Contains a list of integers.
+        </summary>
+    </class>
+    <class name="StringList">
+        <summary>
+            Contains a list of integers.
+        </summary>
+    </class>
 </extradoc>
 ```
 
@@ -234,19 +238,19 @@ Each item in the list is specified with an `<item>` block. When creating a defin
 
 ```xml
 <list type="bullet" | "number" | "table">
-   <listheader>
-      <term>term</term>
-      <description>description</description>
-   </listheader>
-   <item>
-      <term>term</term>
-      <description>description</description>
-   </item>
-   ...
-   <item>
-      <term>term</term>
-      <description>description</description>
-   </item>
+    <listheader>
+        <term>term</term>
+        <description>description</description>
+    </listheader>
+    <item>
+        <term>term</term>
+        <description>description</description>
+    </item>
+    ...
+    <item>
+        <term>term</term>
+        <description>description</description>
+    </item>
 </list>
 ```
 
@@ -260,19 +264,20 @@ where
 ```csharp
 public class MyClass
 {
-   /// <summary>Here is an example of a bulleted list:
-   /// <list type="bullet">
-   /// <item>
-   /// <description>Item 1.</description>
-   /// </item>
-   /// <item>
-   /// <description>Item 2.</description>
-   /// </item>
-   /// </list>
-   /// </summary>
-   public static void Main () {
-      // ...
-   }
+    /// <summary>Here is an example of a bulleted list:
+    /// <list type="bullet">
+    /// <item>
+    /// <description>Item 1.</description>
+    /// </item>
+    /// <item>
+    /// <description>Item 2.</description>
+    /// </item>
+    /// </list>
+    /// </summary>
+    public static void Main()
+    {
+        // ...
+    }
 }
 ```
 
@@ -292,11 +297,15 @@ where
 
 ```csharp
 /// <summary>This is the entry point of the Point class testing program.
-/// <para>This program tests each method and operator, and
+/// <para>
+/// This program tests each method and operator, and
 /// is intended to be run after any non-trvial maintenance has
-/// been performed on the Point class.</para></summary>
-public static void Main() {
-   // ...
+/// been performed on the Point class.
+/// </para>
+/// </summary>
+public static void Main() 
+{
+    // ...
 }
 ```
 
@@ -316,13 +325,16 @@ where
 **Example:**
 
 ```csharp
-/// <summary>This method changes the point's location to
-/// the given coordinates.</summary>
+/// <summary>
+/// This method changes the point's location to
+/// the given coordinates.
+/// </summary>
 /// <param name="xor">the new x-coordinate.</param>
 /// <param name="yor">the new y-coordinate.</param>
-public void Move(int xor, int yor) {
-   X = xor;
-   Y = yor;
+public void Move(int xor, int yor)
+{
+    X = xor;
+    Y = yor;
 }
 ```
 
@@ -342,13 +354,14 @@ where
 
 ```csharp
 /// <summary>This constructor initializes the new Point to
-/// (<paramref name="xor"/>,<paramref name="yor"/>).</summary>
+/// (<paramref name="xor"/>,<paramref name="yor"/>).
+/// </summary>
 /// <param name="xor">the new Point's x-coordinate.</param>
 /// <param name="yor">the new Point's y-coordinate.</param>
-
-public Point(int xor, int yor) {
-   X = xor;
-   Y = yor;
+public Point(int xor, int yor)
+{
+    X = xor;
+    Y = yor;
 }
 ```
 
@@ -368,10 +381,13 @@ where
 **Example:**
 
 ```csharp
-/// <permission cref="System.Security.PermissionSet">Everyone can
-/// access this method.</permission>
-public static void Test() {
-   // ...
+/// <permission cref="System.Security.PermissionSet">
+/// Everyone can
+/// access this method.
+/// </permission>
+public static void Test()
+{
+    // ...
 }
 ```
 
@@ -390,12 +406,16 @@ where
 **Example:**
 
 ```csharp
-/// <summary>Class <c>Point</c> models a point in a
-/// two-dimensional plane.</summary>
-/// <remarks>Uses polar coordinates</remarks>
+/// <summary>
+/// Class <c>Point</c> models a point in a
+/// two-dimensional plane.
+/// </summary>
+/// <remarks>
+/// Uses polar coordinates
+/// </remarks>
 public class Point
 {
-   // ...
+    // ...
 }
 ```
 
@@ -414,10 +434,15 @@ where
 **Example:**
 
 ```csharp
-/// <summary>Report a point's location as a string.</summary>
-/// <returns>A string representing a point's location, in the form (x,y),
-/// without any leading, trailing, or embedded whitespace.</returns>
-public override string ToString() {
+/// <summary>
+/// Report a point's location as a string.
+/// </summary>
+/// <returns>
+/// A string representing a point's location, in the form (x,y),
+/// without any leading, trailing, or embedded whitespace.
+/// </returns>
+public override string ToString()
+{
    return "(" + X + "," + Y + ")";
 }
 ```
@@ -439,18 +464,22 @@ where
 **Example:**
 
 ```csharp
-/// <summary>This method changes the point's location to
-/// the given coordinates. <see cref="Translate"/></summary>
-public void Move(int xor, int yor) {
-   X = xor;
-   Y = yor;
+/// <summary>
+/// This method changes the point's location to
+/// the given coordinates. <see cref="Translate"/>
+/// </summary>
+public void Move(int xor, int yor)
+{
+    X = xor;
+    Y = yor;
 }
 /// <summary>This method changes the point's location by
 /// the given x- and y-offsets. <see cref="Move"/>
 /// </summary>
-public void Translate(int xor, int yor) {
-   X += xor;
-   Y += yor;
+public void Translate(int xor, int yor)
+{
+    X += xor;
+    Y += yor;
 }
 ```
 
@@ -470,12 +499,14 @@ where
 **Example:**
 
 ```csharp
-/// <summary>This method determines whether two Points have the same
-/// location.</summary>
+/// <summary>
+/// This method determines whether two Points have the same location.
+/// </summary>
 /// <seealso cref="operator=="/>
 /// <seealso cref="operator!="/>
-public override bool Equals(object o) {
-   // ...
+public override bool Equals(object o)
+{
+    // ...
 }
 ```
 
@@ -495,7 +526,8 @@ where
 
 ```csharp
 /// <summary>This constructor initializes the new Point to (0,0).</summary>
-public Point() : this(0,0) {
+public Point() : this(0,0)
+{
 }
 ```
 
@@ -517,7 +549,8 @@ where
 ```csharp
 /// <summary>A generic list class.</summary>
 /// <typeparam name="T">The type stored by the list.</typeparam>
-public class MyList<T> {
+public class MyList<T>
+{
 ...
 }
 ```
@@ -539,7 +572,8 @@ where
 ```csharp
 /// <summary>This method fetches data and returns a list of <typeparamref name="T"> "/>"> .</summary>
 /// <param name="string">query to execute</param>
-public List<T> FetchData<T>(string query) {
+public List<T> FetchData<T>(string query)
+{
 ...
 }
 ```
@@ -562,8 +596,8 @@ where
 /// <value>Property <c>X</c> represents the point's x-coordinate.</value>
 public int X
 {
-   get { return x; }
-   set { x = value; }
+    get { return x; }
+    set { x = value; }
 }
 ```
 
@@ -616,19 +650,22 @@ enum Color { Red, Blue, Green }
 
 namespace Acme
 {
-   interface IProcess { ... }
-   struct ValueType { ... }
-   class Widget: IProcess
-   {
-      public class NestedClass { ... }
-      public interface IMenuItem { ... }
-      public delegate void Del(int i);
-      public enum Direction { North, South, East, West }
-   }
-   class MyList<T>
-   {
-      class Helper<U,V>{ ... }
-   }
+    interface IProcess { ... }
+
+    struct ValueType { ... }
+
+    class Widget: IProcess
+    {
+        public class NestedClass { ... }
+        public interface IMenuItem { ... }
+        public delegate void Del(int i);
+        public enum Direction { North, South, East, West }
+    }
+
+    class MyList<T>
+    {
+        class Helper<U,V>{ ... }
+    }
 }
 
 "T:Color"
@@ -648,25 +685,27 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-   struct ValueType
-   {
-      private int total;
-   }
-   class Widget: IProcess
-   {
-      public class NestedClass
-      {
-         private int value;
-      }
-      private string message;
-      private static Color defaultColor;
-      private const double PI = 3.14159;
-      protected readonly double monthlyAverage;
-      private long[] array1;
-      private Widget[,] array2;
-      private unsafe int *pCount;
-      private unsafe float **ppValues;
-   }
+    struct ValueType
+    {
+        private int total;
+    }
+
+    class Widget: IProcess
+    {
+        public class NestedClass
+        {
+            private int value;
+        }
+
+        private string message;
+        private static Color defaultColor;
+        private const double PI = 3.14159;
+        protected readonly double monthlyAverage;
+        private long[] array1;
+        private Widget[,] array2;
+        private unsafe int *pCount;
+        private unsafe float **ppValues;
+    }
 }
 
 "F:Acme.ValueType.total"
@@ -686,12 +725,12 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-   class Widget: IProcess
-   {
-      static Widget() { ... }
-      public Widget() { ... }
-      public Widget(string s) { ... }
-   }
+    class Widget: IProcess
+    {
+        static Widget() { ... }
+        public Widget() { ... }
+        public Widget(string s) { ... }
+    }
 }
 
 "M:Acme.Widget.#cctor"
@@ -704,10 +743,10 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-   class Widget: IProcess
-   {
-      ~Widget() { ... }
-   }
+    class Widget: IProcess
+    {
+        ~Widget() { ... }
+    }
 }
 
 "M:Acme.Widget.Finalize"
@@ -718,32 +757,37 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-   struct ValueType
-   {
-      public void M(int i) { ... }
-   }
-   class Widget: IProcess
-   {
-      public class NestedClass
-      {
-         public void M(int i) { ... }
-      }
-      public static void M0() { ... }
-      public void M1(char c, out float f, ref ValueType v) { ... }
-      public void M2(short[] x1, int[,] x2, long[][] x3) { ... }
-      public void M3(long[][] x3, Widget[][,,] x4) { ... }
-      public unsafe void M4(char *pc, Color **pf) { ... }
-      public unsafe void M5(void *pv, double *[][,] pd) { ... }
-      public void M6(int i, params object[] args) { ... }
-   }
-   class MyList<T>
-   {
-      public void Test(T t) { ... }
-   }
-   class UseList
-   {
-      public void Process(MyList<int> list) { ... }
-      public MyList<T> GetValues<T>(T value) { ... } }
+    struct ValueType
+    {
+        public void M(int i) { ... }
+    }
+
+    class Widget: IProcess
+    {
+        public class NestedClass
+        {
+            public void M(int i) { ... }
+        }
+
+        public static void M0() { ... }
+        public void M1(char c, out float f, ref ValueType v) { ... }
+        public void M2(short[] x1, int[,] x2, long[][] x3) { ... }
+        public void M3(long[][] x3, Widget[][,,] x4) { ... }
+        public unsafe void M4(char *pc, Color **pf) { ... }
+        public unsafe void M5(void *pv, double *[][,] pd) { ... }
+        public void M6(int i, params object[] args) { ... }
+    }
+
+    class MyList<T>
+    {
+        public void Test(T t) { ... }
+    }
+
+    class UseList
+    {
+        public void Process(MyList<int> list) { ... }
+        public MyList<T> GetValues<T>(T value) { ... } 
+    }
 }
 
 "M:Acme.ValueType.M(System.Int32)"
@@ -765,12 +809,12 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-   class Widget: IProcess
-   {
-      public int Width {get { ... } set { ... }}
-      public int this[int i] {get { ... } set { ... }}
-      public int this[string s, int i] {get { ... } set { ... }}
-   }
+    class Widget: IProcess
+    {
+        public int Width { get { ... } set { ... } }
+        public int this[int i] { get { ... } set { ... } }
+        public int this[string s, int i] { get { ... } set { ... } }
+    }
 }
 
 "P:Acme.Widget.Width"
@@ -783,10 +827,10 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-   class Widget: IProcess
-   {
-      public event Del AnEvent;
-   }
+    class Widget: IProcess
+    {
+        public event Del AnEvent;
+    }
 }
 
 "E:Acme.Widget.AnEvent"
@@ -797,10 +841,10 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-   class Widget: IProcess
-   {
-      public static Widget operator+(Widget x) { ... }
-   }
+    class Widget: IProcess
+    {
+        public static Widget operator+(Widget x) { ... }
+    }
 }
 
 "M:Acme.Widget.op_UnaryPlus(Acme.Widget)"
@@ -813,10 +857,10 @@ The complete set of unary operator function names used is as follows: `op_UnaryP
 ```csharp
 namespace Acme
 {
-   class Widget: IProcess
-   {
-      public static Widget operator+(Widget x1, Widget x2) { ... }
-   }
+    class Widget: IProcess
+    {
+        public static Widget operator+(Widget x1, Widget x2) { ... }
+    }
 }
 
 "M:Acme.Widget.op_Addition(Acme.Widget,Acme.Widget)"
@@ -829,11 +873,11 @@ The complete set of binary operator function names used is as follows: `op_Addit
 ```csharp
 namespace Acme
 {
-   class Widget: IProcess
-   {
-      public static explicit operator int(Widget x) { ... }
-      public static implicit operator long(Widget x) { ... }
-   }
+    class Widget: IProcess
+    {
+        public static explicit operator int(Widget x) { ... }
+        public static implicit operator long(Widget x) { ... }
+    }
 }
 
 "M:Acme.Widget.op_Explicit(Acme.Widget)~System.Int32"
@@ -849,130 +893,163 @@ The following example shows the source code of a Point class:
 ```csharp
 namespace Graphics
 {
-   /// <summary>Class <c>Point</c> models a point in a two-dimensional plane.
-   /// </summary>
-   public class Point
-   {
-      /// <summary>Instance variable <c>x</c> represents the point's
-      /// x-coordinate.</summary>
-      private int x;
-
-      /// <summary>Instance variable <c>y</c> represents the point's
-      /// y-coordinate.</summary>
-      private int y;
-
-      /// <value>Property <c>X</c> represents the point's x-coordinate.</value>
-      public int X
-      {
-         get { return x; }
-         set { x = value; }
-      }
-      
-      /// <value>Property <c>Y</c> represents the point's y-coordinate.</value>
-      public int Y
-      {
-         get { return y; }
-         set { y = value; }
-      }
-
-      /// <summary>This constructor initializes the new Point to
-      /// (0,0).</summary>
-      public Point() : this(0,0) {}
-
-      /// <summary>This constructor initializes the new Point to
-      /// (<paramref name="xor"/>,<paramref name="yor"/>).</summary>
-      /// <param><c>xor</c> is the new Point's x-coordinate.</param>
-      /// <param><c>yor</c> is the new Point's y-coordinate.</param>
-      public Point(int xor, int yor) {
-         X = xor;
-         Y = yor;
-      }
-
-      /// <summary>This method changes the point's location to
-      /// the given coordinates. <see cref="Translate"/></summary>
-      /// <param><c>xor</c> is the new x-coordinate.</param>
-      /// <param><c>yor</c> is the new y-coordinate.</param>
-      public void Move(int xor, int yor) {
-         X = xor;
-         Y = yor;
-      }
-
-      /// <summary>This method changes the point's location by
-      /// the given x- and y-offsets.
-      /// <example>For example:
-      /// <code>
-      /// Point p = new Point(3,5);
-      /// p.Translate(-1,3);
-      /// </code>
-      /// results in <c>p</c>'s having the value (2,8).
-      /// <see cref="Move"/></example>
-      /// </summary>
-      /// <param><c>xor</c> is the relative x-offset.</param>
-      /// <param><c>yor</c> is the relative y-offset.</param>
-      public void Translate(int xor, int yor) {
-         X += xor;
-         Y += yor;
-      }
-
-      /// <summary>This method determines whether two Points have the same
-      /// location.</summary>
-      /// <param><c>o</c> is the object to be compared to the current object.
-      /// </param>
-      /// <returns>True if the Points have the same location and they have
-      /// the exact same type; otherwise, false.</returns>
-      /// <seealso cref="operator=="/>
-      /// <seealso cref="operator!="/>
-      public override bool Equals(object o) {
-         if (o == null) {
+    /// <summary>
+    /// Class <c>Point</c> models a point in a two-dimensional plane.
+    /// </summary>
+    public class Point
+    {
+        /// <summary>
+        /// Instance variable <c>x</c> represents the point's x-coordinate.
+        /// </summary>
+        private int x;
+        
+        /// <summary>
+        /// Instance variable <c>y</c> represents the point's y-coordinate.
+        /// </summary>
+        private int y;
+        
+        /// <value>
+        /// Property <c>X</c> represents the point's x-coordinate.
+        /// </value>
+        public int X
+        {
+            get { return x; }
+            set { x = value; }
+        }
+        
+        /// <value>
+        /// Property <c>Y</c> represents the point's y-coordinate.
+        /// </value>
+        public int Y
+        {
+            get { return y; }
+            set { y = value; }
+        }
+        
+        /// <summary>
+        /// This constructor initializes the new Point to (0,0).
+        /// </summary>
+        public Point() : this(0,0) {}
+        
+        /// <summary>
+        /// This constructor initializes the new Point to
+        /// (<paramref name="xor"/>,<paramref name="yor"/>).
+        /// </summary>
+        /// <param><c>xor</c> is the new Point's x-coordinate.</param>
+        /// <param><c>yor</c> is the new Point's y-coordinate.</param>
+        public Point(int xor, int yor) 
+        {
+            X = xor;
+            Y = yor;
+        }
+        
+        /// <summary>
+        /// This method changes the point's location to
+        /// the given coordinates. <see cref="Translate"/>
+        /// </summary>
+        /// <param><c>xor</c> is the new x-coordinate.</param>
+        /// <param><c>yor</c> is the new y-coordinate.</param>
+        public void Move(int xor, int yor) 
+        {
+            X = xor;
+            Y = yor;
+        }
+        
+        /// <summary>
+        /// This method changes the point's location by
+        /// the given x- and y-offsets.
+        /// <example>For example:
+        /// <code>
+        /// Point p = new Point(3,5);
+        /// p.Translate(-1,3);
+        /// </code>
+        /// results in <c>p</c>'s having the value (2,8).
+        /// <see cref="Move"/>
+        /// </example>
+        /// </summary>
+        /// <param><c>xor</c> is the relative x-offset.</param>
+        /// <param><c>yor</c> is the relative y-offset.</param>
+        public void Translate(int xor, int yor)
+        {
+            X += xor;
+            Y += yor;
+        }
+        
+        /// <summary>
+        /// This method determines whether two Points have the same location.
+        /// </summary>
+        /// <param>
+        /// <c>o</c> is the object to be compared to the current object.
+        /// </param>
+        /// <returns>
+        /// True if the Points have the same location and they have
+        /// the exact same type; otherwise, false.
+        /// </returns>
+        /// <seealso cref="operator=="/>
+        /// <seealso cref="operator!="/>
+        public override bool Equals(object o)
+        {
+            if (o == null)
+            {
+                return false;
+            }
+            if (this == o) 
+            {
+                return true;
+            }
+            if (GetType() == o.GetType()) 
+            {
+                Point p = (Point)o;
+                return (X == p.X) && (Y == p.Y);
+            }
             return false;
-         }
-         if (this == o) {
-            return true;
-         }
-         if (GetType() == o.GetType()) {
-            Point p = (Point)o;
-            return (X == p.X) && (Y == p.Y);
-         }
-         return false;
-      }
-
-      /// <summary>Report a point's location as a string.</summary>
-      /// <returns>A string representing a point's location, in the form (x,y),
-      /// without any leading, training, or embedded whitespace.</returns>
-      public override string ToString() {
-         return "(" + X + "," + Y + ")";
-      }
-
-      /// <summary>This operator determines whether two Points have the same
-      /// location.</summary>
-      /// <param><c>p1</c> is the first Point to be compared.</param>
-      /// <param><c>p2</c> is the second Point to be compared.</param>
-      /// <returns>True if the Points have the same location and they have
-      /// the exact same type; otherwise, false.</returns>
-      /// <seealso cref="Equals"/>
-      /// <seealso cref="operator!="/>
-      public static bool operator==(Point p1, Point p2) {
-         if ((object)p1 == null || (object)p2 == null) {
+        }
+        
+        /// <summary>Report a point's location as a string.</summary>
+        /// <returns>
+        /// A string representing a point's location, in the form (x,y),
+        /// without any leading, training, or embedded whitespace.
+        /// </returns>
+        public override string ToString() => 
+            "(" + X + "," + Y + ")";
+        
+        /// <summary>
+        /// This operator determines whether two Points have the same location.
+        /// </summary>
+        /// <param><c>p1</c> is the first Point to be compared.</param>
+        /// <param><c>p2</c> is the second Point to be compared.</param>
+        /// <returns>
+        /// True if the Points have the same location and they have
+        /// the exact same type; otherwise, false.
+        /// </returns>
+        /// <seealso cref="Equals"/>
+        /// <seealso cref="operator!="/>
+        public static bool operator==(Point p1, Point p2)
+        {
+            if ((object)p1 == null || (object)p2 == null)
+            {
+                return false;
+            }
+            if (p1.GetType() == p2.GetType())
+            {
+                return (p1.X == p2.X) && (p1.Y == p2.Y);
+            }
             return false;
-         }
-         if (p1.GetType() == p2.GetType()) {
-            return (p1.X == p2.X) && (p1.Y == p2.Y);
-         }
-         return false;
-      }
-
-      /// <summary>This operator determines whether two Points have the same
-      /// location.</summary>
-      /// <param><c>p1</c> is the first Point to be compared.</param>
-      /// <param><c>p2</c> is the second Point to be compared.</param>
-      /// <returns>True if the Points do not have the same location and the
-      /// exact same type; otherwise, false.</returns>
-      /// <seealso cref="Equals"/>
-      /// <seealso cref="operator=="/>
-      public static bool operator!=(Point p1, Point p2) {
-         return !(p1 == p2);
-      }
-   }
+        }
+        
+        /// <summary>
+        /// This operator determines whether two Points have the same location.
+        /// </summary>
+        /// <param><c>p1</c> is the first Point to be compared.</param>
+        /// <param><c>p2</c> is the second Point to be compared.</param>
+        /// <returns>
+        /// True if the Points do not have the same location and the
+        /// exact same type; otherwise, false.
+        /// </returns>
+        /// <seealso cref="Equals"/>
+        /// <seealso cref="operator=="/>
+        public static bool operator!=(Point p1, Point p2) => !(p1 == p2);
+    }
 }
 ```
 
@@ -983,113 +1060,135 @@ Here is the output produced by one documentation generator when given the source
 ```xml
 <?xml version="1.0"?>
 <doc>
-   <assembly>
-      <name>Point</name>
-   </assembly>
-   <members>
-      <member name="T:Graphics.Point">
-         <summary>Class <c>Point</c> models a point in a two-dimensional
-         plane.
-         </summary>
-      </member>
-      <member name="F:Graphics.Point.x">
-         <summary>Instance variable <c>x</c> represents the point's
-         x-coordinate.</summary>
-      </member>
-      <member name="F:Graphics.Point.y">
-         <summary>Instance variable <c>y</c> represents the point's
-         y-coordinate.</summary>
-      </member>
-      <member name="M:Graphics.Point.#ctor">
-         <summary>This constructor initializes the new Point to
-         (0,0).</summary>
-      </member>
-      <member name="M:Graphics.Point.#ctor(System.Int32,System.Int32)">
-         <summary>This constructor initializes the new Point to
-         (<paramref name="xor"/>,<paramref name="yor"/>).</summary>
-         <param><c>xor</c> is the new Point's x-coordinate.</param>
-         <param><c>yor</c> is the new Point's y-coordinate.</param>
-      </member>
-      <member name="M:Graphics.Point.Move(System.Int32,System.Int32)">
-         <summary>This method changes the point's location to
-         the given coordinates. <see cref="M:Graphics.Point.Translate(System.Int32,System.Int32)"/></summary>
-         <param><c>xor</c> is the new x-coordinate.</param>
-         <param><c>yor</c> is the new y-coordinate.</param>
-      </member>
-      <member name="M:Graphics.Point.Translate(System.Int32,System.Int32)">
-         <summary>This method changes the point's location by
-         the given x- and y-offsets.
-         <example>For example:
-            <code>
-               Point p = new Point(3,5);
-               p.Translate(-1,3);
-            </code>
-         results in <c>p</c>'s having the value (2,8).
-         </example>
-         <see cref="M:Graphics.Point.Move(System.Int32,System.Int32)"/></summary>
-         <param><c>xor</c> is the relative x-offset.</param>
-         <param><c>yor</c> is the relative y-offset.</param>
-      </member>
-      <member name="M:Graphics.Point.Equals(System.Object)">
-         <summary>This method determines whether two Points have the same
-         location.</summary>
-         <param><c>o</c> is the object to be compared to the current
-         object.
-         </param>
-         <returns>True if the Points have the same location and they have
-         the exact same type; otherwise, false.</returns>
-         <seealso
-            cref="M:Graphics.Point.op_Equality(Graphics.Point,Graphics.Point)"/>
-         <seealso
-            cref="M:Graphics.Point.op_Inequality(Graphics.Point,Graphics.Point)"/>
-      </member>
-      <member name="M:Graphics.Point.ToString">
-         <summary>Report a point's location as a string.</summary>
-         <returns>A string representing a point's location, in the form
-         (x,y),
-         without any leading, training, or embedded whitespace.</returns>
-      </member>
-      <member name="M:Graphics.Point.op_Equality(Graphics.Point,Graphics.Point)">
-         <summary>This operator determines whether two Points have the
-         same
-         location.</summary>
-         <param><c>p1</c> is the first Point to be compared.</param>
-         <param><c>p2</c> is the second Point to be compared.</param>
-         <returns>True if the Points have the same location and they have
-         the exact same type; otherwise, false.</returns>
-         <seealso cref="M:Graphics.Point.Equals(System.Object)"/>
-         <seealso
-             cref="M:Graphics.Point.op_Inequality(Graphics.Point,Graphics.Point)"/>
-      </member>
-      <member name="M:Graphics.Point.op_Inequality(Graphics.Point,Graphics.Point)">
-         <summary>This operator determines whether two Points have the
-         same
-         location.</summary>
-         <param><c>p1</c> is the first Point to be compared.</param>
-         <param><c>p2</c> is the second Point to be compared.</param>
-         <returns>True if the Points do not have the same location and
-         the
-         exact same type; otherwise, false.</returns>
-         <seealso cref="M:Graphics.Point.Equals(System.Object)"/>
-         <seealso
-            cref="M:Graphics.Point.op_Equality(Graphics.Point,Graphics.Point)"/>
-      </member>
-      <member name="M:Graphics.Point.Main">
-         <summary>This is the entry point of the Point class testing
-         program.
-         <para>This program tests each method and operator, and
-         is intended to be run after any non-trvial maintenance has
-         been performed on the Point class.</para></summary>
-      </member>
-      <member name="P:Graphics.Point.X">
-         <value>Property <c>X</c> represents the point's
-         x-coordinate.</value>
-      </member>
-      <member name="P:Graphics.Point.Y">
-          <value>Property <c>Y</c> represents the point's
-          y-coordinate.</value>
-      </member>
-   </members>
+    <assembly>
+        <name>Point</name>
+    </assembly>
+    <members>
+        <member name="T:Graphics.Point">
+        <summary>Class <c>Point</c> models a point in a two-dimensional
+        plane.
+        </summary>
+        </member>
+            <member name="F:Graphics.Point.x">
+            <summary>
+                Instance variable <c>x</c> represents the point's x-coordinate.
+            </summary>
+        </member>
+        <member name="F:Graphics.Point.y">
+            <summary>
+                Instance variable <c>y</c> represents the point's y-coordinate.
+            </summary>
+        </member>
+        <member name="M:Graphics.Point.#ctor">
+            <summary>This constructor initializes the new Point to (0,0).</summary>
+        </member>
+        <member name="M:Graphics.Point.#ctor(System.Int32,System.Int32)">
+            <summary>
+                This constructor initializes the new Point to
+                (<paramref name="xor"/>,<paramref name="yor"/>).
+            </summary>
+            <param><c>xor</c> is the new Point's x-coordinate.</param>
+            <param><c>yor</c> is the new Point's y-coordinate.</param>
+        </member>
+        <member name="M:Graphics.Point.Move(System.Int32,System.Int32)">
+            <summary>
+                This method changes the point's location to
+                the given coordinates.
+                <see cref="M:Graphics.Point.Translate(System.Int32,System.Int32)"/>
+            </summary>
+            <param><c>xor</c> is the new x-coordinate.</param>
+            <param><c>yor</c> is the new y-coordinate.</param>
+            </member>
+        <member name="M:Graphics.Point.Translate(System.Int32,System.Int32)">
+            <summary>
+                This method changes the point's location by
+                the given x- and y-offsets.
+                <example>For example:
+                <code>
+                Point p = new Point(3,5);
+                p.Translate(-1,3);
+                </code>
+                results in <c>p</c>'s having the value (2,8).
+                </example>
+                <see cref="M:Graphics.Point.Move(System.Int32,System.Int32)"/>
+            </summary>
+            <param><c>xor</c> is the relative x-offset.</param>
+            <param><c>yor</c> is the relative y-offset.</param>
+        </member>
+        <member name="M:Graphics.Point.Equals(System.Object)">
+            <summary>
+                This method determines whether two Points have the same location.
+            </summary>
+            <param>
+                <c>o</c> is the object to be compared to the current object.
+            </param>
+            <returns>
+                True if the Points have the same location and they have
+                the exact same type; otherwise, false.
+            </returns>
+            <seealso 
+                cref="M:Graphics.Point.op_Equality(Graphics.Point,Graphics.Point)" />
+            <seealso 
+                cref="M:Graphics.Point.op_Inequality(Graphics.Point,Graphics.Point)"/>
+        </member>
+         <member name="M:Graphics.Point.ToString">
+            <summary>
+                Report a point's location as a string.
+            </summary>
+            <returns>
+                A string representing a point's location, in the form (x,y),
+                without any leading, training, or embedded whitespace.
+            </returns>
+         </member>
+        <member name="M:Graphics.Point.op_Equality(Graphics.Point,Graphics.Point)">
+            <summary>
+                This operator determines whether two Points have the same location.
+            </summary>
+            <param><c>p1</c> is the first Point to be compared.</param>
+            <param><c>p2</c> is the second Point to be compared.</param>
+            <returns>
+                True if the Points have the same location and they have
+                the exact same type; otherwise, false.
+            </returns>
+            <seealso cref="M:Graphics.Point.Equals(System.Object)"/>
+            <seealso
+                cref="M:Graphics.Point.op_Inequality(Graphics.Point,Graphics.Point)"/>
+        </member>
+        <member name="M:Graphics.Point.op_Inequality(Graphics.Point,Graphics.Point)">
+            <summary>
+                This operator determines whether two Points have the same location.
+            </summary>
+            <param><c>p1</c> is the first Point to be compared.</param>
+            <param><c>p2</c> is the second Point to be compared.</param>
+            <returns>
+                True if the Points do not have the same location and the
+                exact same type; otherwise, false.
+            </returns>
+            <seealso cref="M:Graphics.Point.Equals(System.Object)"/>
+            <seealso
+                cref="M:Graphics.Point.op_Equality(Graphics.Point,Graphics.Point)"/>
+            </member>
+            <member name="M:Graphics.Point.Main">
+                <summary>
+                    This is the entry point of the Point class testing program.
+                    <para>
+                        This program tests each method and operator, and
+                        is intended to be run after any non-trvial maintenance has
+                        been performed on the Point class.
+                    </para>
+                </summary>
+            </member>
+            <member name="P:Graphics.Point.X">
+                <value>
+                    Property <c>X</c> represents the point's x-coordinate.
+                </value>
+            </member>
+            <member name="P:Graphics.Point.Y">
+                <value>
+                    Property <c>Y</c> represents the point's y-coordinate.
+                </value>
+        </member>
+    </members>
 </doc>
 ```
 

--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -41,9 +41,9 @@ In a *Delimited_Doc_Comment*, if the first non-*Whitespace* character on the sec
 public class Point
 {
     /// <summary>
-    /// method <c>draw</c> renders the point.
+    /// Method <c>Draw</c> renders the point.
     /// </summary>
-    void draw() {...}
+    void Draw() {...}
 }
 ```
 
@@ -129,10 +129,10 @@ This tag is used to set one or more lines of source code or program output in so
 /// results in <c>p</c>'s having the value (2,8).
 /// </example>
 /// </summary>
-public void Translate(int xor, int yor)
+public void Translate(int dx, int dy)
 {
-    X += xor;
-    Y += yor;
+    X += dx;
+    Y += dy;
 }
 ```
 
@@ -166,14 +166,18 @@ where
 ```csharp
 public class DataBaseOperations
 {
-    /// <exception cref="MasterFileFormatCorruptException"></exception>
-    /// <exception cref="MasterFileLockedOpenException"></exception>
+    /// <exception cref="MasterFileFormatCorruptException">Thrown when the master file is corrupted.</exception>
+    /// <exception cref="MasterFileLockedOpenException">Thrown when the master file is already open.</exception>
     public static void ReadRecord(int flag)
     {
         if (flag == 1)
+        {
             throw new MasterFileFormatCorruptException();
+        }
         else if (flag == 2)
+        {
             throw new MasterFileLockedOpenException();
+        }
          // ...
     }
 }
@@ -299,7 +303,7 @@ where
 /// <summary>This is the entry point of the Point class testing program.
 /// <para>
 /// This program tests each method and operator, and
-/// is intended to be run after any non-trvial maintenance has
+/// is intended to be run after any non-trivial maintenance has
 /// been performed on the Point class.
 /// </para>
 /// </summary>
@@ -329,12 +333,12 @@ where
 /// This method changes the point's location to
 /// the given coordinates.
 /// </summary>
-/// <param name="xor">the new x-coordinate.</param>
-/// <param name="yor">the new y-coordinate.</param>
-public void Move(int xor, int yor)
+/// <param name="xPosition">the new x-coordinate.</param>
+/// <param name="yPosition">the new y-coordinate.</param>
+public void Move(int xPosition, int yPosition)
 {
-    X = xor;
-    Y = yor;
+    X = xPosition;
+    Y = yPosition;
 }
 ```
 
@@ -354,14 +358,14 @@ where
 
 ```csharp
 /// <summary>This constructor initializes the new Point to
-/// (<paramref name="xor"/>,<paramref name="yor"/>).
+/// (<paramref name="xPosition"/>,<paramref name="yPosition"/>).
 /// </summary>
-/// <param name="xor">the new Point's x-coordinate.</param>
-/// <param name="yor">the new Point's y-coordinate.</param>
-public Point(int xor, int yor)
+/// <param name="xPosition">the new Point's x-coordinate.</param>
+/// <param name="yPosition">the new Point's y-coordinate.</param>
+public Point(int xPosition, int yPosition)
 {
-    X = xor;
-    Y = yor;
+    X = xPosition;
+    Y = yPosition;
 }
 ```
 
@@ -382,8 +386,7 @@ where
 
 ```csharp
 /// <permission cref="System.Security.PermissionSet">
-/// Everyone can
-/// access this method.
+/// Everyone can access this method.
 /// </permission>
 public static void Test()
 {
@@ -407,8 +410,7 @@ where
 
 ```csharp
 /// <summary>
-/// Class <c>Point</c> models a point in a
-/// two-dimensional plane.
+/// Class <c>Point</c> models a point in a two-dimensional plane.
 /// </summary>
 /// <remarks>
 /// Uses polar coordinates
@@ -441,10 +443,7 @@ where
 /// A string representing a point's location, in the form (x,y),
 /// without any leading, trailing, or embedded whitespace.
 /// </returns>
-public override string ToString()
-{
-   return "(" + X + "," + Y + ")";
-}
+public override string ToString() => $"({X},{Y})";
 ```
 
 ### D.3.14 \<see\>
@@ -468,18 +467,18 @@ where
 /// This method changes the point's location to
 /// the given coordinates. <see cref="Translate"/>
 /// </summary>
-public void Move(int xor, int yor)
+public void Move(int xPosition, int yPosition)
 {
-    X = xor;
-    Y = yor;
+    X = xPosition;
+    Y = yPosition;
 }
 /// <summary>This method changes the point's location by
 /// the given x- and y-offsets. <see cref="Move"/>
 /// </summary>
-public void Translate(int xor, int yor)
+public void Translate(int dx, int dy)
 {
-    X += xor;
-    Y += yor;
+    X += dx;
+    Y += dy;
 }
 ```
 
@@ -526,7 +525,7 @@ where
 
 ```csharp
 /// <summary>This constructor initializes the new Point to (0,0).</summary>
-public Point() : this(0,0)
+public Point() : this(0, 0)
 {
 }
 ```
@@ -654,7 +653,7 @@ namespace Acme
 
     struct ValueType { ... }
 
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public class NestedClass { ... }
         public interface IMenuItem { ... }
@@ -664,7 +663,7 @@ namespace Acme
 
     class MyList<T>
     {
-        class Helper<U,V>{ ... }
+        class Helper<U,V> { ... }
     }
 }
 
@@ -690,7 +689,7 @@ namespace Acme
         private int total;
     }
 
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public class NestedClass
         {
@@ -725,7 +724,7 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-    class Widget: IProcess
+    class Widget : IProcess
     {
         static Widget() { ... }
         public Widget() { ... }
@@ -743,7 +742,7 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-    class Widget: IProcess
+    class Widget : IProcess
     {
         ~Widget() { ... }
     }
@@ -762,7 +761,7 @@ namespace Acme
         public void M(int i) { ... }
     }
 
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public class NestedClass
         {
@@ -809,7 +808,7 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public int Width { get { ... } set { ... } }
         public int this[int i] { get { ... } set { ... } }
@@ -827,7 +826,7 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public event Del AnEvent;
     }
@@ -841,7 +840,7 @@ namespace Acme
 ```csharp
 namespace Acme
 {
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public static Widget operator+(Widget x) { ... }
     }
@@ -857,7 +856,7 @@ The complete set of unary operator function names used is as follows: `op_UnaryP
 ```csharp
 namespace Acme
 {
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public static Widget operator+(Widget x1, Widget x2) { ... }
     }
@@ -873,7 +872,7 @@ The complete set of binary operator function names used is as follows: `op_Addit
 ```csharp
 namespace Acme
 {
-    class Widget: IProcess
+    class Widget : IProcess
     {
         public static explicit operator int(Widget x) { ... }
         public static implicit operator long(Widget x) { ... }
@@ -929,30 +928,30 @@ namespace Graphics
         /// <summary>
         /// This constructor initializes the new Point to (0,0).
         /// </summary>
-        public Point() : this(0,0) {}
+        public Point() : this(0, 0) {}
         
         /// <summary>
         /// This constructor initializes the new Point to
-        /// (<paramref name="xor"/>,<paramref name="yor"/>).
+        /// (<paramref name="xPosition"/>,<paramref name="yPosition"/>).
         /// </summary>
-        /// <param><c>xor</c> is the new Point's x-coordinate.</param>
-        /// <param><c>yor</c> is the new Point's y-coordinate.</param>
-        public Point(int xor, int yor) 
+        /// <param><c>xPosition</c> is the new Point's x-coordinate.</param>
+        /// <param><c>yPosition</c> is the new Point's y-coordinate.</param>
+        public Point(int xPosition, int yPosition) 
         {
-            X = xor;
-            Y = yor;
+            X = xPosition;
+            Y = yPosition;
         }
         
         /// <summary>
         /// This method changes the point's location to
         /// the given coordinates. <see cref="Translate"/>
         /// </summary>
-        /// <param><c>xor</c> is the new x-coordinate.</param>
-        /// <param><c>yor</c> is the new y-coordinate.</param>
-        public void Move(int xor, int yor) 
+        /// <param><c>xPosition</c> is the new x-coordinate.</param>
+        /// <param><c>yPosition</c> is the new y-coordinate.</param>
+        public void Move(int xPosition, int yPosition) 
         {
-            X = xor;
-            Y = yor;
+            X = xPosition;
+            Y = yPosition;
         }
         
         /// <summary>
@@ -960,19 +959,19 @@ namespace Graphics
         /// the given x- and y-offsets.
         /// <example>For example:
         /// <code>
-        /// Point p = new Point(3,5);
-        /// p.Translate(-1,3);
+        /// Point p = new Point(3, 5);
+        /// p.Translate(-1, 3);
         /// </code>
-        /// results in <c>p</c>'s having the value (2,8).
+        /// results in <c>p</c>'s having the value (2, 8).
         /// <see cref="Move"/>
         /// </example>
         /// </summary>
-        /// <param><c>xor</c> is the relative x-offset.</param>
-        /// <param><c>yor</c> is the relative y-offset.</param>
-        public void Translate(int xor, int yor)
+        /// <param><c>dx</c> is the relative x-offset.</param>
+        /// <param><c>dy</c> is the relative y-offset.</param>
+        public void Translate(int dx, int dy)
         {
-            X += xor;
-            Y += yor;
+            X += dx;
+            Y += dy;
         }
         
         /// <summary>
@@ -1010,8 +1009,7 @@ namespace Graphics
         /// A string representing a point's location, in the form (x,y),
         /// without any leading, training, or embedded whitespace.
         /// </returns>
-        public override string ToString() => 
-            "(" + X + "," + Y + ")";
+        public override string ToString() => $"("{X},{Y})";
         
         /// <summary>
         /// This operator determines whether two Points have the same location.
@@ -1080,15 +1078,15 @@ Here is the output produced by one documentation generator when given the source
             </summary>
         </member>
         <member name="M:Graphics.Point.#ctor">
-            <summary>This constructor initializes the new Point to (0,0).</summary>
+            <summary>This constructor initializes the new Point to (0, 0).</summary>
         </member>
         <member name="M:Graphics.Point.#ctor(System.Int32,System.Int32)">
             <summary>
                 This constructor initializes the new Point to
-                (<paramref name="xor"/>,<paramref name="yor"/>).
+                (<paramref name="xPosition"/>,<paramref name="yor"/>).
             </summary>
-            <param><c>xor</c> is the new Point's x-coordinate.</param>
-            <param><c>yor</c> is the new Point's y-coordinate.</param>
+            <param><c>xPosition</c> is the new Point's x-coordinate.</param>
+            <param><c>yPosition</c> is the new Point's y-coordinate.</param>
         </member>
         <member name="M:Graphics.Point.Move(System.Int32,System.Int32)">
             <summary>
@@ -1096,8 +1094,8 @@ Here is the output produced by one documentation generator when given the source
                 the given coordinates.
                 <see cref="M:Graphics.Point.Translate(System.Int32,System.Int32)"/>
             </summary>
-            <param><c>xor</c> is the new x-coordinate.</param>
-            <param><c>yor</c> is the new y-coordinate.</param>
+            <param><c>xPosition</c> is the new x-coordinate.</param>
+            <param><c>yPosition</c> is the new y-coordinate.</param>
             </member>
         <member name="M:Graphics.Point.Translate(System.Int32,System.Int32)">
             <summary>
@@ -1112,8 +1110,8 @@ Here is the output produced by one documentation generator when given the source
                 </example>
                 <see cref="M:Graphics.Point.Move(System.Int32,System.Int32)"/>
             </summary>
-            <param><c>xor</c> is the relative x-offset.</param>
-            <param><c>yor</c> is the relative y-offset.</param>
+            <param><c>dx</c> is the relative x-offset.</param>
+            <param><c>dy</c> is the relative y-offset.</param>
         </member>
         <member name="M:Graphics.Point.Equals(System.Object)">
             <summary>
@@ -1173,7 +1171,7 @@ Here is the output produced by one documentation generator when given the source
                     This is the entry point of the Point class testing program.
                     <para>
                         This program tests each method and operator, and
-                        is intended to be run after any non-trvial maintenance has
+                        is intended to be run after any non-trivial maintenance has
                         been performed on the Point class.
                     </para>
                 </summary>


### PR DESCRIPTION
Update code to our evolving standard practice.

Here, I also formatted the XML comments for readability. If the opening and closing tag both fit on one line, make the tag a single line. Otherwise, put each of the opening and closing tags on their own line.