### PR TITLE
markdig (used by the smarten tool) has a bug, this is a workaround…

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1479,7 +1479,7 @@ These restrictions ensure that all threads will observe volatile writes performe
 >
 >         // Run Thread2() in a new thread
 >         new Thread(new ThreadStart(Thread2)).Start();    
->                                                          
+>
 >         // Wait for Thread2() to signal that it has a result by setting finished to true.
 >         for (;;)
 >         {

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -5734,7 +5734,7 @@ When a property or indexer declared in a *struct_type* is the target of an assig
 >         this.a = a;
 >         this.b = b;
 >     }
->    
+>
 >     public Point A
 >     {
 >         get { return a; }


### PR DESCRIPTION
markdig (used by the smarten tool) has a bug, when a line starts with a ‘>‘
and is followed by nothing but n > 1 spaces then when roundtripping markdig
adds an extra n-1 spaces to the line.
In terms of MD this is harmless, in terms of roundtripping it is a bug as
the outptu doesn't match the input.
In the whole Standard there are two such lines, as a workaround until we
can find and kill the markdig bug this change deletes the extra spaces on
those lines.