### PR TITLE
More markdown lint fixes

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD027" : false,
     "MD028" : false,
     "MD030" : false,
     "MD031" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD022" : false,
     "MD027" : false,
     "MD028" : false,
     "MD030" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD028" : false,
     "MD030" : false,
     "MD031" : false,
     "MD032" : false,

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -168,20 +168,14 @@ An array initializer consists of a sequence of variable initializers, enclosed b
 
 The context in which an array initializer is used determines the type of the array being initialized. In an array creation expression, the array type immediately precedes the initializer, or is inferred from the expressions in the array initializer. In a field or variable declaration, the array type is the type of the field or variable being declared. When an array initializer is used in a field or variable declaration,
 
-> *Example*:
-> ```csharp
-> int[] a = {0, 2, 4, 6, 8};
-> ```
-> *end example*
+```csharp
+int[] a = {0, 2, 4, 6, 8};
+```
+it is simply shorthand for an equivalent array creation expression:
 
-It is simply shorthand for an equivalent array creation expression:
-
-> *Example*:
-> ```csharp
-> int[] a = new int[] {0, 2, 4, 6, 8};
-> ```
-> *end example*
-
+```csharp
+int[] a = new int[] {0, 2, 4, 6, 8};
+```
 For a single-dimensional array, the array initializer shall consist of a sequence of expressions, each having an implicit conversion to the element type of the array ([§10.2](conversions.md#102-implicit-conversions)). The expressions initialize array elements in increasing order, starting with the element at index zero. The number of expressions in the array initializer determines the length of the array instance being created.
 
 > *Example*: The array initializer above creates an `int[]` instance of length 5 and then initializes the instance with the following values:

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -174,7 +174,7 @@ The context in which an array initializer is used determines the type of the arr
 > ```
 > *end example*
 
-> it is simply shorthand for an equivalent array creation expression:
+It is simply shorthand for an equivalent array creation expression:
 
 > *Example*:
 > ```csharp
@@ -232,5 +232,7 @@ When an array creation expression includes both explicit dimension lengths and a
 > int[] z = new int[3] {0, 1, 2, 3}; // Error, length/initializer mismatch
 > ```
 > Here, the initializer for `y` results in a compile-time error because the dimension length expression is not a constant, and the initializer for `z` results in a compile-time error because the length and the number of elements in the initializer do not agree. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: C# allows a trailing comma at the end of an *array_initializer*. This syntax provides flexibility in adding or deleting members from such a list, and simplifies machine generation of such lists. *end note*

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -470,7 +470,9 @@ The attribute instance represented by `T`, `C`, `P`, and `N`, and associated wi
   - The result is `O`, an instance of the attribute class `T` that has been initialized with the *positional_argument_list * `P` and the *named_argument_list* `N`.
 
 > *Note*: The format for storing `T`, `C`, `P`, `N` (and associating it with `E`) in `A` and the mechanism to specify `E` and retrieve `T`, `C`, `P`, `N` from `A` (and hence how an attribute instance is obtained at runtime) is beyond the scope of this standard. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In an implementation of the CLI, the `Help` attribute instances in the assembly created by compiling the example program in [§21.2.3](attributes.md#2123-positional-and-named-parameters) can be retrieved with the following program:
 > ```csharp
 > using System;

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -93,7 +93,9 @@ The textual order in which names are declared is generally of no significance. I
 > }
 > ```
 > The two namespace declarations above contribute to the same declaration space, in this case declaring two classes with the fully qualified names `Megacorp.Data.Customer` and `Megacorp.Data.Order`. Because the two declarations contribute to the same declaration space, it would have caused a compile-time error if each contained a declaration of a class with the same name. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: As specified above, the declaration space of a block includes any nested blocks. Thus, in the following example, the `F` and `G` methods result in a compile-time error because the name `i` is declared in the outer block and cannot be redeclared in the inner block. However, the `H` and `I` methods are valid since the two `i`’s are declared in separate non-nested blocks.
 > ```csharp
 > class A
@@ -250,7 +252,9 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 -   If the declared accessibility of `M` is `private`, the accessibility domain of `M` is the program text of `T`.
 
 > *Note*: From these definitions it follows that the accessibility domain of a nested member is always at least the program text of the type in which the member is declared. Furthermore, it follows that the accessibility domain of a member is never more inclusive than the accessibility domain of the type in which the member is declared. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: In intuitive terms, when a type or member `M` is accessed, the following steps are evaluated to ensure that the access is permitted:
 >
 > -   First, if `M` is declared within a type (as opposed to a compilation unit or a namespace), a compile-time error occurs if that type is not accessible.
@@ -262,7 +266,9 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 > -   Otherwise, the type or member is inaccessible, and a compile-time error occurs.
 >
 > *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > public class A
@@ -364,7 +370,9 @@ In addition to these forms of access, a derived class can access a protected ins
 > }
 > ```
 > within `A`, it is possible to access `x` through instances of both `A` and `B`, since in either case the access takes place *through* an instance of `A` or a class derived from `A`. However, within `B`, it is not possible to access `x` through an instance of `A`, since `A` does not derive from `B`. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*:
 > ```csharp
 > class C<T>
@@ -386,7 +394,9 @@ In addition to these forms of access, a derived class can access a protected ins
 > }
 > ```
 > Here, the three assignments to `x` are permitted because they all take place through instances of class types constructed from the generic type. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note:* The accessibility domain ([§7.5.3](basic-concepts.md#753-accessibility-domains)) of a protected member declared in a generic class includes the program text of all class declarations derived from any type constructed from that generic class. In the example:
 > ```csharp
 > class C<T>
@@ -429,7 +439,9 @@ The following accessibility constraints exist:
 > public class B: A {...}
 > ```
 > the `B` class results in a compile-time error because `A` is not at least as accessible as `B`. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: Likewise, in the following code
 > ```csharp
 > class A {...}
@@ -567,7 +579,9 @@ Within the scope of a local variable, it is a compile-time error to refer to the
 > }
 > ```
 > In the `F` method above, the first assignment to `i` specifically does not refer to the field declared in the outer scope. Rather, it refers to the local variable and it results in a compile-time error because it textually precedes the declaration of the variable. In the `G` method, the use of `j` in the initializer for the declaration of `j` is valid because the use does not precede the *local_variable_declarator*. In the `H` method, a subsequent *local_variable_declarator* correctly refers to a local variable declared in an earlier *local_variable_declarator* within the same *local_variable_declaration*. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The scoping rules for local variables and local constants are designed to guarantee that the meaning of a name used in an expression context is always the same within a block. If the scope of a local variable were to extend only from its declaration to the end of the block, then in the example above, the first assignment would assign to the instance variable and the second assignment would assign to the local variable, possibly leading to compile-time errors if the statements of the block were later to be rearranged.)
 >
 > The meaning of a name within a block may differ based on the context in which the name is used. In the example

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -674,7 +674,7 @@ A *class_declaration* creates a new declaration space ([§7.3](basic-concepts.md
 
 -  The name of a type shall differ from the names of all non-type members declared in the same class. If two or more type declarations share the same fully qualified name, the declarations shall have the `partial` modifier ([§14.2.7](classes.md#1427-partial-declarations)) and these declarations combine to define a single type.
 
->  *Note*: Since the fully qualified name of a type declaration encodes the number of type parameters, two distinct types may share the  same name as long as they have different number of type parameters. *end note*
+> *Note*: Since the fully qualified name of a type declaration encodes the number of type parameters, two distinct types may share the  same name as long as they have different number of type parameters. *end note*
 
 -  The name of a constant, field, property, or event shall differ from the names of all other members declared in the same class.
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -673,6 +673,7 @@ A *class_declaration* creates a new declaration space ([§7.3](basic-concepts.md
 -  The name of a type parameter in the *type_parameter_list* of a class declaration shall differ from the names of all other type parameters in the same *type_parameter_list* and shall differ from the name of the class and the names of all members of the class.
 
 -  The name of a type shall differ from the names of all non-type members declared in the same class. If two or more type declarations share the same fully qualified name, the declarations shall have the `partial` modifier ([§14.2.7](classes.md#1427-partial-declarations)) and these declarations combine to define a single type.
+
 >  *Note*: Since the fully qualified name of a type declaration encodes the number of type parameters, two distinct types may share the  same name as long as they have different number of type parameters. *end note*
 
 -  The name of a constant, field, property, or event shall differ from the names of all other members declared in the same class.
@@ -1253,7 +1254,9 @@ The value of a constant is obtained in an expression using a *simple_name* ([§1
 A constant can itself participate in a *constant_expression*. Thus, a constant may be used in any construct that requires a *constant_expression*.
 
 > *Note*: Examples of such constructs include `case` labels, `goto case` statements, `enum` member declarations, attributes, and other constant declarations. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: As described in [§11.20](expressions.md#1120-constant-expressions), a *constant_expression* is an expression that can be fully evaluated at compile-time. Since the only way to create a non-null value of a *reference_type* other than `string` is to apply the `new` operator, and since the `new` operator is not permitted in a *constant_expression*, the only possible value for constants of *reference_type*s other than `string` is `null`. *end note*
 
 When a symbolic name for a constant value is desired, but when the type of that value is not permitted in a constant declaration, or when the value cannot be computed at compile-time by a *constant_expression*, a readonly field ([§14.5.3](classes.md#1453-readonly-fields)) may be used instead.
@@ -2048,7 +2051,9 @@ When performing overload resolution, a method with a parameter array might be ap
 > F(object[]);
 > ```
 > In the example, two of the possible expanded forms of the method with a parameter array are already included in the class as regular methods. These expanded forms are therefore not considered when performing overload resolution, and the first and third method invocations thus select the regular methods. When a class declares a method with a parameter array, it is not uncommon to also include some of the expanded forms as regular methods. By doing so, it is possible to avoid the allocation of an array instance that occurs when an expanded form of a method with a parameter array is invoked. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > An array is a reference type, so the value passed for a parameter array can be `null`.
 >
 > *Example*: The example:
@@ -2308,7 +2313,9 @@ Only by including an `override` modifier can a method override another method. I
 > }
 > ```
 > the `F` method in `B` does not include an `override` modifier and therefore does not override the `F` method in `A`. Rather, the `F` method in `B` hides the method in `A`, and a warning is reported because the declaration does not include a new modifier. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > class A
@@ -2808,7 +2815,9 @@ Based on the presence or absence of the get and set accessors, a property is cla
 -  A property that has only a set accessor is said to be a ***write-only property***. Except as the target of an assignment, it is a compile-time error to reference a write-only property in an expression.
 
 > *Note*: The pre- and postfix `++` and `--` operators and compound assignment operators cannot be applied to write-only properties, since these operators read the old value of their operand before they write the new one. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > public class Button : Control
@@ -2936,9 +2945,13 @@ Unlike public fields, properties provide a separation between an object’s inte
 > }
 > ```
 > Had `x` and `y` instead been `public readonly` fields, it would have been impossible to make such a change to the `Label` class. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: Exposing state through properties is not necessarily any less efficient than exposing fields directly. In particular, when a property is non-virtual and contains only a small amount of code, the execution environment might replace calls to accessors with the actual code of the accessors. This process is known as ***inlining***, and it makes property access as efficient as field access, yet preserves the increased flexibility of properties. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: Since invoking a get accessor is conceptually equivalent to reading the value of a field, it is considered bad programming style for get accessors to have observable side-effects. In the example
 > ```csharp
 > class Counter

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3035,7 +3035,9 @@ An auto-property may optionally have a *property_initializer*, which is applied 
 > }
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enablesure MD028 -->
 > *Example*: In the following
 > ```csharp
 > public class ReadOnlyPoint
@@ -3659,7 +3661,9 @@ When an indexer declaration includes an `extern` modifier, the indexer is said t
 > }
 > ```
 > Note that the syntax for accessing elements of the `BitArray` is precisely the same as for a `bool[]`. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The following example shows a 26×10 grid class that has an indexer with two parameters. The first parameter is required to be an upper- or lowercase letter in the range A–Z, and the second is required to be an integer in the range 0–9.
 > ```csharp
 > using System;
@@ -3925,7 +3929,9 @@ User-defined conversions are not allowed to convert from or to *interface_type*s
 The signature of a conversion operator consists of the source type and the target type. (This is the only form of member for which the return type participates in the signature.) The implicit or explicit classification of a conversion operator is not part of the operator’s signature. Thus, a class or struct cannot declare both an implicit and an explicit conversion operator with the same source and target types.
 
 > *Note*: In general, user-defined implicit conversions should be designed to never throw exceptions and never lose information. If a user-defined conversion can give rise to exceptions (for example, because the source argument is out of range) or loss of information (such as discarding high-order bits), then that conversion should be defined as an explicit conversion. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > using System;

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -714,7 +714,9 @@ Specifically, an anonymous function `F` is compatible with a delegate type `D`
 > };
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The examples that follow use a generic delegate type `Func<A,R>` that represents a function that takes an argument of type `A` and returns a value of type `R`:
 > ```csharp
 > delegate R Func<A,R>(A arg);

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -108,7 +108,9 @@ This definition of consistency allows covariance in return type and contravarian
 > }
 > ```
 > The methods `A.M1` and `B.M1` are compatible with both the delegate types `D1` and `D2`, since they have the same return type and parameter list. The methods `B.M2`, `B.M3`, and `B.M4` are incompatible with the delegate types `D1` and `D2`, since they have different return types or parameter lists. The methods `B.M5` and `B.M6` are both compatible with delegate type `D3`. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*:
 > ```csharp
 > delegate bool Predicate<T>(T value);
@@ -120,7 +122,9 @@ This definition of consistency allows covariance in return type and contravarian
 > }
 > ```
 > The method `X.F` is compatible with the delegate type `Predicate<int>` and the method `X.G` is compatible with the delegate type `Predicate<string>`.  *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The intuitive meaning of delegate compatibility is that a method is compatible with a delegate type if every invocation of the delegate could be replaced with an invocation of the method without violating type safety, treating optional parameters and parameter arrays as explicit parameters. For example, in the following code:
 > ```csharp
 > delegate void Action<T>(T arg);

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -57,9 +57,13 @@ An enum declaration that does not explicitly declare an underlying type has an u
 > }
 > ```
 > declares an enum with an underlying type of `long`. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: A developer might choose to use an underlying type of `long`, as in the example, to enable the use of values that are in the range of `long` but not in the range of `int`, or to preserve this option for the future. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: C# allows a trailing comma in an *enum_body*, just like it allows one in an *array_initializer* ([§16.7](arrays.md#167-array-initializers)). *end note*
 
 An enum declaration cannot include a type parameter list, but any enum nested inside a generic class declaration or a generic struct declaration is a generic enum declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -5879,6 +5879,7 @@ non_assignment_expression
     | query_expression
     ;
 ```
+
 ## 11.20 Constant expressions
 
 A constant expression is an expression that shall be fully evaluated at compile-time.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -5838,7 +5838,7 @@ non_assignment_expression
     | lambda_expression
     | query_expression
     ;
-```
+``
 ## 11.20 Constant expressions
 
 A constant expression is an expression that shall be fully evaluated at compile-time.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -5878,7 +5878,7 @@ non_assignment_expression
     | lambda_expression
     | query_expression
     ;
-``
+```
 ## 11.20 Constant expressions
 
 A constant expression is an expression that shall be fully evaluated at compile-time.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -133,23 +133,23 @@ The precedence of an operator is established by the definition of its associated
 
 > *Note*: The following table summarizes all operators in order of precedence from highest to lowest:
 >
->   **Subclause**      | **Category**                     | **Operators**
->   ---------------    | -------------------------------  | -------------------------------------------------------
->   [§11.7](expressions.md#117-primary-expressions)              | Primary                          | `x.y` `x?.y` `f(x)` `a[x]` `a?[x]` `x++` `x--` `new` `typeof` `default` `checked` `unchecked` `delegate`
->   [§11.8](expressions.md#118-unary-operators)              | Unary                            | `+` `-` `!` `~` `++x` `--x` `(T)x` `await x`
->   [§11.9](expressions.md#119-arithmetic-operators)              | Multiplicative                   | `*` `/` `%`
->   [§11.9](expressions.md#119-arithmetic-operators)              | Additive                         | `+` `-`
->   [§11.10](expressions.md#1110-shift-operators)             | Shift                            | `<<` `>>`
->   [§11.11](expressions.md#1111-relational-and-type-testing-operators)             | Relational and type-testing      | `<` `>` `<=` `>=` `is` `as`
->   [§11.11](expressions.md#1111-relational-and-type-testing-operators)             | Equality                         | `==` `!=`
->   [§11.12](expressions.md#1112-logical-operators)             | Logical AND                      | `&`
->   [§11.12](expressions.md#1112-logical-operators)             | Logical XOR                      | `^`
->   [§11.12](expressions.md#1112-logical-operators)             | Logical OR                       | `\|`
->   [§11.13](expressions.md#1113-conditional-logical-operators)             | Conditional AND                  | `&&`
->   [§11.13](expressions.md#1113-conditional-logical-operators)             | Conditional OR                   | `\|\|`
->   [§11.14](expressions.md#1114-the-null-coalescing-operator)             | Null coalescing                  | `??`
->   [§11.15](expressions.md#1115-conditional-operator)             | Conditional                      | `?:`
->   [§11.18](expressions.md#1118-assignment-operators) and [§11.16](expressions.md#1116-anonymous-function-expressions)  | Assignment and lambda expression | `=` `*=` `/=` `%=` `+=` `-=` `<<=` `>>=` `&=` `^=` `\|=` `=>`
+> |  **Subclause**      | **Category**                     | **Operators**
+> |  ---------------    | -------------------------------  | -------------------------------------------------------
+> |  [§11.7](expressions.md#117-primary-expressions)              | Primary                          | `x.y` `x?.y` `f(x)` `a[x]` `a?[x]` `x++` `x--` `new` `typeof` `default` `checked` `unchecked` `delegate`
+> |  [§11.8](expressions.md#118-unary-operators)              | Unary                            | `+` `-` `!` `~` `++x` `--x` `(T)x` `await x`
+> |  [§11.9](expressions.md#119-arithmetic-operators)              | Multiplicative                   | `*` `/` `%`
+> |  [§11.9](expressions.md#119-arithmetic-operators)              | Additive                         | `+` `-`
+> |  [§11.10](expressions.md#1110-shift-operators)             | Shift                            | `<<` `>>`
+> |  [§11.11](expressions.md#1111-relational-and-type-testing-operators)             | Relational and type-testing      | `<` `>` `<=` `>=` `is` `as`
+> |  [§11.11](expressions.md#1111-relational-and-type-testing-operators)             | Equality                         | `==` `!=`
+> |  [§11.12](expressions.md#1112-logical-operators)             | Logical AND                      | `&`
+> |  [§11.12](expressions.md#1112-logical-operators)             | Logical XOR                      | `^`
+> |  [§11.12](expressions.md#1112-logical-operators)             | Logical OR                       | `\|`
+> |  [§11.13](expressions.md#1113-conditional-logical-operators)             | Conditional AND                  | `&&`
+> |  [§11.13](expressions.md#1113-conditional-logical-operators)             | Conditional OR                   | `\|\|`
+> |  [§11.14](expressions.md#1114-the-null-coalescing-operator)             | Null coalescing                  | `??`
+> |  [§11.15](expressions.md#1115-conditional-operator)             | Conditional                      | `?:`
+> |  [§11.18](expressions.md#1118-assignment-operators) and [§11.16](expressions.md#1116-anonymous-function-expressions)  | Assignment and lambda expression | `=` `*=` `/=` `%=` `+=` `-=` `<<=` `>>=` `&=` `^=` `\|=` `=>`
 >
 > *end note*
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -130,7 +130,9 @@ When an expression contains multiple operators, the ***precedence*** of the oper
 The precedence of an operator is established by the definition of its associated grammar production.
 
 > *Note*: For example, an *additive_expression* consists of a sequence of *multiplicative_expression*s separated by `+` or `-` operators, thus giving the `+` and `-` operators lower precedence than the `*`, `/`, and `%` operators. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The following table summarizes all operators in order of precedence from highest to lowest:
 >
 > |  **Subclause**      | **Category**                     | **Operators**
@@ -213,7 +215,9 @@ User-defined operator declarations always require at least one of the parameters
 User-defined operator declarations cannot modify the syntax, precedence, or associativity of an operator.
 
 > *Example*: The `/` operator is always a binary operator, always has the precedence level specified in [§11.4.2](expressions.md#1142-operator-precedence-and-associativity), and is always left-associative. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: While it is possible for a user-defined operator to perform any computation it pleases, implementations that produce results other than those that are intuitively expected are strongly discouraged. For example, an implementation of operator `==` should compare the two operands for equality and return an appropriate `bool` result. *end note*
 
 The descriptions of individual operators in [§11.8](expressions.md#118-unary-operators) through [§11.18](expressions.md#1118-assignment-operators) specify the predefined implementations of the operators and any additional rules that apply to each operator. The descriptions make use of the terms ***unary operator overload resolution***, ***binary operator overload resolution***, ***numeric promotion***, and lifted operator definitions of which are found in the following subclauses.
@@ -301,7 +305,9 @@ Binary numeric promotion occurs for the operands of the predefined `+`, `–`, `
 -   Otherwise, both operands are converted to type `int`.
 
 > *Note*: The first rule disallows any operations that mix the `decimal` type with the `double` and `float` types. The rule follows from the fact that there are no implicit conversions between the `decimal` type and the `double` and `float` types. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: Also note that it is not possible for an operand to be of type `ulong` when the other operand is of a signed integral type. The reason is that no integral type exists that can represent the full range of `ulong` as well as the signed integral types. *end note*
 
 In both of the above cases, a cast expression can be used to explicitly convert one operand to a type that is compatible with the other operand.
@@ -982,7 +988,9 @@ Given two different types `T₁` and `T₂`, `T₁` is a better conversion tar
 #### 11.6.4.7 Overloading in generic classes
 
 > *Note*: While signatures as declared shall be unique ([§8.6](types.md#86-expression-tree-types)), it is possible that substitution of type arguments results in identical signatures. In such a situation, overload resolution will pick the most specific ([§11.6.4.3](expressions.md#11643-better-function-member)) of the original signatures (before substitution of type arguments), if it exists, and otherwise report an error. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The following examples show overloads that are valid and invalid according to this rule:
 > ```csharp
 > interface I1<T> {...}
@@ -1268,7 +1276,9 @@ Six of the lexical rules defined above are *context sensitive* as follows:
 
 > *Note:* The above rules are context sensitive as their definitions overlap with those of
 other tokens in the language. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note:* The above grammar is not ANTLR-ready due to the context sensitive lexical rules. As with
 other lexer generators ANTLR supports context sensitive lexical rules, for example using its *lexical modes*,
 but this is an implementation detail and therefore not part of this Standard. *end note*
@@ -2248,13 +2258,17 @@ An array creation expression permits instantiation of an array with elements of 
 > }
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*:  When an array of arrays has a “rectangular” shape, that is when the sub-arrays are all of the same length, it is more efficient to use a multi-dimensional array. In the example above, instantiation of the array of arrays creates 101 objects—one outer array and 100 sub-arrays. In contrast,
 > ```csharp
 > int[,] = new int[100, 5];
 > ```
 > creates only a single object, a two-dimensional array, and accomplishes the allocation in a single statement. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The following are examples of implicitly typed array creation expressions:
 > ```csharp
 > var a = new[] { 1, 10, 100, 1000 };                     // int[]
@@ -2594,7 +2608,9 @@ The body of an anonymous function is not affected by `checked` or `unchecked` co
 > }
 > ```
 > no compile-time errors are reported since neither of the expressions can be evaluated at compile-time. At run-time, the `F` method throws a `System.OverflowException`, and the `G` method returns –727379968 (the lower 32 bits of the out-of-range result). The behavior of the `H` method depends on the default overflow-checking context for the compilation, but it is either the same as `F` or the same as `G`. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > class Test
@@ -2633,7 +2649,9 @@ The `unchecked` operator is convenient when writing constants of the signed inte
 > }
 > ```
 > Both of the hexadecimal constants above are of type `uint`. Because the constants are outside the `int` range, without the `unchecked` operator, the casts to `int` would produce compile-time errors. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The `checked` and `unchecked` operators and statements allow programmers to control certain aspects of some numeric calculations. However, the behavior of some numeric operators depends on their operands’ data types. For example, multiplying two decimals always results in an exception on overflow even within an explicitly unchecked construct. Similarly, multiplying two floats never results in an exception on overflow even within an explicitly checked construct. In addition, other operators are never affected by the mode of checking, whether default or explicit. *end note*
 
 ### 11.7.19 Default value expressions
@@ -2909,7 +2927,9 @@ To resolve *cast_expression* ambiguities, the following rule exists: A sequence 
 The term “correct grammar” above means only that the sequence of tokens shall conform to the particular grammatical production. It specifically does not consider the actual meaning of any constituent identifiers.
 
 > *Example*: If `x` and `y` are identifiers, then `x.y` is correct grammar for a type, even if `x.y` doesn’t actually denote a type. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: From the disambiguation rule, it follows that, if `x` and `y` are identifiers, `(x)y`, `(x)(y)`, and `(x)(-y)` are *cast_expression*s, but `(x)-y` is not, even if `x` identifies a type. However, if `x` is a keyword that identifies a predefined type (such as `int`), then all four forms are *cast_expression*s (because such a keyword could not possibly be an expression by itself). *end note*
 
 ### 11.8.8 Await expressions
@@ -3962,7 +3982,9 @@ Unless one of these conditions is true, a binding-time error occurs.
 > -   Operands of predefined reference type equality operators are never boxed. It would be meaningless to perform such boxing operations, since references to the newly allocated boxed instances would necessarily differ from all other references.
 >
 > For an operation of the form `x == y` or `x != y`, if any applicable user-defined `operator ==` or `operator !=` exists, the operator overload resolution rules ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) will select that operator instead of the predefined reference type equality operator. It is always possible to select the predefined reference type equality operator by explicitly casting one or both of the operands to type `object`. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The following example checks whether an argument of an unconstrained type parameter type is `null`.
 > ```csharp
 > class C<T>
@@ -3982,7 +4004,9 @@ Unless one of these conditions is true, a binding-time error occurs.
 For an operation of the form `x == y` or `x != y`, if any applicable `operator ==` or `operator !=` exists, the operator overload resolution ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) rules will select that operator instead of the predefined reference type equality operator.
 
 > *Note*: It is always possible to select the predefined reference type equality operator by explicitly casting both of the operands to type `object`. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The example
 > ```csharp
 > using System;
@@ -4103,7 +4127,9 @@ The operation is evaluated as follows:
 User defined conversions are not considered by the `is` operator.
 
 > *Note*: As the `is` operator is evaluated at runtime, all type arguments have been substituted and there are no open types ([§8.4.3](types.md#843-open-and-closed-types)) to consider. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The `is` operator can be understood in terms of compile-time types and conversions as follows, where `C` is the compile-time type of `E`:
 > - If the compile-time type of `e` is the same as `T`, or if an implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)), boxing conversion ([§10.2.9](conversions.md#1029-boxing-conversions)), wrapping conversion ([§10.6](conversions.md#106-conversions-involving-nullable-types)), or an explicit unwrapping conversion ([§10.6](conversions.md#106-conversions-involving-nullable-types)) exists from the compile-time type of `E` to `T`:
 >   - If `C` is of a non-nullable value type, the result of the operation is `true`.
@@ -5153,7 +5179,9 @@ The translations in the following sections assume that queries have no explicit 
 > Where(c => c.City == "London")
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: Explicit range variable types are useful for querying collections that implement the non-generic `IEnumerable` interface, but not the generic `IEnumerable<T>` interface. In the example above, this would be the case if customers were of type `ArrayList`. *end note*
 
 #### 11.17.3.4 Degenerate query expressions
@@ -5635,11 +5663,17 @@ class G<K,T> : C<T>
 The methods above use the generic delegate types `Func<T1, R>` and `Func<T1, T2, R>`, but they could equally well have used other delegate or expression-tree types with the same relationships in parameter and return types.
 
 > *Note*: The recommended relationship between `C<T>` and `O<T>` that ensures that the `ThenBy` and `ThenByDescending` methods are available only on the result of an `OrderBy` or `OrderByDescending`. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The recommended shape of the result of `GroupBy`—a sequence of sequences, where each inner sequence has an additional `Key` property. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: Because query expressions are translated to method invocations by means of a syntactic mapping, types have considerable flexibility in how they implement any or all of the query-expression pattern. For example, the methods of the pattern can be implemented as instance methods or as extension methods because the two have the same invocation syntax, and the methods can request delegates or expression trees because anonymous functions are convertible to both. Types implementing only some of the query expression pattern support only query expression translations that map to the methods that type supports. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The `System.Linq` namespace provides an implementation of the query-expression pattern for any type that implements the `System.Collections.Generic.IEnumerable<T>` interface. *end note*
 
 ## 11.18 Assignment operators
@@ -5696,7 +5730,9 @@ The run-time processing of a simple assignment of the form `x` = `y` consists 
   - The set accessor of `x` is invoked with the value computed for `y` as its value argument.
 
 > *Note*: if the compile time type of `x` is `dynamic` and there is an implicit conversion from the compile time type of `y` to `dynamic`, no runtime resolution is required. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The array co-variance rules ([§16.6](arrays.md#166-array-covariance)) permit a value of an array type `A[]` to be a reference to an instance of an array type `B[]`, provided an implicit reference conversion exists from `B` to `A`. Because of these rules, assignment to an array element of a *reference_type* requires a run-time check to ensure that the value being assigned is compatible with the array instance. In the example
 > ```csharp
 > string[] sa = new string[10];
@@ -5710,7 +5746,9 @@ The run-time processing of a simple assignment of the form `x` = `y` consists 
 When a property or indexer declared in a *struct_type* is the target of an assignment, the instance expression associated with the property or indexer access shall be classified as a variable. If the instance expression is classified as a value, a binding-time error occurs.
 
 > *Note*: Because of [§11.7.6](expressions.md#1176-member-access), the same rule also applies to fields. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: Given the declarations:
 > ```csharp
 > struct Point
@@ -5810,7 +5848,9 @@ The intuitive effect of the rule for predefined operators is simply that `x «op
 > ch += (char)1;    // OK
 > ```
 > the intuitive reason for each error is that a corresponding simple assignment would also have been an error. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: This also means that compound assignment operations support lifted operators. Since a compound assignment `x «op»= y` is evaluated as either `x = x «op» y` or `x = (T)(x «op» y)`, the rules of evaluation implicitly cover lifted operators. *end note*
 
 ### 11.18.4 Event assignment
@@ -5876,7 +5916,9 @@ The following conversions are permitted in constant expressions:
 -   Implicit and explicit reference conversions, provided the source of the conversions is a constant expression that evaluates to the `null` value.
 
 > *Note*: Other conversions including boxing, unboxing, and implicit reference conversions of non-`null` values are not permitted in constant expressions. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > class C

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -373,7 +373,9 @@ For interfaces that are strictly single-inheritance (each interface in the inher
 > }
 > ```
 > the first two statements cause compile-time errors because the member lookup ([§11.5](expressions.md#115-member-lookup)) of `Count` in `IListCounter` is ambiguous. As illustrated by the example, the ambiguity is resolved by casting `x` to the appropriate base interface type. Such casts have no run-time costs—they merely consist of viewing the instance as a less derived type at compile-time. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > interface IInteger
@@ -400,7 +402,9 @@ For interfaces that are strictly single-inheritance (each interface in the inher
 > }
 > ```
 > the invocation `n.Add(1)` selects `IInteger.Add` by applying overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). Similarly, the invocation `n.Add(1.0)` selects `IDouble.Add`. When explicit casts are inserted, there is only one candidate method, and thus no ambiguity. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > interface IBase
@@ -555,7 +559,9 @@ For purposes of implementing interfaces, a class or struct may declare ***explic
 > }
 > ```
 > Here `IDictionary<int,T>.this` and `IDictionary<int,T>.Add` are explicit interface member implementations. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In some cases, the name of an interface member might not be appropriate for the implementing class, in which case, the interface member may be implemented using explicit interface member implementation. A class implementing a file abstraction, for example, would likely implement a `Close` member function that has the effect of releasing the file resource, and implement the `Dispose` method of the `IDisposable` interface using explicit interface member implementation:
 > ```csharp
 > interface IDisposable
@@ -733,7 +739,9 @@ When a generic method implicitly implements an interface method, the constraints
 > ```
 > In this case, the explicit interface member implementation invokes a public method having strictly weaker constraints. The assignment from t to s is valid since `T` inherits a constraint of `T: string`, even though this constraint is not expressible in source code.
 >*end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: When a generic method explicitly implements an interface method no constraints are allowed on the implementing method ([§14.7.1](classes.md#1471-general), [§17.6.2](interfaces.md#1762-explicit-interface-member-implementations)). *end note*
 
 ### 17.6.5 Interface mapping

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -276,6 +276,7 @@ Whitespace
     | '\u000C'  // form feed
     ;
 ```
+
 ## 6.4 Tokens
 
 ### 6.4.1 General

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -13,7 +13,9 @@ Conceptually speaking, a program is compiled using three steps:
 Conforming implementations shall accept Unicode compilation units encoded with the UTF-8 encoding form (as defined by the Unicode standard), and transform them into a sequence of Unicode characters. Implementations can choose to accept and transform additional character encoding schemes (such as UTF-16, UTF-32, or non-Unicode character mappings).
 
 > *Note*: The handling of the Unicode NULL character (U+0000) is implementation-specific. It is strongly recommended that developers avoid using this character in their source code, for the sake of both portability and readability. When the character is required within a character or string literal, the escape sequences `\0` or `\u0000` may be used instead. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: It is beyond the scope of this standard to define how a file using a character representation other than Unicode might be transformed into a sequence of Unicode characters. During such transformation, however, it is recommended that the usual line-separating character (or sequence) in the other character set be translated to the two-character sequence consisting of the Unicode carriage-return character (U+000D) followed by Unicode line-feed character (U+000A). For the most part this transformation will have no visible effects; however, it will affect the interpretation of verbatim string literal tokens ([§6.4.5.6](lexical-structure.md#6456-string-literals)). The purpose of this recommendation is to allow a verbatim string literal to produce the same character sequence when its compilation unit is moved between systems that support differing non-Unicode character sets, in particular, those using differing character sequences for line-separation.  *end note*
 
 ## 6.2 Grammars
@@ -68,7 +70,9 @@ If a sequence of tokens can be parsed (in context) as a *simple_name* ([§11.7.4
 then the *type_argument_list* is retained as part of the *simple_name*, *member_access*, or *pointer_member_access* and any other possible parse of the sequence of tokens is discarded. Otherwise, the *type_argument_list* is not considered part of the *simple_name*, *member_access*, or *pointer_member_access*, even if there is no other possible parse of the sequence of tokens.
 
 > *Note*: These rules are not applied when parsing a *type_argument_list* in a *namespace_or_type_name* ([§7.8](basic-concepts.md#78-namespace-and-type-names)). *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The statement:
 > ```csharp
 > F(G<A, B>(7));
@@ -313,7 +317,9 @@ A Unicode character escape sequence represents the single Unicode code point for
 Multiple translations are not performed. For instance, the string literal `"\u005Cu005C"` is equivalent to `"\u005C"` rather than `"\"`.
 
 > *Note*: The Unicode value `\u005C` is the character “`\`”. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The example
 > ```csharp
 > class Class1
@@ -438,7 +444,9 @@ fragment Formatting_Character
 > - How an implementation enforces the restrictions on the allowable *Unicode_Escape_Sequence* values is an implementation issue.
 >
 > *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: Examples of valid identifiers are `identifier1`, `_identifier2`, and `@if`. *end example*
 
 An identifier in a conforming program shall be in the canonical format defined by Unicode Normalization Form C, as defined by Unicode Standard Annex 15. The behavior when encountering an identifier not in Normalization Form C is implementation-defined; however, a diagnostic is not required.
@@ -446,7 +454,9 @@ An identifier in a conforming program shall be in the canonical format defined b
 The prefix “`@`” enables the use of keywords as identifiers, which is useful when interfacing with other programming languages. The character `@` is not actually part of the identifier, so the identifier might be seen in other languages as a normal identifier, without the prefix. An identifier with an `@` prefix is called a ***verbatim identifier***.
 
 > *Note*:  Use of the `@` prefix for identifiers that are not keywords is permitted, but strongly discouraged as a matter of style. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The example:
 > ```csharp
 > class @class
@@ -689,7 +699,9 @@ fragment Hexadecimal_Escape_Sequence
 ```
 
 > *Note*: A character that follows a backslash character (`\`) in a *Character* must be one of the following characters: `'`, `"`, `\`, `0`, `a`, `b`, `f`, `n`, `r`, `t`, `u`, `U`, `x`, `v`. Otherwise, a compile-time error occurs. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The use of the `\x` *Hexadecimal_Escape_Sequence* production can be error-prone and hard to read due to the variable number of hexadecimal digits following the `\x`. For example, in the code:
 > ```csharp
 > string good = "x9Good text";
@@ -786,9 +798,13 @@ fragment Quote_Escape_Sequence
 > three";
 > ```
 > shows a variety of string literals. The last string literal, `j`, is a verbatim string literal that spans multiple lines. The characters between the quotation marks, including white space such as new line characters, are preserved verbatim, and each pair of double-quote characters is replaced by one such character. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: Any line breaks within verbatim string literals are part of the resulting string. If the exact characters used to form line breaks are semantically relevant to an application, any tools that translate line breaks in source code to different formats (between “`\n`” and “`\r\n`”, for example) will change application behavior. Developers should be careful in such situations. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: Since a hexadecimal escape sequence can have a variable number of hex digits, the string literal `"\x123"` contains a single character with hex value `123`. To create a string containing the character with hex value `12` followed by the character `3`, one could write `"\x00123"` or `"\x12"` + `"3"` instead. *end note*
 
 The type of a *String_Literal* is `string`.
@@ -1031,7 +1047,9 @@ Any `#define` and `#undef` directives in a compilation unit shall occur before t
 > }
 > ```
 > is valid because the `#define` directives precede the first token (the `namespace` keyword) in the compilation unit. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The following example results in a compile-time error because a #define follows real code:
 > ```csharp
 > #define A
@@ -1127,7 +1145,9 @@ The selected conditional section, if any, is processed as a normal *input_sectio
 Any remaining conditional sections are skipped and no tokens, except those for pre-processing directives, are generated from the source code. Therefore skipped source code, except pre-processing directives, may be lexically incorrect. Skipped pre-processing directives shall be lexically correct but are not otherwise processed. Within a conditional section that is being skipped any nested conditional sections (contained in nested `#if...#endif` constructs) are also skipped.
 
 > *Note*: The above grammar does not capture the allowance that the conditional sections between the pre-processing directives may be malformed lexically. Therefore the grammar is not ANTLR-ready as it only supports lexically correct input. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The following example illustrates how conditional compilation directives can nest:
 > ```csharp
 > #define Debug // Debugging on

--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -264,7 +264,7 @@ Each *extern_alias_directive* or *using_alias_directive* in a *compilation_unit*
 > class B {} // Ok
 > ```
 > The using alias named `A` causes an error since there is already an alias named `A` in the same compilation unit. The class named `B` does not conflict with the extern alias named `B` since these names are added to distinct declaration spaces. The former is added to the global declaration space and the latter is added to the alias declaration space for this compilation unit.
-
+>
 > When an alias name matches the name of a member of a namespace, usage of either must be appropriately qualified:
 > ```csharp
 > namespace N1.N2
@@ -481,7 +481,7 @@ Because names may be ambiguous when more than one imported namespace introduces 
 > }
 > ```
 > both `N1` and `N2` contain a member `A`, and because `N3` imports both, referencing `A` in `N3` is a compile-time error. In this situation, the conflict can be resolved either through qualification of references to `A`, or by introducing a *using_alias_directive* that picks a particular `A`. For example:
-
+>
 > ```csharp
 > namespace N3
 > {
@@ -729,7 +729,9 @@ Using this notation, the meaning of a *qualified_alias_member* is determined as 
 > }
 > ```
 > the class `A` is referenced with `global::A` and the type `System.Net.Sockets.Socket` is referenced with `S::Socket`. Using `A.x` and `S.Socket` instead would have caused compile-time errors because `A` and `S` would have resolved to the parameters. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The identifier `global` has special meaning only when used as the left-hand identifier of a *qualified_alias_name*. It is not a keyword and it is not itself an alias; it is a contextual keyword ([§6.4.4](lexical-structure.md#644-keywords)). In the code:
 > ```csharp
 > class A { }

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -20,6 +20,7 @@ It is expected that a conforming C# implementation will supply a significantly 
 **End of informative text.**
 
 ## C.2 Standard Library Types defined in ISO/IEC 23271
+
 ```csharp
 namespace System
 {

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -456,7 +456,9 @@ of formatting applied to the value being represented as a string. The
 *precision specifier* controls the number of significant digits or decimal places in the string, if applicable.
 
 > *Note:* For the list of standard format specifiers, see the table below. Note that a given data type, such as `System.Int32`, might not support one or more of the standard format specifiers. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note:* When a format includes symbols that vary by culture, such as the currencysymbol included by the ‘C’ and ‘c’ formats, a formatting object supplies the actual characters used in the string representation. A method might include a parameter to pass a `System.IFormatProvider` object that supplies a formatting object, or the method might use the default formatting object, which contains the symbol definitions for the current culture. The current culture typically uses the same set of symbols used system-wide by default. In the Base Class Library, the formatting object for system-supplied numeric types is a `System.Globalization.NumberFormatInfo` instance. For `System.DateTime` instances, a `System.Globalization.DateTimeFormatInfo` is used. *end note*
 
 The following table describes the standard format specifiers and associated formatting

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -417,6 +417,7 @@ selection_statement
     | switch_statement
     ;
 ```
+
 ### 12.8.2 The if statement
 
 The `if` statement selects a statement for execution based on the value of a Boolean expression.

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -573,7 +573,9 @@ Multiple labels are permitted in a *switch_section*.
 > }
 > ```
 > is valid. The example does not violate the “no fall through” rule because the labels `case 2:` and `default:` are part of the same *switch_section*. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The “no fall through” rule prevents a common class of bugs that occur in C and C++ when `break` statements are accidentally omitted. For example, the sections of the `switch` statement above can be reversed without affecting the behavior of the statement:
 > ```csharp
 > switch (i)
@@ -590,7 +592,9 @@ Multiple labels are permitted in a *switch_section*.
 > }
 > ```
 > *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The statement list of a switch section typically ends in a `break`, `goto case`, or `goto default` statement, but any construct that renders the end point of the statement list unreachable is permitted. For example, a `while` statement controlled by the Boolean expression `true` is known to never reach its end point. Likewise, a `throw` or `return` statement always transfers control elsewhere and never reaches its end point. Thus, the following example is valid:
 > ```csharp
 > switch (i)
@@ -607,7 +611,9 @@ Multiple labels are permitted in a *switch_section*.
 > }
 > ```
 > *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The governing type of a `switch` statement can be the type `string`. For example:
 > ```csharp
 > void DoCommand(string command)
@@ -630,7 +636,9 @@ Multiple labels are permitted in a *switch_section*.
 > }
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: Like the string equality operators ([§11.11.8](expressions.md#11118-string-equality-operators)), the `switch` statement is case sensitive and will execute a given switch section only if the switch expression string exactly matches a `case` label constant. *end note*
 When the governing type of a `switch` statement is `string` or a nullable value type, the value `null` is permitted as a `case` label constant.
 
@@ -917,7 +925,9 @@ The order in which `foreach` traverses the elements of an array, is as follows: 
 > 1.2 2.3 3.4 4.5 5.6 6.7 7.8 8.9
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following example
 > ```csharp
 > int[] numbers = { 1, 3, 5, 7, 9 };

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -146,7 +146,9 @@ A variable of a struct type directly contains the data of the struct, whereas a 
 With classes, it is possible for two variables to reference the same object, and thus possible for operations on one variable to affect the object referenced by the other variable. With structs, the variables each have their own copy of the data (except in the case of `ref` and `out` parameter variables), and it is not possible for operations on one to affect the other. Furthermore, except when explicitly nullable ([§8.3.11](types.md#8311-nullable-value-types)), it is not possible for values of a struct type to be `null`.
 
 > *Note*: If a struct contains a field of reference type then the contents of the object referenced can be altered by other operations. However the value of the field itself, i.e., which object it references, cannot be changed through a mutation of a different struct value. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: Given the declaration
 > ```csharp
 > struct Point

--- a/standard/types.md
+++ b/standard/types.md
@@ -220,7 +220,9 @@ All value types implicitly declare a public parameterless instance constructor c
 Like any other instance constructor, the default constructor of a value type is invoked using the `new` operator.
 
 > *Note*: For efficiency reasons, this requirement is not intended to actually have the implementation generate a constructor call. For value types, the default value expression ([§11.7.19](expressions.md#11719-default-value-expressions)) produces the same result as using the default constructor. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the code below, variables `i`, `j` and `k` are all initialized to zero.
 > ```csharp
 > class A
@@ -270,7 +272,9 @@ Because a simple type aliases a struct type, every simple type has members.
 > string t = 123.ToString(); // System.Int32.ToString() instance method
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The simple types differ from other struct types in that they permit certain additional operations:
 >
 > - Most simple types permit values to be created by writing *literals* ([§6.4.5](lexical-structure.md#645-literals)), although C# makes no provision for literals of struct types in general. *Example*: `123` is a literal of type `int` and `'a'` is a literal of type `char`. *end example*

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -511,9 +511,13 @@ The `&` operator does not require its argument to be definitely assigned, but fo
 > }
 > ```
 > `i` is considered definitely assigned following the `&i` operation used to initialize `p`. The assignment to `*p` in effect initializes `i`, but the inclusion of this initialization is the responsibility of the programmer, and no compile-time error would occur if the assignment was removed. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The rules of definite assignment for the `&` operator exist such that redundant initialization of local variables can be avoided. For example, many external APIs take a pointer to a structure which is filled in by the API. Calls to such APIs typically pass the address of a local struct variable, and without the rule, redundant initialization of the struct variable would be required. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: When a local variable, value parameter, or parameter array is captured by an anonymous function ([§11.7.21](expressions.md#11721-anonymous-method-expressions)), that local variable, parameter, or parameter array is no longer considered to be a fixed variable ([§22.7](unsafe-code.md#227-the-fixed-statement)), but is instead considered to be a moveable variable. Thus it is an error for any unsafe code to take the address of a local variable, value parameter, or parameter array that has been captured by an anonymous function. *end note*
 
 ### 22.6.6 Pointer increment and decrement
@@ -724,7 +728,9 @@ Within a `fixed` statement that obtains a pointer `p` to an array instance `a`, 
 > [1,2,0] = 20 [1,2,1] = 21 [1,2,2] = 22 [1,2,3] = 23
 > ```
 > *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > class Test
@@ -778,7 +784,9 @@ A `char*` value produced by fixing a string instance always points to a null-ter
 Modifying objects of managed type through fixed pointers can result in undefined behavior.
 
 > *Note*: For example, because strings are immutable, it is the programmer’s responsibility to ensure that the characters referenced by a pointer to a fixed string are not modified. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The automatic null-termination of strings is particularly convenient when calling external APIs that expect “C-style” strings. Note, however, that a string instance is permitted to contain null characters. If such null characters are present, the string will appear truncated when treated as a null-terminated `char*`. *end note*
 
 ## 22.8 Fixed-size buffers
@@ -932,7 +940,9 @@ Stack allocation initializers are not permitted in `catch` or `finally` blocks (
 All stack-allocated memory blocks created during the execution of a function member are automatically discarded when that function member returns.
 
 > *Note*: This corresponds to the `alloca` function, an extension commonly found in C and C++ implementations. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 > ```csharp
 > using System;

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -115,9 +115,13 @@ A *local_variable_declaration* can occur in a *block*, a *for_statement*, a *swi
 The lifetime of a local variable is the portion of program execution during which storage is guaranteed to be reserved for it. This lifetime extends from entry into the scope with which it is associated, at least until execution of that scope ends in some way. (Entering an enclosed *block*, calling a method, or yielding a value from an iterator block suspends, but does not end, execution of the current scope.) If the local variable is captured by an anonymous function ([§11.16.6.2](expressions.md#111662-captured-outer-variables)), its lifetime extends at least until the delegate or expression tree created from the anonymous function, along with any other objects that come to reference the captured variable, are eligible for garbage collection. If the parent scope is entered recursively or iteratively, a new instance of the local variable is created each time, and its *local_variable_initializer*, if any, is evaluated each time.
 
 > *Note*: A local variable is instantiated each time its scope is entered. This behavior is visible to user code containing anonymous methods. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The lifetime of an *iteration variable* ([§12.9.5](statements.md#1295-the-foreach-statement)) declared by a *foreach_statement* is a single iteration of that statement. Each iteration creates a new variable. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: The actual lifetime of a local variable is implementation-dependent. For example, a compiler might statically determine that a local variable in a block is only used for a small portion of that block. Using this analysis, the compiler could generate code that results in the variable’s storage having a shorter lifetime than its containing block.
 >
 > The storage referred to by a local reference variable is reclaimed independently of the lifetime of that local reference variable ([§7.9](basic-concepts.md#79-automatic-memory-management)). *end note*
@@ -703,7 +707,9 @@ For a *lambda_expression* or *anonymous_method_expression* *expr* with a body (e
 > }
 > ```
 > generates a compile-time error since max is not definitely assigned where the anonymous function is declared. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The example
 > ```csharp
 > delegate void D();


### PR DESCRIPTION
- [MD022](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md022---headings-should-be-surrounded-by-blank-lines) - Headings should be surrounded by blank lines.
- [MD027](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md027---multiple-spaces-after-blockquote-symbol) - Multiple spaces not allowed after a blockquote symbol.
- [MD028](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md028---blank-line-inside-blockquote) - blank line inside a blockquote.

Most of the changes are straightforward. The first commits did the bulk of the work, followed by some warnings and stray characters.