### PR TITLE
Indent lists in notes

### DIFF
--- a/tools/MarkdownConverter.Tests/MarkdownSourceConverterTests.cs
+++ b/tools/MarkdownConverter.Tests/MarkdownSourceConverterTests.cs
@@ -22,7 +22,8 @@ namespace MarkdownConverter.Tests
         [InlineData("note")]
         [InlineData("code-block-in-list")]
         [InlineData("table-in-list")]
-        public void SingleResourceConversion(string name)
+        [InlineData("list-in-note", true)]
+        public void SingleResourceConversion(string name, bool includeNumbering = false)
         {
             var reporter = new Reporter(TextWriter.Null);
             var expectedXml = ReadResource($"{name}.xml");
@@ -39,8 +40,11 @@ namespace MarkdownConverter.Tests
             // Gather all the paragraphs together, but remove all namespaces aliases so our test documents can be simpler.
             // (While a single declaration of the namespace in the root element works as a default for element names,
             // it doesn't help with attribute names.)
+            // We optionally include the numbering details - this is basically for tests where list indentation is important.
             var paragraphs = converter.Paragraphs.ToList();
-            XDocument actualXDocument = XDocument.Parse($@"<doc>{string.Join("\r\n", paragraphs.Select(p => p.OuterXml))}</doc>");
+            string? numberingXml = includeNumbering ? resultDoc.MainDocumentPart?.NumberingDefinitionsPart?.Numbering?.OuterXml : null;
+            string paragraphsXml = string.Join("\r\n", paragraphs.Select(p => p.OuterXml));
+            XDocument actualXDocument = XDocument.Parse($@"<doc>{numberingXml}{paragraphsXml}</doc>");
             // Remove attributes
             foreach (var element in actualXDocument.Root!.Descendants())
             {

--- a/tools/MarkdownConverter.Tests/list-in-note.md
+++ b/tools/MarkdownConverter.Tests/list-in-note.md
@@ -1,0 +1,8 @@
+﻿# 1 Heading
+
+> *Note:* this is a note.
+>
+> - List level 1
+>   - List level 2
+>
+> *end note*

--- a/tools/MarkdownConverter.Tests/list-in-note.xml
+++ b/tools/MarkdownConverter.Tests/list-in-note.xml
@@ -1,0 +1,107 @@
+﻿<doc>
+  <numbering>
+    <abstractNum abstractNumId="1">
+      <multiLevelType val="multilevel" />
+      <lvl ilvl="0">
+        <start val="1" />
+        <numFmt val="bullet" />
+        <lvlText val="·" />
+        <pPr>
+          <ind left="1080" hanging="360" />
+        </pPr>
+        <rPr>
+          <rFonts hint="default" ascii="Symbol" hAnsi="Symbol" eastAsia="Times new Roman" cs="Times new Roman" />
+        </rPr>
+      </lvl>
+      <lvl ilvl="1">
+        <start val="1" />
+        <numFmt val="bullet" />
+        <lvlText val="o" />
+        <pPr>
+          <ind left="1440" hanging="360" />
+        </pPr>
+        <rPr>
+          <rFonts hint="default" ascii="Courier New" hAnsi="Courier New" cs="Courier New" />
+        </rPr>
+      </lvl>
+      <lvl ilvl="2">
+        <start val="1" />
+        <numFmt val="lowerRoman" />
+        <lvlText val="%3." />
+        <pPr>
+          <ind left="1800" hanging="360" />
+        </pPr>
+      </lvl>
+      <lvl ilvl="3">
+        <start val="1" />
+        <numFmt val="lowerRoman" />
+        <lvlText val="%4." />
+        <pPr>
+          <ind left="2160" hanging="360" />
+        </pPr>
+      </lvl>
+    </abstractNum>
+    <num numId="1">
+      <abstractNumId val="1" />
+    </num>
+  </numbering>
+  <p>
+    <pPr>
+      <pStyle val="Heading1" />
+    </pPr>
+    <bookmarkStart name="_Toc00001" id="1" />
+    <r>
+      <t space="preserve">Heading</t>
+    </r>
+    <bookmarkEnd id="1" />
+  </p>
+  <p>
+    <pPr>
+      <ind left="540" />
+    </pPr>
+    <r>
+      <rPr>
+        <i />
+      </rPr>
+      <t space="preserve">Note:</t>
+    </r>
+    <r>
+      <t space="preserve"> this is a note.</t>
+    </r>
+  </p>
+  <p>
+    <pPr>
+      <numPr>
+        <pStyle val="ListParagraph" />
+        <ilvl val="0" />
+        <numId val="1" />
+      </numPr>
+    </pPr>
+    <r>
+      <t space="preserve">List level 1</t>
+    </r>
+  </p>
+  <p>
+    <pPr>
+      <numPr>
+        <pStyle val="ListParagraph" />
+        <ilvl val="1" />
+        <numId val="1" />
+      </numPr>
+    </pPr>
+    <r>
+      <t space="preserve">List level 2</t>
+    </r>
+  </p>
+  <p>
+    <pPr>
+      <ind left="540" />
+    </pPr>
+    <r>
+      <rPr>
+        <i />
+      </rPr>
+      <t space="preserve">end note</t>
+    </r>
+  </p>
+</doc>


### PR DESCRIPTION
Fixes #435 (and extract some constants which were duplicated in many places)

I've checked that this looks appropriate in 6.4.3, 8.3.5 and 17.6.2, which were all mentioned in that issue. Given that those ones are fine, I don't expect to see any problems elsewhere.