### PR TITLE
configure markdown lint

### DIFF
--- a/.github/workflows/markdownlint-problem-matcher.json
+++ b/.github/workflows/markdownlint-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "markdownlint",
+            "pattern": [
+                {
+                    "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "code": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,38 @@
+name: Markdownlint
+
+on:
+  push:
+    branches:
+      - draft-v6
+    paths:
+      - "**/*.md"
+      - ".markdownlint.json"
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".markdownlint.json"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'The reason for running the workflow'
+        required: true
+        default: 'Manual run'
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+    permissions:
+        statuses: write
+
+    steps:
+    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
+    - name: Use Node.js
+      uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d #@v1
+      with:
+        node-version: 12.x
+    - name: Run Markdownlint
+      run: |
+        echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
+        npm i -g markdownlint-cli
+        markdownlint "**/*.md"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,7 @@
 {
     "default": true,
+    "MD013": false,
+    "MD033": false,
     "MD046": {
         "style": "fenced"
     },

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,6 +12,7 @@
         ]
     },
 
+    "MD005" : false,
     "MD007" : false,
     "MD009" : false,
     "MD010" : false,
@@ -21,11 +22,14 @@
     "MD028" : false,
     "MD030" : false,
     "MD031" : false,
+    "MD032" : false,
     "MD036" : false,
     "MD037" : false,
+    "MD038" : false,
     "MD040" : false,
     "MD041" : false,
-    "MD047" : false
+    "MD047" : false,
+    "MD050" : false
 
 
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,7 @@
     "default": true,
     "MD013": false,
     "MD033": false,
+    "MD034" : false,
     "MD046": {
         "style": "fenced"
     },
@@ -9,5 +10,22 @@
         "code_blocks": false,
         "names": [
         ]
-    }
+    },
+
+    "MD007" : false,
+    "MD009" : false,
+    "MD010" : false,
+    "MD012" : false,
+    "MD022" : false,
+    "MD027" : false,
+    "MD028" : false,
+    "MD030" : false,
+    "MD031" : false,
+    "MD036" : false,
+    "MD037" : false,
+    "MD040" : false,
+    "MD041" : false,
+    "MD047" : false
+
+
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+    "default": true,
+    "MD046": {
+        "style": "fenced"
+    },
+    "proper-names": {
+        "code_blocks": false,
+        "names": [
+        ]
+    }
+}


### PR DESCRIPTION
First configuration of markdown lint. We can determine which warnings we want to enable or disable from a first test run.

We can adjust what's reported by adding items from the [markdown lint rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md).

