### PR TITLE
Squash markdown lint warnings.

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD009" : false,
     "MD010" : false,
     "MD012" : false,
     "MD022" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,6 +12,7 @@
         ]
     },
 
+    "MD009" : false,
     "MD010" : false,
     "MD012" : false,
     "MD022" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD005" : false,
     "MD007" : false,
     "MD009" : false,
     "MD010" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD007" : false,
     "MD009" : false,
     "MD010" : false,
     "MD012" : false,

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3892,10 +3892,10 @@ It is not possible to directly redefine a pre-defined conversion. Thus, conversi
 
 In cases where a pre-defined conversion exists between two types, any user-defined conversions between those types are ignored. Specifically:
 
--  If a pre-defined implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from type `S` to type `T`, all user-defined conversions (implicit or explicit) from `S` to `T` are ignored.
--  If a pre-defined explicit conversion ([§10.3](conversions.md#103-explicit-conversions)) exists from type `S` to type `T`, any user-defined explicit conversions from `S` to `T` are ignored. Furthermore:
-  -  If either `S` or `T` is an interface type, user-defined implicit conversions from `S` to `T` are ignored.
-  -  Otherwise, user-defined implicit conversions from `S` to `T` are still considered.
+- If a pre-defined implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from type `S` to type `T`, all user-defined conversions (implicit or explicit) from `S` to `T` are ignored.
+- If a pre-defined explicit conversion ([§10.3](conversions.md#103-explicit-conversions)) exists from type `S` to type `T`, any user-defined explicit conversions from `S` to `T` are ignored. Furthermore:
+  - If either `S` or `T` is an interface type, user-defined implicit conversions from `S` to `T` are ignored.
+  - Otherwise, user-defined implicit conversions from `S` to `T` are still considered.
 
 For all types but `object`, the operators declared by the `Convertible<T>` type above do not conflict with pre-defined conversions.
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3894,8 +3894,8 @@ In cases where a pre-defined conversion exists between two types, any user-defin
 
 -  If a pre-defined implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from type `S` to type `T`, all user-defined conversions (implicit or explicit) from `S` to `T` are ignored.
 -  If a pre-defined explicit conversion ([§10.3](conversions.md#103-explicit-conversions)) exists from type `S` to type `T`, any user-defined explicit conversions from `S` to `T` are ignored. Furthermore:
-    -  If either `S` or `T` is an interface type, user-defined implicit conversions from `S` to `T` are ignored.
-    -  Otherwise, user-defined implicit conversions from `S` to `T` are still considered.
+  -  If either `S` or `T` is an interface type, user-defined implicit conversions from `S` to `T` are ignored.
+  -  Otherwise, user-defined implicit conversions from `S` to `T` are still considered.
 
 For all types but `object`, the operators declared by the `Convertible<T>` type above do not conflict with pre-defined conversions.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3366,7 +3366,7 @@ The predefined remainder operators are listed below. The operators all compute t
       <td><code>NaN</code></td>
     </tr>
   </table>
- - Decimal remainder:
+- Decimal remainder:
   ```csharp
   decimal operator %(decimal x, decimal y);
   ```

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1294,17 +1294,17 @@ In both cases, the argument list of the call consists of a *format string litera
 
 The format string literal is constructed as follows, where `N` is the number of interpolations in the *interpolated_string_expression*. The format string literal consists of, in order:
 
-  - The characters of the *Interpolated_Regular_String_Start* or *Interpolated_Verbatim_String_Start*
-  - The characters of the *Interpolated_Regular_String_Mid* or *Interpolated_Verbatim_String_Mid*, if any
-  - Then if `N ≥ 1` for each number `I` from `0` to `N-1`:
-    - A placeholder specification:
-      - A left brace (`{`) character
-      - The decimal representation of `I`
-      - Then, if the corresponding *regular_interpolation* or *verbatim_interpolation* has a *interpolation_minimum_width*, a comma (`,`) followed by the decimal representation of the value of the *constant_expression*
-      - The characters of the *Regular_Interpolation_Format* or *Verbatim_Interpolation_Format*, if any, of the corresponding *regular_interpolation* or *verbatim_interpolation*
-      - A right brace (`}`) character
-    - The characters of the *Interpolated_Regular_String_Mid* or *Interpolated_Verbatim_String_Mid* immediately following the corresponding interpolation, if any
-  - Finally the characters of the *Interpolated_Regular_String_End* or *Interpolated_Verbatim_String_End*.
+- The characters of the *Interpolated_Regular_String_Start* or *Interpolated_Verbatim_String_Start*
+- The characters of the *Interpolated_Regular_String_Mid* or *Interpolated_Verbatim_String_Mid*, if any
+- Then if `N ≥ 1` for each number `I` from `0` to `N-1`:
+  - A placeholder specification:
+    - A left brace (`{`) character
+    - The decimal representation of `I`
+    - Then, if the corresponding *regular_interpolation* or *verbatim_interpolation* has a *interpolation_minimum_width*, a comma (`,`) followed by the decimal representation of the value of the *constant_expression*
+    - The characters of the *Regular_Interpolation_Format* or *Verbatim_Interpolation_Format*, if any, of the corresponding *regular_interpolation* or *verbatim_interpolation*
+    - A right brace (`}`) character
+  - The characters of the *Interpolated_Regular_String_Mid* or *Interpolated_Verbatim_String_Mid* immediately following the corresponding interpolation, if any
+- Finally the characters of the *Interpolated_Regular_String_End* or *Interpolated_Verbatim_String_End*.
 
 The subsequent arguments are the *expression*s from the interpolations, if any, in order.
 
@@ -1314,12 +1314,12 @@ When an *interpolated_string_expression* contains multiple interpolations, the e
 
 This example uses the following format specification features:
 
- - the `X` format specification which formats integers as uppercase hexadecimal,
- - the default format for a `string` value is the value itself,
- - positive alignment values that right-justify within the specified minimum field width,
- - negative alignment values that left-justify within the specified minimum field width,
- - defined constants for the *interpolation_minimum_width*, and
- - that `{{` and `}}` are formatted as `{` and `}` respectively.
+- the `X` format specification which formats integers as uppercase hexadecimal,
+- the default format for a `string` value is the value itself,
+- positive alignment values that right-justify within the specified minimum field width,
+- negative alignment values that left-justify within the specified minimum field width,
+- defined constants for the *interpolation_minimum_width*, and
+- that `{{` and `}}` are formatted as `{` and `}` respectively.
 
 Given:
 

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -98,16 +98,16 @@ A type T is ***output-unsafe*** if one of the following holds:
 - `T` is a contravariant type parameter
 - `T` is an array type with an output-unsafe element type
 - `T` is an interface or delegate type `Sᵢ,... Aₑ` constructed from a generic type `S<Xᵢ, ... Xₑ>` where for at least one `Aᵢ` one of the following holds:
-    - `Xᵢ` is covariant or invariant and `Aᵢ` is output-unsafe.
-    - `Xᵢ` is contravariant or invariant and `Aᵢ` is input-unsafe.
+  - `Xᵢ` is covariant or invariant and `Aᵢ` is output-unsafe.
+  - `Xᵢ` is contravariant or invariant and `Aᵢ` is input-unsafe.
 
 A type T is ***input-unsafe*** if one of the following holds:
 
 - `T` is a covariant type parameter
 - `T` is an array type with an input-unsafe element type
 - `T` is an interface or delegate type  `S<Aᵢ,... Aₑ>` constructed from a generic type `S<Xᵢ, ... Xₑ>` where for at least one `Aᵢ` one of the following holds:
-    - `Xᵢ` is covariant or invariant and `Aᵢ` is input-unsafe.
-    - `Xᵢ` is contravariant or invariant and `Aᵢ` is output-unsafe.
+  - `Xᵢ` is covariant or invariant and `Aᵢ` is input-unsafe.
+  - `Xᵢ` is contravariant or invariant and `Aᵢ` is output-unsafe.
 
 Intuitively, an output-unsafe type is prohibited in an output position, and an input-unsafe type is prohibited in an input position.
 

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -10,12 +10,12 @@ The standard library is intended to be the minimum set of types and members requ
 
 It is expected that a conforming C# implementation will supply a significantly more extensive library that enables useful programs to be written. For example, a conforming implementation might extend this library by
 
- - Adding namespaces.
- - Adding types.
- - Adding members to non-interface types.
- - Adding intervening base classes or interfaces.
- - Having struct and class types implement additional interfaces.
- - Adding attributes (other than the `ConditionalAttribute`) to existing types and members.
+- Adding namespaces.
+- Adding types.
+- Adding members to non-interface types.
+- Adding intervening base classes or interfaces.
+- Having struct and class types implement additional interfaces.
+- Adding attributes (other than the `ConditionalAttribute`) to existing types and members.
 
 **End of informative text.**
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -620,6 +620,7 @@ unmanaged_type
 ```
 
 An *unmanaged_type* is any type that isn’t a *reference_type*, a *type_parameter*, or a constructed type, and contains no fields whose type is not an *unmanaged_type*. In other words, an *unmanaged_type* is one of the following:
+
 - `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal`, or `bool`.
 - Any *enum_type*.
 - Any user-defined *struct_type* that is not a constructed type and contains fields of *unmanaged_type*s only.

--- a/standard/types.md
+++ b/standard/types.md
@@ -624,4 +624,3 @@ An *unmanaged_type* is any type that isn’t a *reference_type*, a *type_paramet
 - Any *enum_type*.
 - Any user-defined *struct_type* that is not a constructed type and contains fields of *unmanaged_type*s only.
 - In unsafe code ([§22.2](unsafe-code.md#222-unsafe-contexts)), any *pointer_type* ([§22.3](unsafe-code.md#223-pointer-types)).
-

--- a/standard/types.md
+++ b/standard/types.md
@@ -594,13 +594,13 @@ The type `dynamic` uses dynamic binding, as described in detail in [§11.3.2](ex
 - Operations on expressions of type `dynamic` can be dynamically bound ([§11.3.3](expressions.md#1133-dynamic-binding)).
 - Type inference ([§11.6.3](expressions.md#1163-type-inference)) will prefer `dynamic` over `object` if both are candidates.
 - `dynamic` cannot be used as
-    - the type in an *object_creation_expression* ([§11.7.15.2](expressions.md#117152-object-creation-expressions))
-    - a *predefined_type* in a *member_access* ([§11.7.6.1](expressions.md#11761-general))
-    - the operand of the `typeof` operator
-    - an attribute argument
-    - a constraint
-    - an extension method type
-    - any part of a type argument within *struct_interfaces* ([§15.2.4](structs.md#1524-struct-interfaces)) or *interface_type_list* ([§14.2.4.1](classes.md#14241-general)).
+  - the type in an *object_creation_expression* ([§11.7.15.2](expressions.md#117152-object-creation-expressions))
+  - a *predefined_type* in a *member_access* ([§11.7.6.1](expressions.md#11761-general))
+  - the operand of the `typeof` operator
+  - an attribute argument
+  - a constraint
+  - an extension method type
+  - any part of a type argument within *struct_interfaces* ([§15.2.4](structs.md#1524-struct-interfaces)) or *interface_type_list* ([§14.2.4.1](classes.md#14241-general)).
 
 Because of this equivalence, the following holds:
 
@@ -620,8 +620,8 @@ unmanaged_type
 ```
 
 An *unmanaged_type* is any type that isn’t a *reference_type*, a *type_parameter*, or a constructed type, and contains no fields whose type is not an *unmanaged_type*. In other words, an *unmanaged_type* is one of the following:
- - `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal`, or `bool`.
- - Any *enum_type*.
- - Any user-defined *struct_type* that is not a constructed type and contains fields of *unmanaged_type*s only.
- - In unsafe code ([§22.2](unsafe-code.md#222-unsafe-contexts)), any *pointer_type* ([§22.3](unsafe-code.md#223-pointer-types)).
+- `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal`, or `bool`.
+- Any *enum_type*.
+- Any user-defined *struct_type* that is not a constructed type and contains fields of *unmanaged_type*s only.
+- In unsafe code ([§22.2](unsafe-code.md#222-unsafe-contexts)), any *pointer_type* ([§22.3](unsafe-code.md#223-pointer-types)).
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -341,8 +341,8 @@ For a statement *stmt* of the form:
 `return ;`
 
 - If *v* is an output parameter, then it shall be definitely assigned either:
- - before *stmt*
- - or at the end of the `finally` block of a `try`-`finally` or `try`-`catch`-`finally` that encloses the `return` statement.
+  - before *stmt*
+  - or at the end of the `finally` block of a `try`-`finally` or `try`-`catch`-`finally` that encloses the `return` statement.
 
 #### 9.4.4.14 Try-catch statements
 


### PR DESCRIPTION
This PR fixes (and enables) two of the MD warnings:

- [MD005](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md005---inconsistent-indentation-for-list-items-at-the-same-level): Inconsistent indentation for list items at the same level.
- [MD007](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md007---unordered-list-indentation): Unordered list indentation.