### PR TITLE
Fix tests by performing conversion in constructor

### DIFF
--- a/tools/MarkdownConverter.Tests/MarkdownSourceConverterTests.cs
+++ b/tools/MarkdownConverter.Tests/MarkdownSourceConverterTests.cs
@@ -35,7 +35,7 @@ namespace MarkdownConverter.Tests
             // Gather all the paragraphs together, but remove all namespaces aliases so our test documents can be simpler.
             // (While a single declaration of the namespace in the root element works as a default for element names,
             // it doesn't help with attribute names.)
-            var paragraphs = converter.Paragraphs().ToList();
+            var paragraphs = converter.Paragraphs.ToList();
             XDocument actualXDocument = XDocument.Parse($@"<doc>{string.Join("\r\n", paragraphs.Select(p => p.OuterXml))}</doc>");
             // Remove attributes
             foreach (var element in actualXDocument.Root!.Descendants())

--- a/tools/MarkdownConverter/Converter/MarkdownSourceConverter.cs
+++ b/tools/MarkdownConverter/Converter/MarkdownSourceConverter.cs
@@ -55,6 +55,8 @@ namespace MarkdownConverter.Converter
         private readonly ConversionContext context;
         private readonly string filename;
         private readonly Reporter reporter;
+        
+        public IReadOnlyList<OpenXmlCompositeElement> Paragraphs { get; }
 
         public MarkdownSourceConverter(
             MarkdownDocument markdownDocument,
@@ -69,10 +71,8 @@ namespace MarkdownConverter.Converter
             this.filename = filename;
             this.reporter = reporter;
             context = spec.Context;
+            Paragraphs = Paragraphs2Paragraphs(markdownDocument.Paragraphs).ToList();
         }
-
-        public IEnumerable<OpenXmlCompositeElement> Paragraphs() =>
-            Paragraphs2Paragraphs(markdownDocument.Paragraphs);
 
         IEnumerable<OpenXmlCompositeElement> Paragraphs2Paragraphs(IEnumerable<MarkdownParagraph> pars) =>
             pars.SelectMany(md => Paragraph2Paragraphs(md));

--- a/tools/MarkdownConverter/Converter/MarkdownSpecConverter.cs
+++ b/tools/MarkdownConverter/Converter/MarkdownSpecConverter.cs
@@ -36,7 +36,7 @@ namespace MarkdownConverter.Converter
                         spec: spec,
                         filename: fileName,
                         reporter.WithFileName(fileName));
-                    foreach (var p in converter.Paragraphs())
+                    foreach (var p in converter.Paragraphs)
                     {
                         body.AppendChild(p);
                     }


### PR DESCRIPTION
We really don't want to perform a new conversion every time
Paragraphs() is called, causing more warnings, more changes to the
context etc. Admittedly doing work in the constructor isn't great
either, but I'm okay with that for now.

Fixes #502