### PR TITLE
Fix long lines in code blocks (above 95 characters)

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1684,7 +1684,8 @@ method_declaration
     ;
 
 method_header
-    : attributes? method_modifier* 'partial'? return_type member_name type_parameter_list? '(' formal_parameter_list? ')' type_parameter_constraints_clause*
+    : attributes? method_modifier* 'partial'? return_type member_name type_parameter_list?
+      '(' formal_parameter_list? ')' type_parameter_constraints_clause*
     ;
 
 method_modifier

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -12,8 +12,9 @@ A *delegate_declaration* is a *type_declaration* ([§13.7](namespaces.md#137-typ
 
 ```ANTLR
 delegate_declaration
-    : attributes? delegate_modifier* 'delegate' return_type identifier variant_type_parameter_list?
-      '(' formal_parameter_list? ')' type_parameter_constraints_clause* ';'
+    : attributes? delegate_modifier* 'delegate' return_type identifier
+      variant_type_parameter_list? '(' formal_parameter_list? ')'
+      type_parameter_constraints_clause* ';'
     ;
     
 delegate_modifier

--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -166,8 +166,12 @@ where
 ```csharp
 public class DataBaseOperations
 {
-    /// <exception cref="MasterFileFormatCorruptException">Thrown when the master file is corrupted.</exception>
-    /// <exception cref="MasterFileLockedOpenException">Thrown when the master file is already open.</exception>
+    /// <exception cref="MasterFileFormatCorruptException">
+    /// Thrown when the master file is corrupted.
+    /// </exception>
+    /// <exception cref="MasterFileLockedOpenException">
+    /// Thrown when the master file is already open.
+    /// </exception>
     public static void ReadRecord(int flag)
     {
         if (flag == 1)
@@ -569,7 +573,9 @@ where
 **Example:**
 
 ```csharp
-/// <summary>This method fetches data and returns a list of <typeparamref name="T"> "/>"> .</summary>
+/// <summary>
+/// This method fetches data and returns a list of <typeparamref name="T"> "/>">.
+/// </summary>
 /// <param name="string">query to execute</param>
 public List<T> FetchData<T>(string query)
 {

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1157,7 +1157,8 @@ interpolated_string_expression
 
 interpolated_regular_string_expression
     : Interpolated_Regular_String_Start Interpolated_Regular_String_Mid?
-      ('{' regular_interpolation '}' Interpolated_Regular_String_Mid?)* Interpolated_Regular_String_End
+      ('{' regular_interpolation '}' Interpolated_Regular_String_Mid?)*
+      Interpolated_Regular_String_End
     ;
 
 regular_interpolation
@@ -1196,15 +1197,17 @@ fragment Interpolated_Regular_String_Element
     ;
 
 fragment Interpolated_Regular_String_Character
-    : ~["\\{}\u000D\u000A\u0085\u2028\u2029]    // Any character except " (U+0022), \\ (U+005C),
-                                                //  { (U+007B), } (U+007D), and New_Line_Character
+    // Any character except " (U+0022), \\ (U+005C),
+    // { (U+007B), } (U+007D), and New_Line_Character.
+    : ~["\\{}\u000D\u000A\u0085\u2028\u2029]
     ;
 
 // interpolated verbatim string expressions
 
 interpolated_verbatim_string_expression
     : Interpolated_Verbatim_String_Start Interpolated_Verbatim_String_Mid?
-      ('{' verbatim_interpolation '}' Interpolated_Verbatim_String_Mid?)* Interpolated_Verbatim_String_End
+      ('{' verbatim_interpolation '}' Interpolated_Verbatim_String_Mid?)*
+      Interpolated_Verbatim_String_End
     ;
 
 verbatim_interpolation
@@ -4998,7 +5001,8 @@ join_clause
     ;
 
 join_into_clause
-    : 'join' type? identifier 'in' expression 'on' expression 'equals' expression 'into' identifier
+    : 'join' type? identifier 'in' expression 'on' expression 'equals' expression
+      'into' identifier
     ;
 
 orderby_clause

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -14,8 +14,9 @@ An *interface_declaration* is a *type_declaration* ([§13.7](namespaces.md#137-t
 
 ```ANTLR 
 interface_declaration
-    : attributes? interface_modifier* 'partial'? 'interface' identifier variant_type_parameter_list?
-      interface_base? type_parameter_constraints_clause* interface_body ';'?
+    : attributes? interface_modifier* 'partial'? 'interface'
+      identifier variant_type_parameter_list? interface_base?
+      type_parameter_constraints_clause* interface_body ';'?
     ;
 ```
 
@@ -235,7 +236,8 @@ Interface methods are declared using *interface_method_declaration*s:
 
 ```ANTLR
 interface_method_declaration
-    : attributes? 'new'? return_type identifier type_parameter_list? '(' formal_parameter_list? ')' type_parameter_constraints_clause* ';'
+    : attributes? 'new'? return_type identifier type_parameter_list?
+      '(' formal_parameter_list? ')' type_parameter_constraints_clause* ';'
     ;
 ```
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -211,7 +211,8 @@ fragment Single_Line_Comment
     ;
 
 fragment Input_Character
-    : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029')   // anything but New_Line_Character
+    // anything but New_Line_Character
+    : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029')
     ;
     
 fragment New_Line_Character
@@ -362,8 +363,8 @@ fragment Available_Identifier
     ;
 
 fragment Escaped_Identifier
-    : '@' Basic_Identifier // includes keywords and contextual keywords prefixed by '@',
-                           // see note below
+    // Includes keywords and contextual keywords prefixed by '@'. See note below.
+    : '@' Basic_Identifier 
     ;
 
 fragment Basic_Identifier
@@ -389,28 +390,38 @@ fragment Identifier_Part_Character
     ;
 
 fragment Letter_Character
-    : [\p{L}\p{Nl}]           // category Letter, all subcategories; category Number, subcategory letter
-    | Unicode_Escape_Sequence // only escapes for categories L & Nl allowed, see note below
+    // Category Letter, all subcategories; category Number, subcategory letter.
+    : [\p{L}\p{Nl}]
+    // Only escapes for categories L & Nl allowed. See note below.
+    | Unicode_Escape_Sequence
     ;
 
 fragment Combining_Character
-    : [\p{Mn}\p{Mc}]          // category Mark, subcategories non-spacing and spacing combining
-    | Unicode_Escape_Sequence // only escapes for categories Mn & Mc allowed, see note below
+    // Category Mark, subcategories non-spacing and spacing combining.
+    : [\p{Mn}\p{Mc}]
+    // Only escapes for categories Mn & Mc allowed. See note below.
+    | Unicode_Escape_Sequence
     ;
 
 fragment Decimal_Digit_Character
-    : [\p{Nd}]                // category Number, subcategory decimal digit
-    | Unicode_Escape_Sequence // only escapes for category Nd allowed, see note below
+    // Category Number, subcategory decimal digit.
+    : [\p{Nd}]
+    // Only escapes for category Nd allowed. See note below.
+    | Unicode_Escape_Sequence
     ;
 
 fragment Connecting_Character
-    : [\p{Pc}]                // category Punctuation, subcategory connector
-    | Unicode_Escape_Sequence // only escapes for category Pc allowed, see note below
+    // Category Punctuation, subcategory connector.
+    : [\p{Pc}]
+    // Only escapes for category Pc allowed. See note below.
+    | Unicode_Escape_Sequence
     ;
 
 fragment Formatting_Character
-    : [\p{Cf}]                // category Other, subcategory format
-    | Unicode_Escape_Sequence // only escapes for category Cf allowed, see note below
+    // Category Other, subcategory format.
+    : [\p{Cf}]
+    // Only escapes for category Cf allowed, see note below.
+    | Unicode_Escape_Sequence
     ;
 ```
 
@@ -1277,7 +1288,8 @@ fragment PP_Compilation_Unit_Name
     ;
     
 fragment PP_Compilation_Unit_Name_Character
-    : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029' | '#')   // any Input_Character except "
+    // Any Input_Character except "
+    : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029' | '#')
     ;
 ```
 

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -326,7 +326,8 @@ namespace System.Collections.Generic
 
 namespace System.Diagnostics
 {
-    [AttributeUsageAttribute(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+    [AttributeUsageAttribute(AttributeTargets.Method | AttributeTargets.Class,
+                             AllowMultiple = true)]
     public sealed class ConditionalAttribute : Attribute
     {
         public ConditionalAttribute(string conditionString);

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -788,7 +788,8 @@ Fixed-size buffers are only permitted in struct declarations and may only occur 
 
 ```ANTLR
 fixed_size_buffer_declaration
-    : attributes? fixed_size_buffer_modifier* 'fixed' buffer_element_type fixed_size_buffer_declarator+ ';'
+    : attributes? fixed_size_buffer_modifier* 'fixed' buffer_element_type
+      fixed_size_buffer_declarator+ ';'
     ;
 
 fixed_size_buffer_modifier


### PR DESCRIPTION
This does *not* change grammar.md; once we've agreed on grammar
changes, the grammar extraction tool can do that.

The grammar changes are almost all a matter of moving end-of-line
comments to line-above-production comments. In some places these
have been done even when the line wasn't too long, just for
consistency. (The casing of the comment has been changed slightly in
some cases as well; somehow sentence fragments feel more
acceptable for end-of-line than line-above-production comments.)

In some cases very long productions have just been split over more
lines.

Fixes #434.