### PR TITLE
Better betterness

### DIFF
--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -79,7 +79,6 @@ A method or delegate type `M` is ***compatible*** with a delegate type `D` if al
 
 -   `D` and `M` have the same number of parameters, and each parameter in `D` has the same `ref` or `out` modifiers as the corresponding parameter in `M`.
 -   For each value parameter (a parameter with no `ref` or `out` modifier), an identity conversion ([§10.2.2](conversions.md#1022-identity-conversion)) or implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)) exists from the parameter type in `D` to the corresponding parameter type in `M`.
-
 -   For each `ref` or `out` parameter, the parameter type in `D` is the same as the parameter type in `M`.
 -   An identity or implicit reference conversion exists from the return type of `M` to the return type of `D`.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -965,7 +965,7 @@ Given an expression `E` and a type `T`, `E` ***exactly matches*** `T` if one of 
 Given two different types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` if one of the following holds:
 
 - An implicit conversion from `T₁` to `T₂` exists
-- In case of a method group conversion (§10.6) for the corresponding argument, if a better conversion target (§7.5.3.5), is a delegate type that is not compatible (§19.4) with the single best method from the method group (§10.6), then neither delegate type is better.
+- In case of a method group conversion (§10.6) for the corresponding argument, if a better conversion target (§11.6.4.6), is a delegate type that is not compatible (§19.4) with the single best method from the method group (§10.6), then neither delegate type is better.
 - `T₁` is `Task<S₁>`, `T₂` is `Task<S₂>`, and `S₁` is a better conversion target than `S₂`
 - `T₁` is `S₁` or `S₁?` where `S₁` is a signed integral type, and `T₂` is `S₂` or `S₂?` where `S₂` is an unsigned integral type. Specifically:
   - `S₁` is `sbyte` and `S₂` is `byte`, `ushort`, `uint`, or `ulong`

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -945,12 +945,6 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂
 
 #### 11.6.4.4 Better conversion from expression
 
-<!-- 
-> Section 7.5.3.3 is now 11.6.4.4
-> Section 7.5.3.4 is now 11.6.4.5
-> Section 7.5.3.5 is now 11.6.4.6
--->
-
 Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a better conversion than `C₂` if one of the following holds:
 - `E` exactly matches `T₁` and `E` does not exactly match `T₂` (§11.6.4.5)
 - `E` exactly matches both or neither of `T₁` and `T2`, and `T₁` is a better conversion target than `T2` (§11.6.4.6)
@@ -963,17 +957,15 @@ Given an expression `E` and a type `T`, `E` ***exactly matches*** `T` is one of 
 - `E` is an anonymous function, `T` is either a delegate type `D` or an expression tree type `Expression<D>` and one of the following holds:
   - An inferred return type `X` exists for `E` in the context of the parameter list of `D` (§11.6.3.12), and an identity conversion exists from `X` to the return type of `D`
   - Either `E` is non-async and `D` has a return type `Y` or `E` is async and  `D` has a return type `Task<Y>`, and one of the following holds:
-- The body of `E` is an expression that exactly matches `Y`
-- The body of `E` is a statement block where every return statement returns an expression that exactly matches `Y`
+    - The body of `E` is an expression that exactly matches `Y`
+    - The body of `E` is a statement block where every return statement returns an expression that exactly matches `Y`
 
 ### 11.6.4.6 Better conversion target
 
 Given two different types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` if:
 
 - An implicit conversion from `T₁` to `T₂` exists
-- `T₁` is either a delegate type `D₁` or an expression tree type `Expression<D₁>`, `T₂` is either a delegate type `D₂` or an expression tree type `Expression<D₂>`, `D₁` has a return type `S₁` and one of the following holds:
-  - `D₂` is void returning
-  - `D₂` has a return type `S₂`, and `S₁` is a better conversion target than `S₂`
+- In case of a method group conversion (§10.6) for the corresponding argument, if a better conversion target (§7.5.3.5), is a delegate type that is not compatible (§19.4) with the single best method from the method group (§10.6), then neither delegate type is better.
 - `T₁` is `Task<S₁>`, `T₂` is `Task<S₂>`, and `S₁` is a better conversion target than `S₂`
 - `T₁` is `S₁` or `S₁`? where `S₁` is a signed integral type, and `T₂` is `S₂` or `S₂`? where `S₂` is an unsigned integral type. Specifically:
   - `S₁` is `sbyte` and `S₂` is `byte`, `ushort`, `uint`, or `ulong`

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -945,34 +945,42 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂
 
 #### 11.6.4.4 Better conversion from expression
 
-Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a ***better conversion*** than `C₂` if at least one of the following holds:
+<!-- 
+> Section 7.5.3.3 is now 11.6.4.4
+> Section 7.5.3.4 is now 11.6.4.5
+> Section 7.5.3.5 is now 11.6.4.6
+-->
 
-- `E` has a type `S` and an identity conversion exists from `S` to `T₁` but not from `S` to `T₂`
-- `E` is not an anonymous function and `T₁` is a better conversion target than `T₂` ([§11.6.4.6](expressions.md#11646-better-conversion-target))
-- `E` is an anonymous function, `T₁` is either a delegate type `D₁` or an expression tree type `Expression<D₁>`, `T₂` is either a delegate type `D₂` or an expression tree type `Expression<D₂>` and one of the following holds:
-  - `D₁` is a better conversion target than `D₂`
-  - `D₁` and `D₂` have identical parameter lists, and one of the following holds:
-    - `D₁` has a return type `Y₁`, and `D₂` has a return type `Y₂`, an inferred return type `X` exists for `E` in the context of that parameter list ([§11.6.3.13](expressions.md#116313-inferred-return-type)), and the conversion from `X` to `Y₁` is better than the conversion from `X` to `Y₂`
-    - `E` is async, `D₁` has a return type `Task<Y₁>`, and `D₂` has a return type `Task<Y>`, an inferred return type `Task<X>` exists for `E` in the context of that parameter list ([§11.6.3.13](expressions.md#116313-inferred-return-type)), and the conversion from `X` to `Y₁` is better than the conversion from `X` to `Y₂`
-    - `D₁` has a return type `Y`, and `D₂` is void returning
+Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a ***better conversion*** than `C₂` if `E` does not exactly match `T₂` and one of the following holds:
 
-#### 11.6.4.5 Better conversion from type
+- `E` exactly matches `T₁` (§11.6.4.5)
+- `T₁` is a better conversion target than `T₂` (§11.6.4.6)
 
-Given a conversion `C₁` that converts from a type `S` to a type `T₁`, and a conversion `C₂` that converts from a type `S` to a type `T₂`, `C₁` is a *better conversion* than `C₂` if at least one of the following holds:
+### 11.6.4.5 Exactly matching Expression
 
--   An identity conversion exists from `S` to `T₁` but not from `S` to `T₂`
--   `T₁` is a better conversion target than `T₂` ([§11.6.4.6](expressions.md#11646-better-conversion-target))
+Given an expression `E` and a type `T`, `E` ***exactly matches*** `T` is one of the following holds:
 
-#### 11.6.4.6 Better conversion target
+- `E` has a type `S`, and an identity conversion exists from `S` to `T`
+- `E` is an anonymous function, `T` is either a delegate type `D` or an expression tree type `Expression<D>` and one of the following holds:
+  - An inferred return type `X` exists for `E` in the context of the parameter list of `D` (§11.6.3.12), and an identity conversion exists from `X` to the return type of `D`
+  - Either `E` is non-async and `D` has a return type `Y` or `E` is async and  `D` has a return type `Task<Y>`, and one of the following holds:
+- The body of `E` is an expression that exactly matches `Y`
+- The body of `E` is a statement block where every return statement returns an expression that exactly matches `Y`
 
-Given two different types `T₁` and `T₂`, `T₁` is a better conversion target than `T₂` if at least one of the following holds:
+### 11.6.4.6 Better conversion target
 
-- An implicit conversion from `T₁` to `T₂` exists, and no implicit conversion from `T₂` to `T₁` exists
-- `T₁` is a signed integral type and `T₂` is an unsigned integral type. Specifically:
-  - `T₁` is `sbyte` and `T₂` is `byte`, `ushort`, `uint`, or `ulong`
-  - `T₁` is `short` and `T₂` is `ushort`, `uint`, or `ulong`
-  - `T₁` is `int` and `T₂` is `uint`, or `ulong`
-  - `T₁` is `long` and `T₂` is `ulong`
+Given two different types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` if:
+
+- An implicit conversion from `T₁` to `T₂` exists
+- `T₁` is either a delegate type `D₁` or an expression tree type `Expression<D₁>`, `T₂` is either a delegate type `D₂` or an expression tree type `Expression<D₂>`, `D₁` has a return type `S₁` and one of the following holds:
+  - `D₂` is void returning
+  - `D₂` has a return type `S₂`, and `S₁` is a better conversion target than `S₂`
+- `T₁` is `Task<S₁>`, `T₂` is `Task<S₂>`, and `S₁` is a better conversion target than `S₂`
+- `T₁` is `S₁` or `S₁`? where `S₁` is a signed integral type, and `T₂` is `S₂` or `S₂`? where `S₂` is an unsigned integral type. Specifically:
+  - `S₁` is `sbyte` and `S₂` is `byte`, `ushort`, `uint`, or `ulong`
+  - `S₁` is `short` and `S₂` is `ushort`, `uint`, or `ulong`
+  - `S₁` is `int` and `S₂` is `uint`, or `ulong`
+  - `S₁` is `long` and `S₂` is `ulong`
 
 #### 11.6.4.7 Overloading in generic classes
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -946,8 +946,9 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂
 #### 11.6.4.4 Better conversion from expression
 
 Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a better conversion than `C₂` if one of the following holds:
+
 - `E` exactly matches `T₁` and `E` does not exactly match `T₂` (§11.6.4.5)
-- `E` exactly matches both or neither of `T₁` and `T₂`, and `T₁` is a better conversion target than `T2` (§11.6.4.6)
+- `E` exactly matches both or neither of `T₁` and `T₂`, and `T₁` is a better conversion target than `T₂` (§11.6.4.6)
 
 #### 11.6.4.5 Exactly matching expression
 
@@ -962,16 +963,20 @@ Given an expression `E` and a type `T`, `E` ***exactly matches*** `T` if one of 
 
 #### 11.6.4.6 Better conversion target
 
-Given two different types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` if one of the following holds:
+Given an expression `E` and two types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` for `E` if one of the following holds:
 
 - An implicit conversion from `T₁` to `T₂` exists
-- In case of a method group conversion (§10.6) for the corresponding argument, if a better conversion target (§11.6.4.6), is a delegate type that is not compatible (§19.4) with the single best method from the method group (§10.6), then neither delegate type is better.
 - `T₁` is `Task<S₁>`, `T₂` is `Task<S₂>`, and `S₁` is a better conversion target than `S₂`
 - `T₁` is `S₁` or `S₁?` where `S₁` is a signed integral type, and `T₂` is `S₂` or `S₂?` where `S₂` is an unsigned integral type. Specifically:
   - `S₁` is `sbyte` and `S₂` is `byte`, `ushort`, `uint`, or `ulong`
   - `S₁` is `short` and `S₂` is `ushort`, `uint`, or `ulong`
   - `S₁` is `int` and `S₂` is `uint`, or `ulong`
   - `S₁` is `long` and `S₂` is `ulong`
+- In case of a method group conversion (§10.6) for the corresponding argument, if a better conversion target (§11.6.4.6), is a delegate type that is not compatible (§19.4) with the single best method from the method group (§10.6), then neither delegate type is better.
+- `E` is the result of a method group conversion is a delegate creation expression (§11.7.15.6) whose argument is a method group and `T₁` is compatible (§19.4) with the single best method from the method group (§10.8)
+- `T₁` is either a delegate type `D₁` or an expression tree type `Expression<D₁>`, `T₂` is either a delegate type `D₂` or an expression tree type `Expression<D₂>`, `D₁` has a return type `S₁` and one of the following holds:
+  - `D₂` is void returning
+  - `D₂` has a return type `S₂`, and `S₁` is a better conversion target than `S₂`
 
 #### 11.6.4.7 Overloading in generic classes
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -972,11 +972,7 @@ Given an expression `E` and two types `T₁` and `T₂`, `T₁` is a ***better c
   - `S₁` is `short` and `S₂` is `ushort`, `uint`, or `ulong`
   - `S₁` is `int` and `S₂` is `uint`, or `ulong`
   - `S₁` is `long` and `S₂` is `ulong`
-- In case of a method group conversion (§10.6) for the corresponding argument, if a better conversion target (§11.6.4.6), is a delegate type that is not compatible (§19.4) with the single best method from the method group (§10.6), then neither delegate type is better.
 - `E` is the result of a method group conversion is a delegate creation expression (§11.7.15.6) whose argument is a method group and `T₁` is compatible (§19.4) with the single best method from the method group (§10.8)
-- `T₁` is either a delegate type `D₁` or an expression tree type `Expression<D₁>`, `T₂` is either a delegate type `D₂` or an expression tree type `Expression<D₂>`, `D₁` has a return type `S₁` and one of the following holds:
-  - `D₂` is void returning
-  - `D₂` has a return type `S₂`, and `S₁` is a better conversion target than `S₂`
 
 #### 11.6.4.7 Overloading in generic classes
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -947,11 +947,11 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂
 
 Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a better conversion than `C₂` if one of the following holds:
 - `E` exactly matches `T₁` and `E` does not exactly match `T₂` (§11.6.4.5)
-- `E` exactly matches both or neither of `T₁` and `T2`, and `T₁` is a better conversion target than `T2` (§11.6.4.6)
+- `E` exactly matches both or neither of `T₁` and `T₂`, and `T₁` is a better conversion target than `T2` (§11.6.4.6)
 
-### 11.6.4.5 Exactly matching Expression
+#### 11.6.4.5 Exactly matching expression
 
-Given an expression `E` and a type `T`, `E` ***exactly matches*** `T` is one of the following holds:
+Given an expression `E` and a type `T`, `E` ***exactly matches*** `T` if one of the following holds:
 
 - `E` has a type `S`, and an identity conversion exists from `S` to `T`
 - `E` is an anonymous function, `T` is either a delegate type `D` or an expression tree type `Expression<D>` and one of the following holds:
@@ -960,14 +960,14 @@ Given an expression `E` and a type `T`, `E` ***exactly matches*** `T` is one of 
     - The body of `E` is an expression that exactly matches `Y`
     - The body of `E` is a statement block where every return statement returns an expression that exactly matches `Y`
 
-### 11.6.4.6 Better conversion target
+#### 11.6.4.6 Better conversion target
 
-Given two different types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` if:
+Given two different types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` if one of the following holds:
 
 - An implicit conversion from `T₁` to `T₂` exists
 - In case of a method group conversion (§10.6) for the corresponding argument, if a better conversion target (§7.5.3.5), is a delegate type that is not compatible (§19.4) with the single best method from the method group (§10.6), then neither delegate type is better.
 - `T₁` is `Task<S₁>`, `T₂` is `Task<S₂>`, and `S₁` is a better conversion target than `S₂`
-- `T₁` is `S₁` or `S₁`? where `S₁` is a signed integral type, and `T₂` is `S₂` or `S₂`? where `S₂` is an unsigned integral type. Specifically:
+- `T₁` is `S₁` or `S₁?` where `S₁` is a signed integral type, and `T₂` is `S₂` or `S₂?` where `S₂` is an unsigned integral type. Specifically:
   - `S₁` is `sbyte` and `S₂` is `byte`, `ushort`, `uint`, or `ulong`
   - `S₁` is `short` and `S₂` is `ushort`, `uint`, or `ulong`
   - `S₁` is `int` and `S₂` is `uint`, or `ulong`

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -972,7 +972,7 @@ Given an expression `E` and two types `T₁` and `T₂`, `T₁` is a ***better c
   - `S₁` is `short` and `S₂` is `ushort`, `uint`, or `ulong`
   - `S₁` is `int` and `S₂` is `uint`, or `ulong`
   - `S₁` is `long` and `S₂` is `ulong`
-- `E` is a delegate creation expression (§11.7.15.6) resulting from the result of a method group conversion and `T₁` is compatible (§19.4) with the single best method from the method group (§10.8)
+- `E` is a delegate creation expression (§11.7.15.6) resulting from a method group conversion and `T₁` is compatible (§19.4) with the single best method from the method group (§10.8)
 
 #### 11.6.4.7 Overloading in generic classes
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -951,10 +951,9 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂
 > Section 7.5.3.5 is now 11.6.4.6
 -->
 
-Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a ***better conversion*** than `C₂` if `E` does not exactly match `T₂` and one of the following holds:
-
-- `E` exactly matches `T₁` (§11.6.4.5)
-- `T₁` is a better conversion target than `T₂` (§11.6.4.6)
+Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a better conversion than `C₂` if one of the following holds:
+- `E` exactly matches `T₁` and `E` does not exactly match `T₂` (§11.6.4.5)
+- `E` exactly matches both or neither of `T₁` and `T2`, and `T₁` is a better conversion target than `T2` (§11.6.4.6)
 
 ### 11.6.4.5 Exactly matching Expression
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -972,7 +972,7 @@ Given an expression `E` and two types `T₁` and `T₂`, `T₁` is a ***better c
   - `S₁` is `short` and `S₂` is `ushort`, `uint`, or `ulong`
   - `S₁` is `int` and `S₂` is `uint`, or `ulong`
   - `S₁` is `long` and `S₂` is `ulong`
-- `E` is a delegate creation expression (§11.7.15.6) resulting from a method group conversion and `T₁` is compatible (§19.4) with the single best method from the method group (§10.8)
+- `E` is a method group conversion (§10.8() and `T₁` is compatible (§19.4) with the single best method from the method group
 
 #### 11.6.4.7 Overloading in generic classes
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -972,7 +972,7 @@ Given an expression `E` and two types `T₁` and `T₂`, `T₁` is a ***better c
   - `S₁` is `short` and `S₂` is `ushort`, `uint`, or `ulong`
   - `S₁` is `int` and `S₂` is `uint`, or `ulong`
   - `S₁` is `long` and `S₂` is `ulong`
-- `E` is the result of a method group conversion is a delegate creation expression (§11.7.15.6) whose argument is a method group and `T₁` is compatible (§19.4) with the single best method from the method group (§10.8)
+- `E` is a delegate creation expression (§11.7.15.6) resulting from the result of a method group conversion and `T₁` is compatible (§19.4) with the single best method from the method group (§10.8)
 
 #### 11.6.4.7 Overloading in generic classes
 


### PR DESCRIPTION
Fixes #157
Fixes #283 

This takes the text from [Better betterness](https://github.com/dotnet/roslyn/blob/main/docs/specs/CSharp%206/Better%20Betterness.md) and then updates it for compatibility fixes, related to exact matches and method group conversions.

Reviewing each commit in order clarifies what changes came from the roslyn doc, and then those changes that followed after incorporating that initial spec. Commit messages link to dotnet/roslyn#6750 that explains the later changes.