### PR TITLE
Note that an enum can be a generic type

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -21,7 +21,7 @@ A *class_declaration* consists of an optional set of *attributes* ([§21](attrib
 
 A class declaration shall not supply a *type_parameter_constraints_clause*s unless it also supplies a *type_parameter_list*.
 
-A class declaration that supplies a *type_parameter_list* is a generic class declaration. Additionally, any class nested inside a generic class declaration or a generic struct declaration is itself a generic class declaration, since type arguments for the containing type shall be supplied to create a constructed type.
+A class declaration that supplies a *type_parameter_list* is a generic class declaration. Additionally, any class nested inside a generic class declaration or a generic struct declaration is itself a generic class declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
 
 ### 14.2.2 Class modifiers
 

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -33,7 +33,7 @@ It is a compile-time error for the same modifier to appear multiple times in a d
 
 A delegate declaration shall not supply any *type_parameter_constraints_clause*s unless it also supplies a *variant_type_parameter_list*.
 
-A delegate declaration that supplies a *variant_type_parameter_list* is a generic delegate declaration. Additionally, any delegate nested inside a generic class declaration or a generic struct declaration is itself a generic delegate declaration, since type arguments for the containing type shall be supplied to create a constructed type.
+A delegate declaration that supplies a *variant_type_parameter_list* is a generic delegate declaration. Additionally, any delegate nested inside a generic class declaration or a generic struct declaration is itself a generic delegate declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
 
 The `new` modifier is only permitted on delegates declared within another type, in which case it specifies that such a delegate hides an inherited member by the same name, as described in [§14.3.5](classes.md#1435-the-new-modifier).
 

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -62,6 +62,8 @@ An enum declaration that does not explicitly declare an underlying type has an u
 
 > *Note*: C# allows a trailing comma in an *enum_body*, just like it allows one in an *array_initializer* ([§16.7](arrays.md#167-array-initializers)). *end note*
 
+An enum declaration cannot include a type parameter list, but any enum nested inside a generic class declaration or a generic struct declaration is a generic enum declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
+
 ## 18.3 Enum modifiers
 
 An *enum_declaration* may optionally include a sequence of enum modifiers:

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -24,7 +24,7 @@ An *interface_declaration* consists of an optional set of *attributes* ([§21](a
 
 An interface declaration shall not supply a *type_parameter_constraints_clause*s unless it also supplies a *type_parameter_list*.
 
-An interface declaration that supplies a *type_parameter_list* is a generic interface declaration. Additionally, any interface nested inside a generic class declaration or a generic struct declaration is itself a generic interface declaration, since type arguments for the containing type shall be supplied to create a constructed type.
+An interface declaration that supplies a *type_parameter_list* is a generic interface declaration. Additionally, any interface nested inside a generic class declaration or a generic struct declaration is itself a generic interface declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
 
 ### 17.2.2 Interface modifiers
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -25,7 +25,7 @@ A *struct_declaration* consists of an optional set of *attributes* ([§21](attri
 
 A struct declaration shall not supply a *type_parameter_constraints_clauses* unless it also supplies a *type_parameter_list*.
 
-A struct declaration that supplies a *type_parameter_list* is a generic struct declaration. Additionally, any struct nested inside a generic class declaration or a generic struct declaration is itself a generic struct declaration, since type arguments for the containing type shall be supplied to create a constructed type.
+A struct declaration that supplies a *type_parameter_list* is a generic struct declaration. Additionally, any struct nested inside a generic class declaration or a generic struct declaration is itself a generic struct declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
 
 ### 15.2.2 Struct modifiers
 


### PR DESCRIPTION
Also link to the constructed types clause for all kinds of type,
which clarifies why we classify nested types that don't themselves
declare type parameters as generic types.

Fixes #482.