### PR TITLE
Improve named parameter wording

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -108,7 +108,7 @@ class X : Attribute { ... }
 
 ### 21.2.3 Positional and named parameters
 
-Attribute classes can have ***positional parameters*** and ***named parameters***. Each public instance constructor for an attribute class defines a valid sequence of positional parameters for that attribute class. Each non-static public read-write field and property for an attribute class defines a named parameter for the attribute class. Both accessors of a property need to be public for the property to define a named parameter.
+Attribute classes can have ***positional parameters*** and ***named parameters***. Each public instance constructor for an attribute class defines a valid sequence of positional parameters for that attribute class. Each non-static public read-write field and property for an attribute class defines a named parameter for the attribute class. For a property to define a named parameter, that property shall have both a public get accessor and a public set accessor.   
 
 > *Example*: The example
 > ```csharp


### PR DESCRIPTION
The change may seem pedantic, but the new wording makes it clear that *both* accessors are needed, and *both* must be public. Also, this makes it easier to allow init accessors instead of get accessors in V9.