### PR TITLE
Fix formatting issues around code

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -641,7 +641,7 @@ The use of conditional methods in an inheritance chain can be confusing. Calls m
 >     public override void M()
 >     {
 >         Console.WriteLine("Class2.M executed");
->         base.M(); // base.M is not called!\
+>         base.M(); // base.M is not called!
 >     }
 > }
 > 
@@ -745,9 +745,9 @@ When an optional parameter is annotated with one of the caller-info attributes, 
 > ...
 >
 > public void Log(
->    [CallerLineNumber] int line = -1,
->    [CallerFilePath] string path = null,
->    [CallerMemberName] string name = null
+>     [CallerLineNumber] int line = -1,
+>     [CallerFilePath] string path = null,
+>     [CallerMemberName] string name = null
 > )
 > {
 >     Console.WriteLine((line < 0) ? "No line" : "Line "+ line);

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -13,7 +13,7 @@ A *class_declaration* is a *type_declaration* ([§13.7](namespaces.md#137-type-d
 ```ANTLR
 class_declaration
   : attributes? class_modifier* 'partial'? 'class' identifier type_parameter_list?
-  class_base? type_parameter_constraints_clause* class_body ';'?
+    class_base? type_parameter_constraints_clause* class_body ';'?
   ;
 ```
 
@@ -201,7 +201,7 @@ The base class specified in a class declaration can be a constructed class type 
 > ```csharp
 > class Base<T> {}
 > class Extend : Base<int>     // Valid, non-constructed class with constructed base class
-> class Extend<V> : V {}        // Error, type parameter used as base class
+> class Extend<V> : V {}       // Error, type parameter used as base class
 > class Extend<V> : Base<V> {} // Valid, type parameter used as type argument for base class
 > ```
 > *end example*
@@ -214,9 +214,11 @@ In determining the meaning of the direct base class specification `A` of a clas
 
 > *Example*: The following
 > ```csharp
-> class X<T> {
+> class X<T>
+> {
 >     public class Y{}
 > }
+>
 > class Z : X<Z.Y> {}
 > ```
 > is in error since in the base class specification `X<Z.Y>` the direct base class of `Z` is considered to be object, and hence (by the rules of [§7.8](basic-concepts.md#78-namespace-and-type-names)) `Z` is not considered to have a member `Y`. *end example*
@@ -435,14 +437,14 @@ It is a compile-time error for *type_parameter_constraints* having a *primary_co
 >     T GetKey();
 > }
 >
-> class Printer<T> where T: IPrintable {...}
-> class SortedList<T> where T: IComparable<T> {...}
+> class Printer<T> where T : IPrintable {...}
+> class SortedList<T> where T : IComparable<T> {...}
 >
 > class Dictionary<K,V>
->     where K: IComparable<K>
->     where V: IPrintable, IKeyProvider<K>, new()
+>     where K : IComparable<K>
+>     where V : IPrintable, IKeyProvider<K>, new()
 > {
-> ...
+>     ...
 > }
 > ```
 > The following example is in error because it causes a circularity in the dependency graph of the type parameters:
@@ -457,8 +459,8 @@ It is a compile-time error for *type_parameter_constraints* having a *primary_co
 > The following examples illustrate additional invalid situations:
 > ```csharp
 > class Sealed<S,T>
->     where S: T
->     where T: struct // Error, `T` is sealed
+>     where S : T
+>     where T : struct // Error, `T` is sealed
 > {
 >     ...
 > }
@@ -467,16 +469,16 @@ It is a compile-time error for *type_parameter_constraints* having a *primary_co
 > class B {...}
 >
 > class Incompat<S,T>
->     where S: A, T
->     where T: B // Error, incompatible class-type constraints
+>     where S : A, T
+>     where T : B // Error, incompatible class-type constraints
 > {
 >     ...
 > }
 >
 > class StructWithClass<S,T,U>
->     where S: struct, T
->     where T: U
->     where U: A // Error, A incompatible with struct
+>     where S : struct, T
+>     where T : U
+>     where U : A // Error, A incompatible with struct
 > {
 >     ...
 > }
@@ -1033,28 +1035,20 @@ A nested type has access to all of the members that are accessible to its contai
 > *Example*: The example
 > ```csharp
 > using System;
+>
 > class C
 > {
->     private static void F()
->     {
->         Console.WriteLine("C.F");
->     }
+>     private static void F() => Console.WriteLine("C.F");
 >
 >     public class Nested
 >     {
->         public static void G()
->         {
->             F();
->         }
+>         public static void G() => F();
 >     }
 > }
 >
 > class Test
 > {
->     static void Main()
->     {
->         C.Nested.G();
->     }
+>     static void Main() => C.Nested.G();
 > }
 > ```
 > shows a class `C` that contains a nested class `Nested`. Within `Nested`, the method `G` calls the static method `F` defined in `C`, and `F` has private declared accessibility. *end example*
@@ -1066,10 +1060,7 @@ A nested type also may access protected members defined in a base type of its co
 > using System;
 > class Base
 > {
->     protected void F()
->     {
->         Console.WriteLine("Base.F");
->     }
+>     protected void F() => Console.WriteLine("Base.F");
 > }
 >
 > class Derived: Base
@@ -1464,6 +1455,7 @@ These restrictions ensure that all threads will observe volatile writes performe
 > ```csharp
 > using System;
 > using System.Threading;
+>
 > class Test
 > {
 >     public static int result;
@@ -1507,6 +1499,7 @@ The initial value of a field, whether it be a static field or an instance field,
 > *Example*: The example
 > ```csharp
 > using System;
+>
 > class Test
 > {
 >     static bool b;
@@ -1586,6 +1579,7 @@ The static field variable initializers of a class correspond to a sequence of as
 > *Example*: The example
 > ```csharp
 > using System;
+>
 > class Test
 > {
 >     static void Main()
@@ -1625,6 +1619,7 @@ The static field variable initializers of a class correspond to a sequence of as
 > because the execution of `X`’s initializer and `Y`’s initializer could occur in either order; they are only constrained to occur before the references to those fields. However, in the example:
 > ```csharp
 > using System;
+>
 > class Test
 > {
 >     static void Main()
@@ -2063,10 +2058,7 @@ When performing overload resolution, a method with a parameter array might be ap
 >
 > class Test
 > {
->     void F(params string[] array)
->     {
->         Console.WriteLine(array == null);
->     }
+>     void F(params string[] array) => Console.WriteLine(array == null);
 > 
 >     static void Main()
 >     {
@@ -2076,7 +2068,7 @@ When performing overload resolution, a method with a parameter array might be ap
 > }
 > ```
 > produces the output:
-> ```csharp
+> ```console
 > True
 > False
 > ```

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -447,7 +447,7 @@ If dynamic binding of the conversion is not desired, the expression can be first
 > ```csharp
 > object o = "1";
 > dynamic d = "2";
-> var c1 = (C)o; // Compiles, but explicit reference conversion fails\
+> var c1 = (C)o; // Compiles, but explicit reference conversion fails
 > var c2 = (C)d; // Compiles and user defined conversion succeeds
 > ```
 > The best conversion of `o` to `C` is found at compile-time to be an explicit reference conversion. This fails at run-time, because `"1"` is not in fact a `C`. The conversion of `d` to `C` however, as an explicit dynamic conversion, is suspended to run-time, where a user defined conversion from the run-time type of `d` (`string`) to `C` is found, and succeeds. *end example*

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -162,10 +162,10 @@ An instance of a delegate is created by a *delegate_creation_expression* ([§11.
 > {
 >     static void Main()
 >     {
->         D cd1 = new D(C.M1); // static method
+>         D cd1 = new D(C.M1); // Static method
 >         C t = new C();
->         D cd2 = new D(t.M2); // instance method
->         D cd3 = new D(cd2); // another delegate
+>         D cd2 = new D(t.M2); // Instance method
+>         D cd3 = new D(cd2);  // Another delegate
 >     }
 > }
 > ```
@@ -193,15 +193,15 @@ Delegates are combined using the binary `+` ([§11.9.5](expressions.md#1195-add
 >     {
 >         D cd1 = new D(C.M1); // M1 - one entry in invocation list
 >         D cd2 = new D(C.M2); // M2 - one entry
->         D cd3 = cd1 + cd2; // M1 + M2 - two entries
->         D cd4 = cd3 + cd1; // M1 + M2 + M1 - three entries
->         D cd5 = cd4 + cd3; // M1 + M2 + M1 + M1 + M2 - five entries
->         D td3 = new D(cd3); // [M1 + M2] - ONE entry in invocation
->                             // list, which is itself a list of two methods.
->         D td4 = td3 + cd1; // [M1 + M2] + M1 - two entries
->         D cd6 = cd4 - cd2; // M1 + M1 - two entries in invocation list
->         D td6 = td4 - cd2; // [M1 + M2] + M1 - two entries in
->                            // invocation list, but still three methods called, M2 not removed.
+>         D cd3 = cd1 + cd2;   // M1 + M2 - two entries
+>         D cd4 = cd3 + cd1;   // M1 + M2 + M1 - three entries
+>         D cd5 = cd4 + cd3;   // M1 + M2 + M1 + M1 + M2 - five entries
+>         D td3 = new D(cd3);  // [M1 + M2] - ONE entry in invocation
+>                              // list, which is itself a list of two methods.
+>         D td4 = td3 + cd1;   // [M1 + M2] + M1 - two entries
+>         D cd6 = cd4 - cd2;   // M1 + M1 - two entries in invocation list
+>         D td6 = td4 - cd2;   // [M1 + M2] + M1 - two entries in invocation list,
+>                              // but still three methods called, M2 not removed.
 >    }
 > }
 > ```

--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -554,7 +554,7 @@ where
 /// <typeparam name="T">The type stored by the list.</typeparam>
 public class MyList<T>
 {
-...
+   ...
 }
 ```
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -843,7 +843,8 @@ The ***inferred return type*** is determined as follows:
 > 
 > The following example demonstrates how anonymous function type inference allows type information to “flow” between arguments in a generic method invocation. Given the method:
 > ```csharp
-> static Z F<X,Y,Z>(X value, Func<X,Y> f1, Func<Y,Z> f2) {
+> static Z F<X,Y,Z>(X value, Func<X,Y> f1, Func<Y,Z> f2)
+> {
 >    return f2(f1(value));
 > }
 > ```
@@ -3683,13 +3684,13 @@ The predefined subtraction operators are listed below. The operators all subtrac
   >         D cd2 = new D(C.M2);
   >         D delList = null;
   > 
-  >         delList = null - cd1;                                         // null
-  >         delList = (cd1 + cd2 + cd2 + cd1) - null;                     // M1 + M2 + M2 + M1
-  >         delList = (cd1 + cd2 + cd2 + cd1) - cd1;                      // M1 + M2 + M2
-  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd1 + cd2);              // M2 + M1
-  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd2 + cd2);              // M1 + M1
-  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd2 + cd1);              // M1 + M2
-  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd1 + cd1);              // M1 + M2 + M2 + M1
+  >         delList = null - cd1;                                // null
+  >         delList = (cd1 + cd2 + cd2 + cd1) - null;            // M1 + M2 + M2 + M1
+  >         delList = (cd1 + cd2 + cd2 + cd1) - cd1;             // M1 + M2 + M2
+  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd1 + cd2);     // M2 + M1
+  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd2 + cd2);     // M1 + M1
+  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd2 + cd1);     // M1 + M2
+  >         delList = (cd1 + cd2 + cd2 + cd1) - (cd1 + cd1);     // M1 + M2 + M2 + M1
   >         delList = (cd1 + cd2 + cd2 + cd1) - (cd1 + cd2 + cd2 + cd1);  // null
   >     }
   > }
@@ -3967,8 +3968,12 @@ Unless one of these conditions is true, a binding-time error occurs.
 > ```csharp
 > class C<T>
 > {
->    void F(T x) {
->       if (x == null) throw new ArgumentNullException();
+>    void F(T x)
+>    {
+>       if (x == null)
+>       {
+>           throw new ArgumentNullException();
+>       }
 >       ...
 >    }
 > }

--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -236,19 +236,19 @@ An *extern_alias_directive* or *using_alias_directive* makes an alias available 
 > ```
 > the scopes of the alias directives that introduce `R1` and `R2` only extend to member declarations in the namespace body in which they are contained, so `R1` and `R2` are unknown in the second namespace declaration. However, placing the alias directives in the containing compilation unit causes the alias to become available within both namespace declarations:
 > ```csharp
->    extern alias R1;
+> extern alias R1;
 >
->    using R2 = N1.N2;
+> using R2 = N1.N2;
 >
->    namespace N3
->    {
->        class B : R1::A, R2.I {}
->    }
+> namespace N3
+> {
+>     class B : R1::A, R2.I {}
+> }
 >
->    namespace N3
->    {
->        class C : R1::A, R2.I {}
->    }
+> namespace N3
+> {
+>     class C : R1::A, R2.I {}
+> }
 > ```
 > *end example*
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -849,13 +849,15 @@ The body of the `finally` block is constructed according to the following steps:
 
 - If there is an implicit conversion from `E` to the `System.IDisposable` interface, then
   - If `E` is a non-nullable value type then the `finally` clause is expanded to the semantic equivalent of:
-  ```csharp
+
+    ```csharp
     finally
     {
         ((System.IDisposable)e).Dispose();
     }
     ```
   - Otherwise the `finally` clause is expanded to the semantic equivalent of:
+
     ```csharp
     finally
     {
@@ -868,10 +870,12 @@ The body of the `finally` block is constructed according to the following steps:
     ```
     except that if `E` is a value type, or a type parameter instantiated to a value type, then the conversion of `e` to `System.IDisposable` shall not cause boxing to occur.
 - Otherwise, if `E` is a sealed type, the `finally` clause is expanded to an empty block:
+
   ```csharp
   finally {}
   ```
 - Otherwise, the `finally` clause is expanded to:
+  
   ```csharp
   finally
   {

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -209,7 +209,10 @@ The default value of a struct corresponds to the value returned by the default c
 >
 >     public KeyValuePair(string key, string value)
 >     {
->         if (key == null || value == null) throw new ArgumentException();
+>         if (key == null || value == null)
+>         {
+>             throw new ArgumentException();
+>         }
 >
 >         this.key = key;
 >         this.value = value;
@@ -271,6 +274,7 @@ Similarly, boxing never implicitly occurs when accessing a member on a constrain
 > *Example*:
 > ```csharp
 > using System;
+>
 > interface ICounter
 > {
 >     void Increment();
@@ -284,15 +288,16 @@ Similarly, boxing never implicitly occurs when accessing a member on a constrain
 >
 >     void ICounter.Increment() => value++;
 > }
+>
 > class Program
 > {
 >     static void Test<T>() where T : ICounter, new()
 >     {
 >         T x = new T();
 >         Console.WriteLine(x);
->         x.Increment(); // Modify x
+>         x.Increment();              // Modify x
 >         Console.WriteLine(x);
->         ((ICounter)x).Increment(); // Modify boxed copy of x
+>         ((ICounter)x).Increment();  // Modify boxed copy of x
 >         Console.WriteLine(x);
 >     }
 >

--- a/standard/types.md
+++ b/standard/types.md
@@ -425,8 +425,8 @@ When a *namespace_or_type_name* is evaluated, only generic types with the correc
 >
 >     class X
 >     {
->         Queue q1; // Non-generic Widgets.Queue\
->         Queue<int> q2; // Generic Widgets.Queue\
+>         Queue q1;      // Non-generic Widgets.Queue
+>         Queue<int> q2; // Generic Widgets.Queue
 >     }
 > }
 > ```

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -67,6 +67,7 @@ Other than establishing an unsafe context, thus permitting the use of pointer ty
 >         ...
 >     }
 > }
+>
 > public class B : A
 > {
 >     public override void F() 
@@ -84,6 +85,7 @@ Other than establishing an unsafe context, thus permitting the use of pointer ty
 > {
 >     public virtual void F(char* p) {...}
 > }
+>
 > public class B: A
 > {
 >     public unsafe override void F(char* p) {...}
@@ -388,6 +390,7 @@ A pointer member access of the form `P->I` is evaluated exactly as `(*P).I`. For
 >     public int y;
 >     public override string ToString() => $"({x},{y})";
 > }
+>
 > class Test
 > {
 >     static void Main()
@@ -492,6 +495,7 @@ The `&` operator does not require its argument to be definitely assigned, but fo
 > *Example*: In the following code
 > ```csharp
 > using System;
+>
 > class Test
 > {
 >     static void Main()
@@ -649,10 +653,12 @@ Fixed objects can cause fragmentation of the heap (because they can’t be moved
 > {
 >     static int x;
 >     int y;
+>
 >     unsafe static void F(int* p)
 >     {
 >         *p = 1;
 >     }
+>
 >     static void Main()
 >     {
 >         Test t = new Test();
@@ -678,6 +684,7 @@ Within a `fixed` statement that obtains a pointer `p` to an array instance `a`, 
 > *Example*:
 > ```csharp
 > using System;
+>
 > class Test
 > {
 >     static void Main()
@@ -729,6 +736,7 @@ Within a `fixed` statement that obtains a pointer `p` to an array instance `a`, 
 >             *p++ = value;
 >         }
 >     }
+>
 >     static void Main()
 >     {
 >         int[] a = new int[100];
@@ -754,6 +762,7 @@ A `char*` value produced by fixing a string instance always points to a null-ter
 >         for (int i = 0; p[i] != '\\0'; ++i)
 >             Console.WriteLine(p[i]);
 >     }
+>
 >     static void Main()
 >     {
 >         unsafe
@@ -864,6 +873,7 @@ The subsequent elements of the fixed-size buffer can be accessed using pointer o
 >     public int size;
 >     public fixed char name[32];
 > }
+>
 > class Test
 > {
 >     unsafe static void PutString(string s, char* buffer, int bufSize)
@@ -882,6 +892,7 @@ The subsequent elements of the fixed-size buffer can be accessed using pointer o
 >             buffer[i] = (char)0;
 >         }
 >     }
+>
 >     unsafe static void Main()
 >     {
 >         Font f;
@@ -925,11 +936,15 @@ All stack-allocated memory blocks created during the execution of a function mem
 > *Example*: In the following code
 > ```csharp
 > using System;
+>
 > class Test
 > {
 >     static string IntToString(int value)
 >     {
->         if (value == int.MinValue) return "-2147483648";
+>         if (value == int.MinValue)
+>         {
+>             return "-2147483648";
+>         }
 >         int n = value >= 0 ? value : -value;
 >         unsafe
 >         {
@@ -947,6 +962,7 @@ All stack-allocated memory blocks created during the execution of a function mem
 >             return new string(p, 0, (int)(buffer + 16 - p));
 >         }
 >     }
+>
 >     static void Main()
 >     {
 >         Console.WriteLine(IntToString(12345));


### PR DESCRIPTION
This was originally intended to find examples with over-long lines, but found a bunch of minor issues along the way.

Fixes #511 as far as I think we want to - I don't think it's worth going to extraordinary lengths to detect the issues.

(This was checked with the Word converter in the "latest possible" state, i.e. after applying all the other open PRs for code.)