### PR TITLE
Remove last vestiges of "antlr" language for code blocks

### DIFF
--- a/tools/MarkdownConverter/Converter/MarkdownSourceConverter.cs
+++ b/tools/MarkdownConverter/Converter/MarkdownSourceConverter.cs
@@ -356,7 +356,6 @@ namespace MarkdownConverter.Converter
                         lines = Colorize.PlainText(code);
                         break;
                     case "ANTLR":
-                    case "antlr":
                         lines = Colorize.PlainText(code);
                         break;
                     default:


### PR DESCRIPTION
All our grammar blocks use ANTLR instead.

Fixes #432.