### PR TITLE
Improved wording re nested generic structs

### DIFF
--- a/standard/structs.md
+++ b/standard/structs.md
@@ -25,7 +25,7 @@ A *struct_declaration* consists of an optional set of *attributes* ([§21](attri
 
 A struct declaration shall not supply a *type_parameter_constraints_clauses* unless it also supplies a *type_parameter_list*.
 
-A struct declaration that supplies a *type_parameter_list* is a generic struct declaration.
+A struct declaration that supplies a *type_parameter_list* is a generic struct declaration. Additionally, any struct nested inside a generic class declaration or a generic struct declaration is itself a generic struct declaration, since type arguments for the containing type shall be supplied to create a constructed type.
 
 ### 15.2.2 Struct modifiers
 


### PR DESCRIPTION
A class-related version of the proposed sentence exists for [class declarations](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1421-general), and it seems that the same intent applies to struct declaration as well, but was not so stated.
