### PR TITLE
Markdown lint fixes

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - draft-v6
     paths:
-      - "**/*.md"
+      - "standard/*.md"
       - ".markdownlint.json"
   pull_request:
     paths:
-      - "**/*.md"
+      - "standard/*.md"
       - ".markdownlint.json"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -35,4 +35,4 @@ jobs:
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
         npm i -g markdownlint-cli
-        markdownlint "**/*.md"
+        markdownlint "standard/*.md"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,7 +14,6 @@
     },
 
     "MD031" : false,
-    "MD040" : false,
     "MD041" : false,
     "MD047" : false,
     "MD050" : false

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,7 +14,6 @@
     },
 
     "MD031" : false,
-    "MD038" : false,
     "MD040" : false,
     "MD041" : false,
     "MD047" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD030" : false,
     "MD031" : false,
     "MD032" : false,
     "MD036" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,7 +2,8 @@
     "default": true,
     "MD013": false,
     "MD033": false,
-    "MD034" : false,
+    "MD034": false,
+    "MD036": false,
     "MD046": {
         "style": "fenced"
     },
@@ -13,7 +14,6 @@
     },
 
     "MD031" : false,
-    "MD037" : false,
     "MD038" : false,
     "MD040" : false,
     "MD041" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,7 +14,6 @@
     },
 
     "MD031" : false,
-    "MD047" : false,
     "MD050" : false
 
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,7 +14,6 @@
     },
 
     "MD031" : false,
-    "MD041" : false,
     "MD047" : false,
     "MD050" : false
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -13,8 +13,5 @@
         ]
     },
 
-    "MD031" : false,
-    "MD050" : false
-
-
+    "MD031" : false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -13,7 +13,6 @@
     },
 
     "MD031" : false,
-    "MD036" : false,
     "MD037" : false,
     "MD038" : false,
     "MD040" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,6 @@
         ]
     },
 
-    "MD031" : false,
     "MD032" : false,
     "MD036" : false,
     "MD037" : false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,7 +12,7 @@
         ]
     },
 
-    "MD032" : false,
+    "MD031" : false,
     "MD036" : false,
     "MD037" : false,
     "MD038" : false,

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -36,8 +36,8 @@ The rank of an array type is given by the leftmost *rank_specifier* in the *arra
 
 The element type of an array type is the type that results from deleting the leftmost *rank_specifier*:
 
--   An array type of the form `T[R]` is an array with rank `R` and a non-array element type `T`.
--   An array type of the form `T[R][R₁]...[Rₓ]` is an array with rank `R` and an element type `T[R₁]...[Rₓ]`.
+- An array type of the form `T[R]` is an array with rank `R` and a non-array element type `T`.
+- An array type of the form `T[R][R₁]...[Rₓ]` is an array with rank `R` and an element type `T[R₁]...[Rₓ]`.
 
 In effect, the *rank_specifier*s are read from left to right *before* the final non-array element type.
 

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -446,7 +446,7 @@ Retrieval of an attribute instance involves both compile-time and run-time proce
 
 ### 21.4.2 Compilation of an attribute
 
-The compilation of an *attribute* with attribute class `T`, *positional_argument_list * `P`, *named_argument_list* `N`, and specified on a program entity `E` is compiled into an assembly `A` via the following steps:
+The compilation of an *attribute* with attribute class `T`, *positional_argument_list* `P`, *named_argument_list* `N`, and specified on a program entity `E` is compiled into an assembly `A` via the following steps:
 
 - Follow the compile-time processing steps for compiling an *object_creation_expression* of the form new `T(P)`. These steps either result in a compile-time error, or determine an instance constructor `C` on `T` that can be invoked at run-time.
 - If `C` does not have public accessibility, then a compile-time error occurs.
@@ -455,7 +455,7 @@ The compilation of an *attribute* with attribute class `T`, *positional_argumen
   - `Name` shall identify a non-static read-write public field or property on `T`. If `T` has no such field or property, then a compile-time error occurs.
 - If any of the values within *positional_argument_list* `P` or one of the values within *named_argument_list* `N` is of type `System.String` and the value is not well-formed as defined by the Unicode Standard, it is implementation-defined whether the value compiled is equal to the run-time value retrieved ([§21.4.3](attributes.md#2143-run-time-retrieval-of-an-attribute-instance)).
   > *Note*: As an example, a string which contains a high surrogate UTF-16 code unit which isn’t immediately followed by a low surrogate code unit is not well-formed. *end note*
-- Store the following information (for run-time instantiation of the attribute) in the assembly output by the compiler as a result of compiling the program containing the attribute: the attribute class `T`, the instance constructor `C` on `T`, the *positional_argument_list * `P`, the *named_argument_list* `N`, and the associated program entity `E`, with the values resolved completely at compile-time.
+- Store the following information (for run-time instantiation of the attribute) in the assembly output by the compiler as a result of compiling the program containing the attribute: the attribute class `T`, the instance constructor `C` on `T`, the *positional_argument_list* `P`, the *named_argument_list* `N`, and the associated program entity `E`, with the values resolved completely at compile-time.
 
 ### 21.4.3 Run-time retrieval of an attribute instance
 
@@ -467,7 +467,7 @@ The attribute instance represented by `T`, `C`, `P`, and `N`, and associated wi
   - Let `Value` be the result of evaluating the *attribute_argument_expression* of `Arg`.
   - If `Name` identifies a field on `O`, then set this field to `Value`.
   - Otherwise, Name identifies a property on `O`. Set this property to Value.
-  - The result is `O`, an instance of the attribute class `T` that has been initialized with the *positional_argument_list * `P` and the *named_argument_list* `N`.
+  - The result is `O`, an instance of the attribute class `T` that has been initialized with the *positional_argument_list* `P` and the *named_argument_list* `N`.
 
 > *Note*: The format for storing `T`, `C`, `P`, `N` (and associating it with `E`) in `A` and the mechanism to specify `E` and retrieve `T`, `C`, `P`, `N` from `A` (and hence how an attribute instance is obtained at runtime) is beyond the scope of this standard. *end note*
 <!-- markdownlint-disable MD028 -->

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -6,14 +6,14 @@ A program may be compiled either as a ***class library*** to be used as part of 
 
 A program compiled as an application shall contain at least one method qualifying as an entry point by satisfying the following requirements:
 
--   It shall have the name `Main`.
--   It shall be `static`.
--   It shall not be generic.
--   It shall be declared in a non-generic type. If the type declaring the method is a nested type, none of its enclosing types may be generic.
--   It shall not have the `async` modifier.
--   The return type shall be `void` or `int`.
--   It shall not be a partial method ([§14.6.9](classes.md#1469-partial-methods)) without an implementation.
--   The formal parameter list shall either be empty, or have a single value parameter of type `string[]`.
+- It shall have the name `Main`.
+- It shall be `static`.
+- It shall not be generic.
+- It shall be declared in a non-generic type. If the type declaring the method is a nested type, none of its enclosing types may be generic.
+- It shall not have the `async` modifier.
+- The return type shall be `void` or `int`.
+- It shall not be a partial method ([§14.6.9](classes.md#1469-partial-methods)) without an implementation.
+- The formal parameter list shall either be empty, or have a single value parameter of type `string[]`.
 
 If more than one method qualifying as an entry point is declared within a program, an external mechanism may be used to specify which method is deemed to be the actual entry point for the application. It is a compile-time error for a program to be compiled as an application without exactly one entry point. A program compiled as a class library may contain methods that would qualify as application entry points, but the resulting library has no entry point.
 
@@ -48,31 +48,31 @@ Declarations in a C# program define the constituent elements of the program. C#
 
 A declaration defines a name in the ***declaration space*** to which the declaration belongs. It is a compile-time error to have two or more declarations that introduce members with the same name in a declaration space, except in the following cases:
 
--   Two or more namespace declarations with the same name are allowed in the same declaration space. Such namespace declarations are aggregated to form a single logical namespace and share a single declaration space.
--   Declarations in separate programs but in the same namespace declaration space are allowed to share the same name.  
+- Two or more namespace declarations with the same name are allowed in the same declaration space. Such namespace declarations are aggregated to form a single logical namespace and share a single declaration space.
+- Declarations in separate programs but in the same namespace declaration space are allowed to share the same name.  
     > *Note*: However, these declarations could introduce ambiguities if included in the same application. *end note*
--   Two or more methods with the same name but distinct signatures are allowed in the same declaration space ([§7.6](basic-concepts.md#76-signatures-and-overloading)).
--   Two or more type declarations with the same name but distinct numbers of type parameters are allowed in the same declaration space ([§7.8.2](basic-concepts.md#782-unqualified-names)).
--   Two or more type declarations with the partial modifier in the same declaration space may share the same name, same number of type parameters and same classification (class, struct or interface). In this case, the type declarations contribute to a single type and are themselves aggregated to form a single declaration space ([§14.2.7](classes.md#1427-partial-declarations)).
--   A namespace declaration and a type declaration in the same declaration space can share the same name as long as the type declaration has at least one type parameter ([§7.8.2](basic-concepts.md#782-unqualified-names)).
+- Two or more methods with the same name but distinct signatures are allowed in the same declaration space ([§7.6](basic-concepts.md#76-signatures-and-overloading)).
+- Two or more type declarations with the same name but distinct numbers of type parameters are allowed in the same declaration space ([§7.8.2](basic-concepts.md#782-unqualified-names)).
+- Two or more type declarations with the partial modifier in the same declaration space may share the same name, same number of type parameters and same classification (class, struct or interface). In this case, the type declarations contribute to a single type and are themselves aggregated to form a single declaration space ([§14.2.7](classes.md#1427-partial-declarations)).
+- A namespace declaration and a type declaration in the same declaration space can share the same name as long as the type declaration has at least one type parameter ([§7.8.2](basic-concepts.md#782-unqualified-names)).
 
 There are several different types of declaration spaces, as described in the following.
 
--   Within all compilation units of a program, *namespace_member_declaration*s with no enclosing *namespace_declaration* are members of a single combined declaration space called the ***global declaration space***.
--   Within all compilation units of a program, *namespace_member_declaration*s within *namespace_declaration*s that have the same fully qualified namespace name are members of a single combined declaration space.
--   Each *compilation_unit* and *namespace_body* has an ***alias declaration space***. Each *extern_alias_directive* and *using_alias_directive* of the *compilation_unit* or *namespace_body* contributes a member to the alias declaration space ([§13.5.2](namespaces.md#1352-using-alias-directives)).
--   Each non-partial class, struct, or interface declaration creates a new declaration space. Each partial class, struct, or interface declaration contributes to a declaration space shared by all matching parts in the same program ([§15.2.3](structs.md#1523-partial-modifier)).Names are introduced into this declaration space through *class_member_declaration*s, *struct_member_declaration*s, *interface_member_declaration*s, or *type_parameter*s. Except for overloaded instance constructor declarations and static constructor declarations, a class or struct cannot contain a member declaration with the same name as the class or struct. A class, struct, or interface permits the declaration of overloaded methods and indexers. Furthermore, a class or struct permits the declaration of overloaded instance constructors and operators. For example, a class, struct, or interface may contain multiple method declarations with the same name, provided these method declarations differ in their signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)). Note that base classes do not contribute to the declaration space of a class, and base interfaces do not contribute to the declaration space of an interface. Thus, a derived class or interface is allowed to declare a member with the same name as an inherited member. Such a member is said to ***hide*** the inherited member.
--   Each delegate declaration creates a new declaration space. Names are introduced into this declaration space through formal parameters (*fixed_parameter*s and *parameter_array*s) and *type_parameter*s.
--   Each enumeration declaration creates a new declaration space. Names are introduced into this declaration space through *enum_member_declarations*.
--   Each method declaration, property declaration, property accessor declaration, indexer declaration, indexer accessor declaration, operator declaration, instance constructor declaration and anonymous function creates a new declaration space called a ***local variable declaration space***. Names are introduced into this declaration space through formal parameters (*fixed_parameter*s and *parameter_array*s) and *type_parameter*s. The set accessor for a property or an indexer introduces the valuename as a formal parameter. The body of the function member or anonymous function, if any, is considered to be nested within the local variable declaration space. It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.
--   Each *block* or *switch_block*, as well as a `for`, `foreach`, and `using` statement, creates a local variable declaration space for local variables and local constants. Names are introduced into this declaration space through *local_variable_declaration*s and *local_constant_declaration*s. Note that blocks that occur as or within the body of a function member or anonymous function are nested within the local variable declaration space declared by those functions for their parameters. Thus, it is an error to have, for example, a method with a local variable and a parameter of the same name.
--   Each *block* or *switch_block* creates a separate declaration space for labels. Names are introduced into this declaration space through *labeled_statement*s, and the names are referenced through *goto_statement*s. The ***label declaration space*** of a block includes any nested blocks. Thus, within a nested block it is not possible to declare a label with the same name as a label in an enclosing block.
+- Within all compilation units of a program, *namespace_member_declaration*s with no enclosing *namespace_declaration* are members of a single combined declaration space called the ***global declaration space***.
+- Within all compilation units of a program, *namespace_member_declaration*s within *namespace_declaration*s that have the same fully qualified namespace name are members of a single combined declaration space.
+- Each *compilation_unit* and *namespace_body* has an ***alias declaration space***. Each *extern_alias_directive* and *using_alias_directive* of the *compilation_unit* or *namespace_body* contributes a member to the alias declaration space ([§13.5.2](namespaces.md#1352-using-alias-directives)).
+- Each non-partial class, struct, or interface declaration creates a new declaration space. Each partial class, struct, or interface declaration contributes to a declaration space shared by all matching parts in the same program ([§15.2.3](structs.md#1523-partial-modifier)).Names are introduced into this declaration space through *class_member_declaration*s, *struct_member_declaration*s, *interface_member_declaration*s, or *type_parameter*s. Except for overloaded instance constructor declarations and static constructor declarations, a class or struct cannot contain a member declaration with the same name as the class or struct. A class, struct, or interface permits the declaration of overloaded methods and indexers. Furthermore, a class or struct permits the declaration of overloaded instance constructors and operators. For example, a class, struct, or interface may contain multiple method declarations with the same name, provided these method declarations differ in their signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)). Note that base classes do not contribute to the declaration space of a class, and base interfaces do not contribute to the declaration space of an interface. Thus, a derived class or interface is allowed to declare a member with the same name as an inherited member. Such a member is said to ***hide*** the inherited member.
+- Each delegate declaration creates a new declaration space. Names are introduced into this declaration space through formal parameters (*fixed_parameter*s and *parameter_array*s) and *type_parameter*s.
+- Each enumeration declaration creates a new declaration space. Names are introduced into this declaration space through *enum_member_declarations*.
+- Each method declaration, property declaration, property accessor declaration, indexer declaration, indexer accessor declaration, operator declaration, instance constructor declaration and anonymous function creates a new declaration space called a ***local variable declaration space***. Names are introduced into this declaration space through formal parameters (*fixed_parameter*s and *parameter_array*s) and *type_parameter*s. The set accessor for a property or an indexer introduces the valuename as a formal parameter. The body of the function member or anonymous function, if any, is considered to be nested within the local variable declaration space. It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.
+- Each *block* or *switch_block*, as well as a `for`, `foreach`, and `using` statement, creates a local variable declaration space for local variables and local constants. Names are introduced into this declaration space through *local_variable_declaration*s and *local_constant_declaration*s. Note that blocks that occur as or within the body of a function member or anonymous function are nested within the local variable declaration space declared by those functions for their parameters. Thus, it is an error to have, for example, a method with a local variable and a parameter of the same name.
+- Each *block* or *switch_block* creates a separate declaration space for labels. Names are introduced into this declaration space through *labeled_statement*s, and the names are referenced through *goto_statement*s. The ***label declaration space*** of a block includes any nested blocks. Thus, within a nested block it is not possible to declare a label with the same name as a label in an enclosing block.
 
 The textual order in which names are declared is generally of no significance. In particular, textual order is not significant for the declaration and use of namespaces, constants, methods, properties, events, indexers, operators, instance constructors, finalizers, static constructors, and types. Declaration order is significant in the following ways:
 
--   Declaration order for field declarations determines the order in which their initializers (if any) are executed ([§14.5.6.2](classes.md#14562-static-field-initialization), [§14.5.6.3](classes.md#14563-instance-field-initialization)).
--   Local variables shall be defined before they are used ([§7.7](basic-concepts.md#77-scopes)).
--   Declaration order for enum member declarations ([§18.4](enums.md#184-enum-members)) is significant when *constant_expression* values are omitted.
+- Declaration order for field declarations determines the order in which their initializers (if any) are executed ([§14.5.6.2](classes.md#14562-static-field-initialization), [§14.5.6.3](classes.md#14563-instance-field-initialization)).
+- Local variables shall be defined before they are used ([§7.7](basic-concepts.md#77-scopes)).
+- Declaration order for enum member declarations ([§18.4](enums.md#184-enum-members)) is significant when *constant_expression* values are omitted.
 
 > *Example*: The declaration space of a namespace is “open ended”, and two namespace declarations with the same fully qualified name contribute to the same declaration space. For example
 > ```csharp
@@ -211,22 +211,22 @@ When access to a particular member is allowed, the member is said to be ***acces
 
 The ***declared accessibility*** of a member can be one of the following:
 
--   Public, which is selected by including a `public` modifier in the member declaration. The intuitive meaning of `public` is “access not limited”.
--   Protected, which is selected by including a `protected` modifier in the member declaration. The intuitive meaning of `protected` is “access limited to the containing class or types derived from the containing class”.
--   Internal, which is selected by including an `internal` modifier in the member declaration. The intuitive meaning of `internal` is “access limited to this assembly”.
--   Protected internal, which is selected by including both a `protected` and an `internal` modifier in the member declaration. The intuitive meaning of `protected internal` is “accessible within this assembly as well as types derived from the containing class”.
--   Private, which is selected by including a `private` modifier in the member declaration. The intuitive meaning of `private` is “access limited to the containing type”.
+- Public, which is selected by including a `public` modifier in the member declaration. The intuitive meaning of `public` is “access not limited”.
+- Protected, which is selected by including a `protected` modifier in the member declaration. The intuitive meaning of `protected` is “access limited to the containing class or types derived from the containing class”.
+- Internal, which is selected by including an `internal` modifier in the member declaration. The intuitive meaning of `internal` is “access limited to this assembly”.
+- Protected internal, which is selected by including both a `protected` and an `internal` modifier in the member declaration. The intuitive meaning of `protected internal` is “accessible within this assembly as well as types derived from the containing class”.
+- Private, which is selected by including a `private` modifier in the member declaration. The intuitive meaning of `private` is “access limited to the containing type”.
 
 Depending on the context in which a member declaration takes place, only certain types of declared accessibility are permitted. Furthermore, when a member declaration does not include any access modifiers, the context in which the declaration takes place determines the default declared accessibility.
 
--   Namespaces implicitly have `public` declared accessibility. No access modifiers are allowed on namespace declarations.
--   Types declared directly in compilation units or namespaces (as opposed to within other types) can have `public` or `internal` declared accessibility and default to `internal` declared accessibility.
--   Class members can have any of the five kinds of declared accessibility and default to `private` declared accessibility.  
+- Namespaces implicitly have `public` declared accessibility. No access modifiers are allowed on namespace declarations.
+- Types declared directly in compilation units or namespaces (as opposed to within other types) can have `public` or `internal` declared accessibility and default to `internal` declared accessibility.
+- Class members can have any of the five kinds of declared accessibility and default to `private` declared accessibility.  
     > *Note*: A type declared as a member of a class can have any of the five kinds of declared accessibility, whereas a type declared as a member of a namespace can have only `public` or `internal` declared accessibility. *end note*
--   Struct members can have `public`, `internal`, or `private` declared accessibility and default to `private` declared accessibility because structs are implicitly sealed. Struct members introduced in a `struct` (that is, not inherited by that struct) cannot have `protected` or `protected internal` declared accessibility.  
+- Struct members can have `public`, `internal`, or `private` declared accessibility and default to `private` declared accessibility because structs are implicitly sealed. Struct members introduced in a `struct` (that is, not inherited by that struct) cannot have `protected` or `protected internal` declared accessibility.  
     > *Note*: A type declared as a member of a struct can have `public`, `internal`, or `private` declared accessibility, whereas a type declared as a member of a namespace can have only `public` or `internal` declared accessibility. *end note*
--   Interface members implicitly have `public` declared accessibility. No access modifiers are allowed on interface member declarations.
--   Enumeration members implicitly have `public` declared accessibility. No access modifiers are allowed on enumeration member declarations.
+- Interface members implicitly have `public` declared accessibility. No access modifiers are allowed on interface member declarations.
+- Enumeration members implicitly have `public` declared accessibility. No access modifiers are allowed on enumeration member declarations.
 
 ### 7.5.3 Accessibility domains
 
@@ -236,8 +236,8 @@ The accessibility domain of a predefined type (such as `object`, `int`, or `doub
 
 The accessibility domain of a top-level unbound type `T` ([§8.4.4](types.md#844-bound-and-unbound-types)) that is declared in a program `P` is defined as follows:
 
--   If the declared accessibility of `T` is public, the accessibility domain of `T` is the program text of `P` and any program that references `P`.
--   If the declared accessibility of `T` is internal, the accessibility domain of `T` is the program text of `P`.
+- If the declared accessibility of `T` is public, the accessibility domain of `T` is the program text of `P` and any program that references `P`.
+- If the declared accessibility of `T` is internal, the accessibility domain of `T` is the program text of `P`.
 
 > *Note*: From these definitions, it follows that the accessibility domain of a top-level unbound type is always at least the program text of the program in which that type is declared. *end note*
 
@@ -245,11 +245,11 @@ The accessibility domain for a constructed type `T<A₁, ..., Aₑ>` is the inte
 
 The accessibility domain of a nested member `M` declared in a type `T` within a program `P`, is defined as follows (noting that `M` itself might possibly be a type):
 
--   If the declared accessibility of `M` is `public`, the accessibility domain of `M` is the accessibility domain of `T`.
--   If the declared accessibility of `M` is `protected internal`, let `D` be the union of the program text of `P` and the program text of any type derived from `T`, which is declared outside `P`. The accessibility domain of `M` is the intersection of the accessibility domain of `T` with `D`.
--   If the declared accessibility of `M` is `protected`, let `D` be the union of the program text of `T`and the program text of any type derived from `T`. The accessibility domain of `M` is the intersection of the accessibility domain of `T` with `D`.
--   If the declared accessibility of `M` is `internal`, the accessibility domain of `M` is the intersection of the accessibility domain of `T` with the program text of `P`.
--   If the declared accessibility of `M` is `private`, the accessibility domain of `M` is the program text of `T`.
+- If the declared accessibility of `M` is `public`, the accessibility domain of `M` is the accessibility domain of `T`.
+- If the declared accessibility of `M` is `protected internal`, let `D` be the union of the program text of `P` and the program text of any type derived from `T`, which is declared outside `P`. The accessibility domain of `M` is the intersection of the accessibility domain of `T` with `D`.
+- If the declared accessibility of `M` is `protected`, let `D` be the union of the program text of `T`and the program text of any type derived from `T`. The accessibility domain of `M` is the intersection of the accessibility domain of `T` with `D`.
+- If the declared accessibility of `M` is `internal`, the accessibility domain of `M` is the intersection of the accessibility domain of `T` with the program text of `P`.
+- If the declared accessibility of `M` is `private`, the accessibility domain of `M` is the program text of `T`.
 
 > *Note*: From these definitions it follows that the accessibility domain of a nested member is always at least the program text of the type in which the member is declared. Furthermore, it follows that the accessibility domain of a member is never more inclusive than the accessibility domain of the type in which the member is declared. *end note*
 <!-- markdownlint-disable MD028 -->
@@ -257,13 +257,13 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 <!-- markdownlint-enable MD028 -->
 > *Note*: In intuitive terms, when a type or member `M` is accessed, the following steps are evaluated to ensure that the access is permitted:
 >
-> -   First, if `M` is declared within a type (as opposed to a compilation unit or a namespace), a compile-time error occurs if that type is not accessible.
-> -   Then, if `M` is `public`, the access is permitted.
-> -   Otherwise, if `M` is `protected internal`, the access is permitted if it occurs within the program in which `M` is declared, or if it occurs within a class derived from the class in which `M` is declared and takes place through the derived class type ([§7.5.4](basic-concepts.md#754-protected-access)).
-> -   Otherwise, if `M` is `protected`, the access is permitted if it occurs within the class in which `M` is declared, or if it occurs within a class derived from the class in which `M` is declared and takes place through the derived class type ([§7.5.4](basic-concepts.md#754-protected-access)).
-> -   Otherwise, if `M` is `internal`, the access is permitted if it occurs within the program in which `M` is declared.
-> -   Otherwise, if `M` is `private`, the access is permitted if it occurs within the type in which `M` is declared.
-> -   Otherwise, the type or member is inaccessible, and a compile-time error occurs.
+> - First, if `M` is declared within a type (as opposed to a compilation unit or a namespace), a compile-time error occurs if that type is not accessible.
+> - Then, if `M` is `public`, the access is permitted.
+> - Otherwise, if `M` is `protected internal`, the access is permitted if it occurs within the program in which `M` is declared, or if it occurs within a class derived from the class in which `M` is declared and takes place through the derived class type ([§7.5.4](basic-concepts.md#754-protected-access)).
+> - Otherwise, if `M` is `protected`, the access is permitted if it occurs within the class in which `M` is declared, or if it occurs within a class derived from the class in which `M` is declared and takes place through the derived class type ([§7.5.4](basic-concepts.md#754-protected-access)).
+> - Otherwise, if `M` is `internal`, the access is permitted if it occurs within the program in which `M` is declared.
+> - Otherwise, if `M` is `private`, the access is permitted if it occurs within the type in which `M` is declared.
+> - Otherwise, the type or member is inaccessible, and a compile-time error occurs.
 >
 > *end note*
 <!-- markdownlint-disable MD028 -->
@@ -301,13 +301,13 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 > ```
 > the classes and members have the following accessibility domains:
 >
-> -   The accessibility domain of `A` and `A.X` is unlimited.
-> -   The accessibility domain of `A.Y`, `B`, `B.X`, `B.Y`, `B.C`, `B.C.X`, and `B.C.Y` is the program text of the containing program.
-> -   The accessibility domain of `A.Z` is the program text of `A`.
-> -   The accessibility domain of `B.Z` and `B.D` is the program text of `B`, including the program text of `B.C` and `B.D`.
-> -   The accessibility domain of `B.C.Z` is the program text of `B.C`.
-> -   The accessibility domain of `B.D.X` and `B.D.Y` is the program text of `B`, including the program text of `B.C` and `B.D`.
-> -   The accessibility domain of `B.D.Z` is the program text of `B.D`.
+> - The accessibility domain of `A` and `A.X` is unlimited.
+> - The accessibility domain of `A.Y`, `B`, `B.X`, `B.Y`, `B.C`, `B.C.X`, and `B.C.Y` is the program text of the containing program.
+> - The accessibility domain of `A.Z` is the program text of `A`.
+> - The accessibility domain of `B.Z` and `B.D` is the program text of `B`, including the program text of `B.C` and `B.D`.
+> - The accessibility domain of `B.C.Z` is the program text of `B.C`.
+> - The accessibility domain of `B.D.X` and `B.D.Y` is the program text of `B`, including the program text of `B.C` and `B.D`.
+> - The accessibility domain of `B.D.Z` is the program text of `B.D`.
 > As the example illustrates, the accessibility domain of a member is never larger than that of a containing type. For example, even though all `X` members have public declared accessibility, all but `A.X` have accessibility domains that are constrained by a containing type. *end example*
 
 As described in [§7.4](basic-concepts.md#74-members), all members of a base class, except for instance constructors, finalizers, and static constructors, are inherited by derived types. This includes even private members of a base class. However, the accessibility domain of a private member includes only the program text of the type in which the member is declared.
@@ -340,10 +340,10 @@ When a `protected` instance member is accessed outside the program text of the c
 
 Let `B` be a base class that declares a protected instance member `M`, and let `D` be a class that derives from `B`. Within the *class_body* of `D`, access to `M` can take one of the following forms:
 
--   An unqualified *type_name* or *primary_expression* of the form `M`.
--   A *primary_expression* of the form `E.M`, provided the type of `E` is `T` or a class derived from `T`, where `T` is the class `D`, or a class type constructed from `D`.
--   A *primary_expression* of the form `base.M`.
--   A *primary_expression* of the form `base[`*argument_list*`]`.
+- An unqualified *type_name* or *primary_expression* of the form `M`.
+- A *primary_expression* of the form `E.M`, provided the type of `E` is `T` or a class derived from `T`, where `T` is the class `D`, or a class type constructed from `D`.
+- A *primary_expression* of the form `base.M`.
+- A *primary_expression* of the form `base[`*argument_list*`]`.
 
 In addition to these forms of access, a derived class can access a protected instance constructor of a base class in a *constructor_initializer* ([§14.11.2](classes.md#14112-constructor-initializers)).
 
@@ -420,18 +420,18 @@ Several constructs in the C# language require a type to be at least as accessib
 
 The following accessibility constraints exist:
 
--   The direct base class of a class type shall be at least as accessible as the class type itself.
--   The explicit base interfaces of an interface type shall be at least as accessible as the interface type itself.
--   The return type and parameter types of a delegate type shall be at least as accessible as the delegate type itself.
--   The type of a constant shall be at least as accessible as the constant itself.
--   The type of a field shall be at least as accessible as the field itself.
--   The return type and parameter types of a method shall be at least as accessible as the method itself.
--   The type of a property shall be at least as accessible as the property itself.
--   The type of an event shall be at least as accessible as the event itself.
--   The type and parameter types of an indexer shall be at least as accessible as the indexer itself.
--   The return type and parameter types of an operator shall be at least as accessible as the operator itself.
--   The parameter types of an instance constructor shall be at least as accessible as the instance constructor itself.
--   An interface or class type constraint on a type parameter shall be at least as accessible as the member which declares the constraint.
+- The direct base class of a class type shall be at least as accessible as the class type itself.
+- The explicit base interfaces of an interface type shall be at least as accessible as the interface type itself.
+- The return type and parameter types of a delegate type shall be at least as accessible as the delegate type itself.
+- The type of a constant shall be at least as accessible as the constant itself.
+- The type of a field shall be at least as accessible as the field itself.
+- The return type and parameter types of a method shall be at least as accessible as the method itself.
+- The type of a property shall be at least as accessible as the property itself.
+- The type of an event shall be at least as accessible as the event itself.
+- The type and parameter types of an indexer shall be at least as accessible as the indexer itself.
+- The return type and parameter types of an operator shall be at least as accessible as the operator itself.
+- The parameter types of an instance constructor shall be at least as accessible as the instance constructor itself.
+- An interface or class type constraint on a type parameter shall be at least as accessible as the member which declares the constraint.
 
 > *Example*: In the following code
 > ```csharp
@@ -459,20 +459,20 @@ The following accessibility constraints exist:
 
 Methods, instance constructors, indexers, and operators are characterized by their ***signatures***:
 
--   The signature of a method consists of the name of the method, the number of type parameters, and the type and parameter-passing mode (value, reference, or output) of each of its formal parameters, considered in the order left to right. For these purposes, any type parameter of the method that occurs in the type of a formal parameter is identified not by its name, but by its ordinal position in the type parameter list of the method. The signature of a method specifically does not include the return type, parameter names, type parameter names, type parameter constraints, the `params` or `this` parameter modifiers, nor whether parameters are required or optional.
+- The signature of a method consists of the name of the method, the number of type parameters, and the type and parameter-passing mode (value, reference, or output) of each of its formal parameters, considered in the order left to right. For these purposes, any type parameter of the method that occurs in the type of a formal parameter is identified not by its name, but by its ordinal position in the type parameter list of the method. The signature of a method specifically does not include the return type, parameter names, type parameter names, type parameter constraints, the `params` or `this` parameter modifiers, nor whether parameters are required or optional.
 
--   The signature of an instance constructor consists of the type and parameter-passing mode (value, reference, or output) of each of its formal parameters, considered in the order left to right. The signature of an instance constructor specifically does not include the `params` modifier that may be specified for the right-most parameter.
--   The signature of an indexer consists of the type of each of its formal parameters, considered in the order left to right. The signature of an indexer specifically does not include the element type, nor does it include the `params` modifier that may be specified for the right-most parameter.
--   The signature of an operator consists of the name of the operator and the type of each of its formal parameters, considered in the order left to right. The signature of an operator specifically does not include the result type.
--   The signature of a conversion operator consists of the source type and the target type. The implicit or explicit classification of a conversion operator is not part of the signature.
--   Two signatures of the same member kind (method, instance constructor, indexer or operator) are considered to be the *same signatures* if they have the same name, number of type parameters, number of parameters, and parameter-passing modes, and an identity conversion exists between the types of their corresponding parameters ([§10.2.2](conversions.md#1022-identity-conversion)).
+- The signature of an instance constructor consists of the type and parameter-passing mode (value, reference, or output) of each of its formal parameters, considered in the order left to right. The signature of an instance constructor specifically does not include the `params` modifier that may be specified for the right-most parameter.
+- The signature of an indexer consists of the type of each of its formal parameters, considered in the order left to right. The signature of an indexer specifically does not include the element type, nor does it include the `params` modifier that may be specified for the right-most parameter.
+- The signature of an operator consists of the name of the operator and the type of each of its formal parameters, considered in the order left to right. The signature of an operator specifically does not include the result type.
+- The signature of a conversion operator consists of the source type and the target type. The implicit or explicit classification of a conversion operator is not part of the signature.
+- Two signatures of the same member kind (method, instance constructor, indexer or operator) are considered to be the *same signatures* if they have the same name, number of type parameters, number of parameters, and parameter-passing modes, and an identity conversion exists between the types of their corresponding parameters ([§10.2.2](conversions.md#1022-identity-conversion)).
 
 Signatures are the enabling mechanism for ***overloading*** of members in classes, structs, and interfaces:
 
--   Overloading of methods permits a class, struct, or interface to declare multiple methods with the same name, provided their signatures are unique within that class, struct, or interface.
--   Overloading of instance constructors permits a class or struct to declare multiple instance constructors, provided their signatures are unique within that class or struct.
--   Overloading of indexers permits a class, struct, or interface to declare multiple indexers, provided their signatures are unique within that class, struct, or interface.
--   Overloading of operators permits a class or struct to declare multiple operators with the same name, provided their signatures are unique within that class or struct.
+- Overloading of methods permits a class, struct, or interface to declare multiple methods with the same name, provided their signatures are unique within that class, struct, or interface.
+- Overloading of instance constructors permits a class or struct to declare multiple instance constructors, provided their signatures are unique within that class or struct.
+- Overloading of indexers permits a class, struct, or interface to declare multiple indexers, provided their signatures are unique within that class, struct, or interface.
+- Overloading of operators permits a class or struct to declare multiple operators with the same name, provided their signatures are unique within that class or struct.
 
 Although `out` and `ref` parameter modifiers are considered part of a signature, members declared in a single type cannot differ in signature solely by `ref` and `out`. A compile-time error occurs if two members are declared in the same type with signatures that would be the same if all parameters in both methods with `out` modifiers were changed to `ref` modifiers. For other purposes of signature matching (e.g., hiding or overriding), `ref` and `out` are considered part of the signature and do not match each other.
 
@@ -509,32 +509,32 @@ The types `object` and `dynamic` are not distinguished when comparing signatures
 
 The ***scope*** of a name is the region of program text within which it is possible to refer to the entity declared by the name without qualification of the name. Scopes can be *nested*, and an inner scope may redeclare the meaning of a name from an outer scope. (This does not, however, remove the restriction imposed by [§7.3](basic-concepts.md#73-declarations) that within a nested block it is not possible to declare a local variable or local constant with the same name as a local variable or local constant in an enclosing block.) The name from the outer scope is then said to be ***hidden*** in the region of program text covered by the inner scope, and access to the outer name is only possible by qualifying the name.
 
--   The scope of a namespace member declared by a *namespace_member_declaration* ([§13.6](namespaces.md#136-namespace-member-declarations)) with no enclosing *namespace_declaration* is the entire program text.
--   The scope of a namespace member declared by a *namespace_member_declaration* within a *namespace_declaration* whose fully qualified name is `N`, is the *namespace_body* of every *namespace_declaration* whose fully qualified name is `N` or starts with `N`, followed by a period.
--   The scope of a name defined by an *extern_alias_directive* ([§13.4](namespaces.md#134-extern-alias-directives)) extends over the *using_directive*s, *global_attributes* and *namespace_member_declaration*s of its immediately containing *compilation_unit* or *namespace_body*. An *extern_alias_directive* does not contribute any new members to the underlying declaration space. In other words, an *extern_alias_directive* is not transitive, but, rather, affects only the *compilation_unit* or *namespace_body* in which it occurs.
--   The scope of a name defined or imported by a *using_directive* ([§13.5](namespaces.md#135-using-directives)) extends over the *global_attributes* and *namespace_member_declaration*s of the *compilation_unit* or *namespace_body* in which the *using_directive* occurs. A *using_directive* may make zero or more namespace or type names available within a particular *compilation_unit* or *namespace_body*, but does not contribute any new members to the underlying declaration space. In other words, a *using_directive* is not transitive but rather affects only the *compilation_unit* or *namespace_body* in which it occurs.
--   The scope of a type parameter declared by a *type_parameter_list* on a *class_declaration* ([§14.2](classes.md#142-class-declarations)) is the *class_base*, *type_parameter_constraints_clauses*, and *class_body* of that *class_declaration*.  
+- The scope of a namespace member declared by a *namespace_member_declaration* ([§13.6](namespaces.md#136-namespace-member-declarations)) with no enclosing *namespace_declaration* is the entire program text.
+- The scope of a namespace member declared by a *namespace_member_declaration* within a *namespace_declaration* whose fully qualified name is `N`, is the *namespace_body* of every *namespace_declaration* whose fully qualified name is `N` or starts with `N`, followed by a period.
+- The scope of a name defined by an *extern_alias_directive* ([§13.4](namespaces.md#134-extern-alias-directives)) extends over the *using_directive*s, *global_attributes* and *namespace_member_declaration*s of its immediately containing *compilation_unit* or *namespace_body*. An *extern_alias_directive* does not contribute any new members to the underlying declaration space. In other words, an *extern_alias_directive* is not transitive, but, rather, affects only the *compilation_unit* or *namespace_body* in which it occurs.
+- The scope of a name defined or imported by a *using_directive* ([§13.5](namespaces.md#135-using-directives)) extends over the *global_attributes* and *namespace_member_declaration*s of the *compilation_unit* or *namespace_body* in which the *using_directive* occurs. A *using_directive* may make zero or more namespace or type names available within a particular *compilation_unit* or *namespace_body*, but does not contribute any new members to the underlying declaration space. In other words, a *using_directive* is not transitive but rather affects only the *compilation_unit* or *namespace_body* in which it occurs.
+- The scope of a type parameter declared by a *type_parameter_list* on a *class_declaration* ([§14.2](classes.md#142-class-declarations)) is the *class_base*, *type_parameter_constraints_clauses*, and *class_body* of that *class_declaration*.  
     > *Note*: Unlike members of a class, this scope does not extend to derived classes. *end note*
--   The scope of a type parameter declared by a *type_parameter_list* on a *struct_declaration* ([§15.2](structs.md#152-struct-declarations)) is the *struct_interfaces*, *type_parameter_constraints_clause*s, and *struct_body* of that *struct_declaration*.
--   The scope of a type parameter declared by a *type_parameter_list* on an *interface_declaration* ([§17.2](interfaces.md#172-interface-declarations)) is the *interface_base*, *type_parameter_constraints_clause*s, and *interface_body* of that *interface_declaration*.
--   The scope of a type parameter declared by a *type_parameter_list* on a *delegate_declaration* ([§19.2](delegates.md#192-delegate-declarations)) is the *return_type*, *formal_parameter_list*, and *type_parameter_constraints_clause*s of that *delegate_declaration*.
--   The scope of a type parameter declared by a *type_parameter_list* on a *method_declaration* ([§14.6.1](classes.md#1461-general)) is the *method_declaration*.
--   The scope of a member declared by a *class_member_declaration* ([§14.3.1](classes.md#1431-general)) is the *class_body* in which the declaration occurs. In addition, the scope of a class member extends to the *class_body* of those derived classes that are included in the accessibility domain ([§7.5.3](basic-concepts.md#753-accessibility-domains)) of the member.
--   The scope of a member declared by a *struct_member_declaration* ([§15.3](structs.md#153-struct-members)) is the *struct_body* in which the declaration occurs.
+- The scope of a type parameter declared by a *type_parameter_list* on a *struct_declaration* ([§15.2](structs.md#152-struct-declarations)) is the *struct_interfaces*, *type_parameter_constraints_clause*s, and *struct_body* of that *struct_declaration*.
+- The scope of a type parameter declared by a *type_parameter_list* on an *interface_declaration* ([§17.2](interfaces.md#172-interface-declarations)) is the *interface_base*, *type_parameter_constraints_clause*s, and *interface_body* of that *interface_declaration*.
+- The scope of a type parameter declared by a *type_parameter_list* on a *delegate_declaration* ([§19.2](delegates.md#192-delegate-declarations)) is the *return_type*, *formal_parameter_list*, and *type_parameter_constraints_clause*s of that *delegate_declaration*.
+- The scope of a type parameter declared by a *type_parameter_list* on a *method_declaration* ([§14.6.1](classes.md#1461-general)) is the *method_declaration*.
+- The scope of a member declared by a *class_member_declaration* ([§14.3.1](classes.md#1431-general)) is the *class_body* in which the declaration occurs. In addition, the scope of a class member extends to the *class_body* of those derived classes that are included in the accessibility domain ([§7.5.3](basic-concepts.md#753-accessibility-domains)) of the member.
+- The scope of a member declared by a *struct_member_declaration* ([§15.3](structs.md#153-struct-members)) is the *struct_body* in which the declaration occurs.
 
--   The scope of a member declared by an *enum_member_declaration* ([§18.4](enums.md#184-enum-members)) is the *enum_body* in which the declaration occurs.
--   The scope of a parameter declared in a *method_declaration* ([§14.6](classes.md#146-methods)) is the *method_body* of that *method_declaration*.
--   The scope of a parameter declared in an *indexer_declaration* ([§14.9](classes.md#149-indexers)) is the *accessor_declarations* of that *indexer_declaration*.
--   The scope of a parameter declared in an *operator_declaration* ([§14.10](classes.md#1410-operators)) is the *block* of that *operator_declaration*.
--   The scope of a parameter declared in a *constructor_declaration* ([§14.11](classes.md#1411-instance-constructors)) is the *constructor_initializer* and *block* of that *constructor_declaration*.
--   The scope of a parameter declared in a *lambda_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)) is the *lambda_expression_body* of that *lambda_expression*.
--   The scope of a parameter declared in an *anonymous_method_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)) is the *block* of that *anonymous_method_expression*.
--   The scope of a label declared in a *labeled_statement* ([§12.5](statements.md#125-labeled-statements)) is the *block* in which the declaration occurs.
--   The scope of a local variable declared in a *local_variable_declaration* ([§12.6.2](statements.md#1262-local-variable-declarations)) is the *block* in which the declaration occurs.
--   The scope of a local variable declared in a *switch_block* of a `switch` statement ([§12.8.3](statements.md#1283-the-switch-statement)) is the *switch_block*.
--   The scope of a local variable declared in a *for_initializer* of a `for` statement ([§12.9.4](statements.md#1294-the-for-statement)) is the *for_initializer*, the *for_condition*, the *for_iterator*, and the contained *statement* of the `for` statement.
--   The scope of a local constant declared in a *local_constant_declaration* ([§12.6.3](statements.md#1263-local-constant-declarations)) is the *block* in which the declaration occurs. It is a compile-time error to refer to a local constant in a textual position that precedes its *constant_declarator*.
--   The scope of a variable declared as part of a *foreach_statement*, *using_statement*, *lock_statement* or *query_expression* is determined by the expansion of the given construct.
+- The scope of a member declared by an *enum_member_declaration* ([§18.4](enums.md#184-enum-members)) is the *enum_body* in which the declaration occurs.
+- The scope of a parameter declared in a *method_declaration* ([§14.6](classes.md#146-methods)) is the *method_body* of that *method_declaration*.
+- The scope of a parameter declared in an *indexer_declaration* ([§14.9](classes.md#149-indexers)) is the *accessor_declarations* of that *indexer_declaration*.
+- The scope of a parameter declared in an *operator_declaration* ([§14.10](classes.md#1410-operators)) is the *block* of that *operator_declaration*.
+- The scope of a parameter declared in a *constructor_declaration* ([§14.11](classes.md#1411-instance-constructors)) is the *constructor_initializer* and *block* of that *constructor_declaration*.
+- The scope of a parameter declared in a *lambda_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)) is the *lambda_expression_body* of that *lambda_expression*.
+- The scope of a parameter declared in an *anonymous_method_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)) is the *block* of that *anonymous_method_expression*.
+- The scope of a label declared in a *labeled_statement* ([§12.5](statements.md#125-labeled-statements)) is the *block* in which the declaration occurs.
+- The scope of a local variable declared in a *local_variable_declaration* ([§12.6.2](statements.md#1262-local-variable-declarations)) is the *block* in which the declaration occurs.
+- The scope of a local variable declared in a *switch_block* of a `switch` statement ([§12.8.3](statements.md#1283-the-switch-statement)) is the *switch_block*.
+- The scope of a local variable declared in a *for_initializer* of a `for` statement ([§12.9.4](statements.md#1294-the-for-statement)) is the *for_initializer*, the *for_condition*, the *for_iterator*, and the contained *statement* of the `for` statement.
+- The scope of a local constant declared in a *local_constant_declaration* ([§12.6.3](statements.md#1263-local-constant-declarations)) is the *block* in which the declaration occurs. It is a compile-time error to refer to a local constant in a textual position that precedes its *constant_declarator*.
+- The scope of a variable declared as part of a *foreach_statement*, *using_statement*, *lock_statement* or *query_expression* is determined by the expansion of the given construct.
 
 Within the scope of a namespace, class, struct, or enumeration member it is possible to refer to the member in a textual position that precedes the declaration of the member.
 
@@ -661,9 +661,9 @@ When a name in an inner scope hides a name in an outer scope, it hides all overl
 
 Name hiding through inheritance occurs when classes or structs redeclare names that were inherited from base classes. This type of name hiding takes one of the following forms:
 
--   A constant, field, property, event, or type introduced in a class or struct hides all base class members with the same name.
--   A method introduced in a class or struct hides all non-method base class members with the same name, and all base class methods with the same signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)).
--   An indexer introduced in a class or struct hides all base class indexers with the same signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)) .
+- A constant, field, property, event, or type introduced in a class or struct hides all base class members with the same name.
+- A method introduced in a class or struct hides all non-method base class members with the same name, and all base class methods with the same signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)).
+- An indexer introduced in a class or struct hides all base class indexers with the same signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)) .
 
 The rules governing operator declarations ([§14.10](classes.md#1410-operators)) make it impossible for a derived class to declare an operator with the same signature as an operator in a base class. Thus, operators never hide one another.
 
@@ -751,10 +751,10 @@ A *type_name* is a *namespace_or_type_name* that refers to a type. Following res
 
 If the *namespace_or_type_name* is a *qualified_alias_member* its meaning is as described in [§13.8.1](namespaces.md#1381-general). Otherwise, a *namespace_or_type_name* has one of four forms:
 
--   `I`
--   `I<A₁, ..., Aₓ>`
--   `N.I`
--   `N.I<A₁, ..., Aₓ>`
+- `I`
+- `I<A₁, ..., Aₓ>`
+- `N.I`
+- `N.I<A₁, ..., Aₓ>`
 
 where `I` is a single identifier, `N` is a *namespace_or_type_name* and `<A₁, ..., Aₓ>` is an optional *type_argument_list*. When no *type_argument_list* is specified, consider `x` to be zero.
 
@@ -788,29 +788,29 @@ The meaning of a *namespace_or_type_name* is determined as follows:
 
 A *namespace_or_type_name* is permitted to reference a static class ([§14.2.2.4](classes.md#14224-static-classes)) only if
 
--   The *namespace_or_type_name* is the `T` in a *namespace_or_type_name* of the form `T.I`, or
--   The *namespace_or_type_name* is the `T` in a *typeof_expression* ([§11.7.16](expressions.md#11716-the-typeof-operator)) of the form `typeof(T)`
+- The *namespace_or_type_name* is the `T` in a *namespace_or_type_name* of the form `T.I`, or
+- The *namespace_or_type_name* is the `T` in a *typeof_expression* ([§11.7.16](expressions.md#11716-the-typeof-operator)) of the form `typeof(T)`
 
 ### 7.8.2 Unqualified names
 
 Every namespace declaration and type declaration has an ***unqualified name*** determined as follows:
 
--   For a namespace declaration, the unqualified name is the *qualified_identifier* specified in the declaration.
--   For a type declaration with no *type_parameter_list*, the unqualified name is the *identifier* specified in the declaration.
--   For a type declaration with K type parameters, the unqualified name is the *identifier* specified in the declaration, followed by the *generic_dimension_specifier* ([§11.7.16](expressions.md#11716-the-typeof-operator)) for K type parameters.
+- For a namespace declaration, the unqualified name is the *qualified_identifier* specified in the declaration.
+- For a type declaration with no *type_parameter_list*, the unqualified name is the *identifier* specified in the declaration.
+- For a type declaration with K type parameters, the unqualified name is the *identifier* specified in the declaration, followed by the *generic_dimension_specifier* ([§11.7.16](expressions.md#11716-the-typeof-operator)) for K type parameters.
 
 ### 7.8.3 Fully qualified names
 
 Every namespace and type declaration has a ***fully qualified name,*** which uniquely identifies the namespace or type declaration amongst all others within the program. The fully qualified name of a namespace or type declaration with unqualified name `N` is determined as follows:
 
--   If `N` is a member of the global namespace, its fully qualified name is `N`.
--   Otherwise, its fully qualified name is `S.N`, where `S` is the fully qualified name of the namespace or type declaration in which `N` is declared.
+- If `N` is a member of the global namespace, its fully qualified name is `N`.
+- Otherwise, its fully qualified name is `S.N`, where `S` is the fully qualified name of the namespace or type declaration in which `N` is declared.
 
 In other words, the fully qualified name of `N` is the complete hierarchical path of identifiers and *generic_dimension_specifier*s that lead to `N`, starting from the global namespace. Because every member of a namespace or type shall have a unique name, it follows that the fully qualified name of a namespace or type declaration is always unique. It is a compile-time error for the same fully qualified name to refer to two distinct entities. In particular:
 
--   It is an error for both a namespace declaration and a type declaration to have the same fully qualified name.
--   It is an error for two different kinds of type declarations to have the same fully qualified name (for example, if both a struct and class declaration have the same fully qualified name).
--   It is an error for a type declaration without the partial modifier to have the same fully qualified name as another type declaration ([§14.2.7](classes.md#1427-partial-declarations)).
+- It is an error for both a namespace declaration and a type declaration to have the same fully qualified name.
+- It is an error for two different kinds of type declarations to have the same fully qualified name (for example, if both a struct and class declaration have the same fully qualified name).
+- It is an error for a type declaration without the partial modifier to have the same fully qualified name as another type declaration ([§14.2.7](classes.md#1427-partial-declarations)).
 
 > *Example*: The example below shows several namespace and type declarations along with their associated fully qualified names.
 > ```csharp
@@ -845,13 +845,13 @@ In other words, the fully qualified name of `N` is the complete hierarchical pa
 
 C# employs automatic memory management, which frees developers from manually allocating and freeing the memory occupied by objects. Automatic memory management policies are implemented by a garbage collector. The memory management life cycle of an object is as follows:
 
-1.  When the object is created, memory is allocated for it, the constructor is run, and the object is considered ***live***.
-1.  If neither the object nor any of its instance fields can be accessed by any possible continuation of execution, other than the running of finalizers, the object is considered ***no longer in use*** and it becomes eligible for finalization.  
+1. When the object is created, memory is allocated for it, the constructor is run, and the object is considered ***live***.
+1. If neither the object nor any of its instance fields can be accessed by any possible continuation of execution, other than the running of finalizers, the object is considered ***no longer in use*** and it becomes eligible for finalization.  
     > *Note*: The C# compiler and the garbage collector might choose to analyze code to determine which references to an object might be used in the future. For instance, if a local variable that is in scope is the only existing reference to an object, but that local variable is never referred to in any possible continuation of execution from the current execution point in the procedure, the garbage collector might (but is not required to) treat the object as no longer in use. *end note*
-1.  Once the object is eligible for finalization, at some unspecified later time the finalizer ([§14.13](classes.md#1413-finalizers)) (if any) for the object is run. Under normal circumstances the finalizer for the object is run once only, though implementation-specific APIs may allow this behavior to be overridden.
-1.  Once the finalizer for an object is run, if neither the object nor any of its instance fields can be accessed by any possible continuation of execution, including the running of finalizers, the object is considered inaccessible and the object becomes eligible for collection.  
+1. Once the object is eligible for finalization, at some unspecified later time the finalizer ([§14.13](classes.md#1413-finalizers)) (if any) for the object is run. Under normal circumstances the finalizer for the object is run once only, though implementation-specific APIs may allow this behavior to be overridden.
+1. Once the finalizer for an object is run, if neither the object nor any of its instance fields can be accessed by any possible continuation of execution, including the running of finalizers, the object is considered inaccessible and the object becomes eligible for collection.  
     > *Note*: An object which could previously not be accessed may become accessible again due to its finalizer. An example of this is provided below. *end note*
-1.  Finally, at some time after the object becomes eligible for collection, the garbage collector frees the memory associated with that object.
+1. Finally, at some time after the object becomes eligible for collection, the garbage collector frees the memory associated with that object.
 
 The garbage collector maintains information about object usage, and uses this information to make memory management decisions, such as where in memory to locate a newly created object, when to relocate an object, and when an object is no longer in use or inaccessible.
 
@@ -971,6 +971,6 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 
 Execution of a C# program proceeds such that the side effects of each executing thread are preserved at critical execution points. A ***side effect*** is defined as a read or write of a volatile field, a write to a non-volatile variable, a write to an external resource, and the throwing of an exception. The critical execution points at which the order of these side effects shall be preserved are references to volatile fields ([§14.5.4](classes.md#1454-volatile-fields)), `lock` statements ([§12.13](statements.md#1213-the-lock-statement)), and thread creation and termination. The execution environment is free to change the order of execution of a C# program, subject to the following constraints:
 
--   Data dependence is preserved within a thread of execution. That is, the value of each variable is computed as if all statements in the thread were executed in original program order.
--   Initialization ordering rules are preserved ([§14.5.5](classes.md#1455-field-initialization), [§14.5.6](classes.md#1456-variable-initializers)).
--   The ordering of side effects is preserved with respect to volatile reads and writes ([§14.5.4](classes.md#1454-volatile-fields)). Additionally, the execution environment need not evaluate part of an expression if it can deduce that that expression’s value is not used and that no needed side effects are produced (including any caused by calling a method or accessing a volatile field). When program execution is interrupted by an asynchronous event (such as an exception thrown by another thread), it is not guaranteed that the observable side effects are visible in the original program order.
+- Data dependence is preserved within a thread of execution. That is, the value of each variable is computed as if all statements in the thread were executed in original program order.
+- Initialization ordering rules are preserved ([§14.5.5](classes.md#1455-field-initialization), [§14.5.6](classes.md#1456-variable-initializers)).
+- The ordering of side effects is preserved with respect to volatile reads and writes ([§14.5.4](classes.md#1454-volatile-fields)). Additionally, the execution environment need not evaluate part of an expression if it can deduce that that expression’s value is not used and that no needed side effects are produced (including any caused by calling a method or accessing a volatile field). When program execution is interrupted by an asynchronous event (such as an exception thrown by another thread), it is not guaranteed that the observable side effects are visible in the original program order.

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -263,9 +263,7 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 > - Otherwise, if `M` is `protected`, the access is permitted if it occurs within the class in which `M` is declared, or if it occurs within a class derived from the class in which `M` is declared and takes place through the derived class type ([§7.5.4](basic-concepts.md#754-protected-access)).
 > - Otherwise, if `M` is `internal`, the access is permitted if it occurs within the program in which `M` is declared.
 > - Otherwise, if `M` is `private`, the access is permitted if it occurs within the type in which `M` is declared.
-> - Otherwise, the type or member is inaccessible, and a compile-time error occurs.
->
-> *end note*
+> - Otherwise, the type or member is inaccessible, and a compile-time error occurs. *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3095,7 +3095,7 @@ Once a particular property or indexer has been selected, the accessibility domai
 - If the usage is as the target of a simple assignment ([§11.18.2](expressions.md#11182-simple-assignment)), the set accessor shall exist and be accessible.
 - If the usage is as the target of compound assignment ([§11.18.3](expressions.md#11183-compound-assignment)), or as the target of the `++` or `--` operators ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators), [§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators)), both the get accessors and the set accessor shall exist and be accessible.
 
-> *Example*: In the following example, the property `A.Text` is hidden by the property` B.Text`, even in contexts where only the set accessor is called. In contrast, the property `B.Count` is not accessible to class `M`, so the accessible property `A.Count` is used instead.
+> *Example*: In the following example, the property `A.Text` is hidden by the property `B.Text`, even in contexts where only the set accessor is called. In contrast, the property `B.Count` is not accessible to class `M`, so the accessible property `A.Count` is used instead.
 > ```csharp
 > class A
 > {
@@ -4022,7 +4022,7 @@ Instance constructors are invoked by *object_creation_expression*s ([§11.7.15.2
 
 ### 14.11.2 Constructor initializers
 
-All instance constructors (except those for class` object`) implicitly include an invocation of another instance constructor immediately before the *constructor_body*. The constructor to implicitly invoke is determined by the *constructor_initializer*:
+All instance constructors (except those for class `object`) implicitly include an invocation of another instance constructor immediately before the *constructor_body*. The constructor to implicitly invoke is determined by the *constructor_initializer*:
 
 - An instance constructor initializer of the form `base(`*argument_list*`)` (where *argument_list* is optional) causes an instance constructor from the direct base class to be invoked. That constructor is selected using *argument_list* and the overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). The set of candidate instance constructors consists of all the accessible instance constructors of the direct base class. If this set is empty, or if a single best instance constructor cannot be identified, a compile-time error occurs.
 - An instance constructor initializer of the form `this(`*argument_list*`)` (where *argument_list* is optional) invokes another instance constructor from the same class. The constructor is selected using *argument_list* and the overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). The set of candidate instance constructors consists of all instance constructors declared in the class itself. If the resulting set of applicable instance constructors is empty, or if a single best instance constructor cannot be identified, a compile-time error occurs. If an instance constructor declaration invokes itself through a chain of one or more constructor initializers, a compile-time error occurs.

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -59,9 +59,9 @@ The `abstract`, `sealed`, and `static` modifiers are discussed in the following 
 
 The `abstract` modifier is used to indicate that a class is incomplete and that it is intended to be used only as a base class. An ***abstract class*** differs from a ***non-abstract class*** in the following ways:
 
--  An abstract class cannot be instantiated directly, and it is a compile-time error to use the `new` operator on an abstract class. While it is possible to have variables and values whose compile-time types are abstract, such variables and values will necessarily either be `null` or contain references to instances of non-abstract classes derived from the abstract types.
--  An abstract class is permitted (but not required) to contain abstract members.
--  An abstract class cannot be sealed.
+- An abstract class cannot be instantiated directly, and it is a compile-time error to use the `new` operator on an abstract class. While it is possible to have variables and values whose compile-time types are abstract, such variables and values will necessarily either be `null` or contain references to instances of non-abstract classes derived from the abstract types.
+- An abstract class is permitted (but not required) to contain abstract members.
+- An abstract class cannot be sealed.
 
 When a non-abstract class is derived from an abstract class, the non-abstract class shall include actual implementations of all inherited abstract members, thereby overriding those abstract members.
 
@@ -107,11 +107,11 @@ The `static` modifier is used to mark the class being declared as a ***static cl
 
 A static class declaration is subject to the following restrictions:
 
--  A static class shall not include a `sealed` or `abstract` modifier. (However, since a static class cannot be instantiated or derived from, it behaves as if it was both sealed and abstract.)
--  A static class shall not include a *class_base* specification ([§14.2.4](classes.md#1424-class-base-specification)) and cannot explicitly specify a base class or a list of implemented interfaces. A static class implicitly inherits from type `object`.
--  A static class shall only contain static members ([§14.3.8](classes.md#1438-static-and-instance-members)).  
+- A static class shall not include a `sealed` or `abstract` modifier. (However, since a static class cannot be instantiated or derived from, it behaves as if it was both sealed and abstract.)
+- A static class shall not include a *class_base* specification ([§14.2.4](classes.md#1424-class-base-specification)) and cannot explicitly specify a base class or a list of implemented interfaces. A static class implicitly inherits from type `object`.
+- A static class shall only contain static members ([§14.3.8](classes.md#1438-static-and-instance-members)).  
    > *Note*: All constants and nested types are classified as static members. *end note*
--  A static class shall not have members with `protected` or `protected internal` declared accessibility.
+- A static class shall not have members with `protected` or `protected internal` declared accessibility.
 
 It is a compile-time error to violate any of these restrictions.
 
@@ -125,12 +125,12 @@ If one or more parts of a partial type declaration ([§14.2.7](classes.md#1427-p
 
 A *namespace_or_type_name* ([§7.8](basic-concepts.md#78-namespace-and-type-names)) is permitted to reference a static class if
 
--  The *namespace_or_type_name* is the `T` in a *namespace_or_type_name* of the form `T.I`, or
--  The *namespace_or_type-name* is the `T` in a *typeof_expression* ([§11.7.16](expressions.md#11716-the-typeof-operator)) of the form `typeof(T)`.
+- The *namespace_or_type_name* is the `T` in a *namespace_or_type_name* of the form `T.I`, or
+- The *namespace_or_type-name* is the `T` in a *typeof_expression* ([§11.7.16](expressions.md#11716-the-typeof-operator)) of the form `typeof(T)`.
 
 A *primary_expression* ([§11.7](expressions.md#117-primary-expressions)) is permitted to reference a static class if
 
--  The *primary_expression* is the `E` in a *member_access* ([§11.7.6](expressions.md#1176-member-access)) of the form `E.I`.
+- The *primary_expression* is the `E` in a *member_access* ([§11.7.6](expressions.md#1176-member-access)) of the form `E.I`.
 
 In any other context, it is a compile-time error to reference a static class.
 
@@ -380,16 +380,16 @@ If a constraint is a class type, an interface type, or a type parameter, that ty
 
 A *class_type* constraint shall satisfy the following rules:
 
--  The type shall be a class type.
--  The type shall not be `sealed`.
--  The type shall not be one of the following types: `System.Array`, `System.Delegate`, `System.Enum`, or `System.ValueType`.
--  The type shall not be `object`.
--  At most one constraint for a given type parameter may be a class type.
+- The type shall be a class type.
+- The type shall not be `sealed`.
+- The type shall not be one of the following types: `System.Array`, `System.Delegate`, `System.Enum`, or `System.ValueType`.
+- The type shall not be `object`.
+- At most one constraint for a given type parameter may be a class type.
 
 A type specified as an *interface_type* constraint shall satisfy the following rules:
 
--  The type shall be an interface type.
--  A type shall not be specified more than once in a given `where` clause.
+- The type shall be an interface type.
+- A type shall not be specified more than once in a given `where` clause.
 
 In either case, the constraint may involve any of the type parameters of the associated type or method declaration as part of a constructed type, and may involve the type being declared.
 
@@ -397,22 +397,22 @@ Any class or interface type specified as a type parameter constraint shall be at
 
 A type specified as a *type_parameter* constraint shall satisfy the following rules:
 
--  The type shall be a type parameter.
--  A type shall not be specified more than once in a given `where` clause.
+- The type shall be a type parameter.
+- A type shall not be specified more than once in a given `where` clause.
 
 In addition there shall be no cycles in the dependency graph of type parameters, where dependency is a transitive relation defined by:
 
--  If a type parameter `T` is used as a constraint for type parameter `S` then `S` ***depends on*** `T`.
--  If a type parameter `S` depends on a type parameter `T` and `T` depends on a type parameter `U` then `S` *depends on* `U`.
+- If a type parameter `T` is used as a constraint for type parameter `S` then `S` ***depends on*** `T`.
+- If a type parameter `S` depends on a type parameter `T` and `T` depends on a type parameter `U` then `S` *depends on* `U`.
 
 Given this relation, it is a compile-time error for a type parameter to depend on itself (directly or indirectly).
 
 Any constraints shall be consistent among dependent type parameters. If type parameter `S` depends on type parameter `T` then:
 
--  `T` shall not have the value type constraint. Otherwise, `T` is effectively sealed so `S` would be forced to be the same type as `T`, eliminating the need for two type parameters.
--  If `S` has the value type constraint then `T` shall not have a *class_type* constraint.
--  If `S` has a *class_type* constraint `A` and `T` has a *class_type* constraint `B` then there shall be an identity conversion or implicit reference conversion from `A` to `B` or an implicit reference conversion from `B` to `A`.
--  If `S` also depends on type parameter `U` and `U` has a *class_type* constraint `A` and `T` has a *class_type* constraint `B` then there shall be an identity conversion or implicit reference conversion from `A` to `B` or an implicit reference conversion from `B` to `A`.
+- `T` shall not have the value type constraint. Otherwise, `T` is effectively sealed so `S` would be forced to be the same type as `T`, eliminating the need for two type parameters.
+- If `S` has the value type constraint then `T` shall not have a *class_type* constraint.
+- If `S` has a *class_type* constraint `A` and `T` has a *class_type* constraint `B` then there shall be an identity conversion or implicit reference conversion from `A` to `B` or an implicit reference conversion from `B` to `A`.
+- If `S` also depends on type parameter `U` and `U` has a *class_type* constraint `A` and `T` has a *class_type* constraint `B` then there shall be an identity conversion or implicit reference conversion from `A` to `B` or an implicit reference conversion from `B` to `A`.
 
 It is valid for `S` to have the value type constraint and `T` to have the reference type constraint. Effectively this limits `T` to the types `System.Object`, `System.ValueType`, `System.Enum`, and any interface type.
 
@@ -487,29 +487,29 @@ It is a compile-time error for *type_parameter_constraints* having a *primary_co
 
 The ***dynamic erasure*** of a type `C` is type `Cₓ` constructed as follows:
 
--  If `C` is a nested type `Outer.Inner` then `Cₓ` is a nested type `Outerₓ.Innerₓ`.
--  If `C` `Cₓ`is a constructed type `G<A¹, ..., Aⁿ>` with type arguments `A¹, ..., Aⁿ` then `Cₓ` is the constructed type `G<A¹ₓ, ..., Aⁿₓ>`.
--  If `C` is an array type `E[]` then `Cₓ` is the array type `Eₓ[]`.
--  If `C` is a pointer type `E*` then `Cₓ` is the pointer type `Eₓ*`.
--  If `C` is dynamic then `Cₓ` is `object`.
--  Otherwise, `Cₓ` is `C`.
+- If `C` is a nested type `Outer.Inner` then `Cₓ` is a nested type `Outerₓ.Innerₓ`.
+- If `C` `Cₓ`is a constructed type `G<A¹, ..., Aⁿ>` with type arguments `A¹, ..., Aⁿ` then `Cₓ` is the constructed type `G<A¹ₓ, ..., Aⁿₓ>`.
+- If `C` is an array type `E[]` then `Cₓ` is the array type `Eₓ[]`.
+- If `C` is a pointer type `E*` then `Cₓ` is the pointer type `Eₓ*`.
+- If `C` is dynamic then `Cₓ` is `object`.
+- Otherwise, `Cₓ` is `C`.
 
 The ***effective base class*** of a type parameter `T` is defined as follows:
 
 Let `R` be a set of types such that:
 
--  For each constraint of `T` that is a type parameter, `R` contains its effective base class.
--  For each constraint of `T` that is a struct type, `R` contains `System.ValueType`.
--  For each constraint of `T` that is an enumeration type, `R` contains `System.Enum`.
--  For each constraint of `T` that is a delegate type, `R` contains its dynamic erasure.
--  For each constraint of `T` that is an array type, `R` contains `System.Array`.
--  For each constraint of `T` that is a class type, `R` contains its dynamic erasure.
+- For each constraint of `T` that is a type parameter, `R` contains its effective base class.
+- For each constraint of `T` that is a struct type, `R` contains `System.ValueType`.
+- For each constraint of `T` that is an enumeration type, `R` contains `System.Enum`.
+- For each constraint of `T` that is a delegate type, `R` contains its dynamic erasure.
+- For each constraint of `T` that is an array type, `R` contains `System.Array`.
+- For each constraint of `T` that is a class type, `R` contains its dynamic erasure.
 
 Then
 
--  If `T` has the value type constraint, its effective base class is `System.ValueType`.
--  Otherwise, if `R` is empty then the effective base class is `object`.
--  Otherwise, the effective base class of `T` is the most-encompassed type ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)) of set `R`. If the set has no encompassed type, the effective base class of `T` is `object`. The consistency rules ensure that the most-encompassed type exists.
+- If `T` has the value type constraint, its effective base class is `System.ValueType`.
+- Otherwise, if `R` is empty then the effective base class is `object`.
+- Otherwise, the effective base class of `T` is the most-encompassed type ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)) of set `R`. If the set has no encompassed type, the effective base class of `T` is `object`. The consistency rules ensure that the most-encompassed type exists.
 
 If the type parameter is a method type parameter whose constraints are inherited from the base method the effective base class is calculated after type substitution.
 
@@ -517,10 +517,10 @@ These rules ensure that the effective base class is always a *class_type*.
 
 The ***effective interface set*** of a type parameter `T` is defined as follows:
 
--  If `T` has no *secondary_constraints*, its effective interface set is empty.
--  If `T` has *interface_type* constraints but no *type_parameter* constraints, its effective interface set is the set of dynamic erasures of its *interface_type* constraints.
--  If `T` has no *interface_type* constraints but has *type_parameter* constraints, its effective interface set is the union of the effective interface sets of its *type_parameter* constraints.
--  If `T` has both *interface_type* constraints and *type_parameter* constraints, its effective interface set is the union of the set of dynamic erasures of its *interface_type* constraints and the effective interface sets of its *type_parameter* constraints.
+- If `T` has no *secondary_constraints*, its effective interface set is empty.
+- If `T` has *interface_type* constraints but no *type_parameter* constraints, its effective interface set is the set of dynamic erasures of its *interface_type* constraints.
+- If `T` has no *interface_type* constraints but has *type_parameter* constraints, its effective interface set is the union of the effective interface sets of its *type_parameter* constraints.
+- If `T` has both *interface_type* constraints and *type_parameter* constraints, its effective interface set is the union of the set of dynamic erasures of its *interface_type* constraints and the effective interface sets of its *type_parameter* constraints.
 
 A type parameter is *known to be a reference type* if it has the reference type constraint or its effective base class is not `object` or `System.ValueType`.
 
@@ -654,37 +654,37 @@ class_member_declaration
 
 The members of a class are divided into the following categories:
 
--  Constants, which represent constant values associated with the class ([§14.4](classes.md#144-constants)).
--  Fields, which are the variables of the class ([§14.5](classes.md#145-fields)).
--  Methods, which implement the computations and actions that can be performed by the class ([§14.6](classes.md#146-methods)).
--  Properties, which define named characteristics and the actions associated with reading and writing those characteristics ([§14.7](classes.md#147-properties)).
--  Events, which define notifications that can be generated by the class ([§14.8](classes.md#148-events)).
--  Indexers, which permit instances of the class to be indexed in the same way (syntactically) as arrays ([§14.9](classes.md#149-indexers)).
--  Operators, which define the expression operators that can be applied to instances of the class ([§14.10](classes.md#1410-operators)).
--  Instance constructors, which implement the actions required to initialize instances of the class ([§14.11](classes.md#1411-instance-constructors))
--  Finalizers, which implement the actions to be performed before instances of the class are permanently discarded ([§14.13](classes.md#1413-finalizers)).
--  Static constructors, which implement the actions required to initialize the class itself ([§14.12](classes.md#1412-static-constructors)).
--  Types, which represent the types that are local to the class ([§13.7](namespaces.md#137-type-declarations)).
+- Constants, which represent constant values associated with the class ([§14.4](classes.md#144-constants)).
+- Fields, which are the variables of the class ([§14.5](classes.md#145-fields)).
+- Methods, which implement the computations and actions that can be performed by the class ([§14.6](classes.md#146-methods)).
+- Properties, which define named characteristics and the actions associated with reading and writing those characteristics ([§14.7](classes.md#147-properties)).
+- Events, which define notifications that can be generated by the class ([§14.8](classes.md#148-events)).
+- Indexers, which permit instances of the class to be indexed in the same way (syntactically) as arrays ([§14.9](classes.md#149-indexers)).
+- Operators, which define the expression operators that can be applied to instances of the class ([§14.10](classes.md#1410-operators)).
+- Instance constructors, which implement the actions required to initialize instances of the class ([§14.11](classes.md#1411-instance-constructors))
+- Finalizers, which implement the actions to be performed before instances of the class are permanently discarded ([§14.13](classes.md#1413-finalizers)).
+- Static constructors, which implement the actions required to initialize the class itself ([§14.12](classes.md#1412-static-constructors)).
+- Types, which represent the types that are local to the class ([§13.7](namespaces.md#137-type-declarations)).
 
 A *class_declaration* creates a new declaration space ([§7.3](basic-concepts.md#73-declarations)), and the *type_parameter*s and the *class_member_declaration*s immediately contained by the *class_declaration* introduce new members into this declaration space. The following rules apply to *class_member_declaration*s:
 
--  Instance constructors, finalizers, and static constructors shall have the same name as the immediately enclosing class. All other members shall have names that differ from the name of the immediately enclosing class.
+- Instance constructors, finalizers, and static constructors shall have the same name as the immediately enclosing class. All other members shall have names that differ from the name of the immediately enclosing class.
 
--  The name of a type parameter in the *type_parameter_list* of a class declaration shall differ from the names of all other type parameters in the same *type_parameter_list* and shall differ from the name of the class and the names of all members of the class.
+- The name of a type parameter in the *type_parameter_list* of a class declaration shall differ from the names of all other type parameters in the same *type_parameter_list* and shall differ from the name of the class and the names of all members of the class.
 
--  The name of a type shall differ from the names of all non-type members declared in the same class. If two or more type declarations share the same fully qualified name, the declarations shall have the `partial` modifier ([§14.2.7](classes.md#1427-partial-declarations)) and these declarations combine to define a single type.
+- The name of a type shall differ from the names of all non-type members declared in the same class. If two or more type declarations share the same fully qualified name, the declarations shall have the `partial` modifier ([§14.2.7](classes.md#1427-partial-declarations)) and these declarations combine to define a single type.
 
 > *Note*: Since the fully qualified name of a type declaration encodes the number of type parameters, two distinct types may share the  same name as long as they have different number of type parameters. *end note*
 
--  The name of a constant, field, property, or event shall differ from the names of all other members declared in the same class.
+- The name of a constant, field, property, or event shall differ from the names of all other members declared in the same class.
 
--  The name of a method shall differ from the names of all other non-methods declared in the same class. In addition, the signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)) of a method shall differ from the signatures of all other methods declared in the same class, and two methods declared in the same class shall not have signatures that differ solely by `ref` and `out`.
+- The name of a method shall differ from the names of all other non-methods declared in the same class. In addition, the signature ([§7.6](basic-concepts.md#76-signatures-and-overloading)) of a method shall differ from the signatures of all other methods declared in the same class, and two methods declared in the same class shall not have signatures that differ solely by `ref` and `out`.
 
--  The signature of an instance constructor shall differ from the signatures of all other instance constructors declared in the same class, and two constructors declared in the same class shall not have signatures that differ solely by `ref` and `out`.
+- The signature of an instance constructor shall differ from the signatures of all other instance constructors declared in the same class, and two constructors declared in the same class shall not have signatures that differ solely by `ref` and `out`.
 
--  The signature of an indexer shall differ from the signatures of all other indexers declared in the same class.
+- The signature of an indexer shall differ from the signatures of all other indexers declared in the same class.
 
--  The signature of an operator shall differ from the signatures of all other operators declared in the same class.
+- The signature of an operator shall differ from the signatures of all other operators declared in the same class.
 
 The inherited members of a class ([§14.3.4](classes.md#1434-inheritance)) are not part of the declaration space of a class.
 
@@ -792,17 +792,17 @@ All members of a generic class can use type parameters from any enclosing class,
 
 A class ***inherits*** the members of its direct base class. Inheritance means that a class implicitly contains all members of its direct base class, except for the instance constructors, finalizers, and static constructors of the base class. Some important aspects of inheritance are:
 
--  Inheritance is transitive. If `C` is derived from `B`, and `B` is derived from `A`, then `C` inherits the members declared in `B` as well as the members declared in `A`.
+- Inheritance is transitive. If `C` is derived from `B`, and `B` is derived from `A`, then `C` inherits the members declared in `B` as well as the members declared in `A`.
 
--  A derived class *extends* its direct base class. A derived class can add new members to those it inherits, but it cannot remove the definition of an inherited member.
+- A derived class *extends* its direct base class. A derived class can add new members to those it inherits, but it cannot remove the definition of an inherited member.
 
--  Instance constructors, finalizers, and static constructors are not inherited, but all other members are, regardless of their declared accessibility ([§7.5](basic-concepts.md#75-member-access)). However, depending on their declared accessibility, inherited members might not be accessible in a derived class.
+- Instance constructors, finalizers, and static constructors are not inherited, but all other members are, regardless of their declared accessibility ([§7.5](basic-concepts.md#75-member-access)). However, depending on their declared accessibility, inherited members might not be accessible in a derived class.
 
--  A derived class can *hide* ([§7.7.2.3](basic-concepts.md#7723-hiding-through-inheritance)) inherited members by declaring new members with the same name or signature. However, hiding an inherited member does not remove that member—it merely makes that member inaccessible directly through the derived class.
+- A derived class can *hide* ([§7.7.2.3](basic-concepts.md#7723-hiding-through-inheritance)) inherited members by declaring new members with the same name or signature. However, hiding an inherited member does not remove that member—it merely makes that member inaccessible directly through the derived class.
 
--  An instance of a class contains a set of all instance fields declared in the class and its base classes, and an implicit conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)) exists from a derived class type to any of its base class types. Thus, a reference to an instance of some derived class can be treated as a reference to an instance of any of its base classes.
+- An instance of a class contains a set of all instance fields declared in the class and its base classes, and an implicit conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)) exists from a derived class type to any of its base class types. Thus, a reference to an instance of some derived class can be treated as a reference to an instance of any of its base classes.
 
--  A class can declare virtual methods, properties, indexers, and events, and derived classes can override the implementation of these function members. This enables classes to exhibit polymorphic behavior wherein the actions performed by a function member invocation vary depending on the run-time type of the instance through which that function member is invoked.
+- A class can declare virtual methods, properties, indexers, and events, and derived classes can override the implementation of these function members. This enables classes to exhibit polymorphic behavior wherein the actions performed by a function member invocation vary depending on the run-time type of the instance through which that function member is invoked.
 
 The inherited members of a constructed class type are the members of the immediate base class type ([§14.2.4.2](classes.md#14242-base-classes)), which is found by substituting the type arguments of the constructed type for each occurrence of the corresponding type parameters in the *base_class_specification*. These members, in turn, are transformed by substituting, for each *type_parameter* in the member declaration, the corresponding *type_argument* of the *base_class_specification*.
 
@@ -844,15 +844,15 @@ Members of a class are either ***static members*** or ***instance members***.
 
 When a field, method, property, event, operator, or constructor declaration includes a `static` modifier, it declares a static member. In addition, a constant or type declaration implicitly declares a static member. Static members have the following characteristics:
 
--  When a static member `M` is referenced in a *member_access* ([§11.7.6](expressions.md#1176-member-access)) of the form `E.M`, `E` shall denote a type that has a member `M`. It is a compile-time error for `E` to denote an instance.
--  A static field in a non-generic class identifies exactly one storage location. No matter how many instances of a non-generic class are created, there is only ever one copy of a static field. Each distinct closed constructed type ([§8.4.3](types.md#843-open-and-closed-types)) has its own set of static fields, regardless of the number of instances of the closed constructed type.
--  A static function member (method, property, event, operator, or constructor) does not operate on a specific instance, and it is a compile-time error to refer to this in such a function member.
+- When a static member `M` is referenced in a *member_access* ([§11.7.6](expressions.md#1176-member-access)) of the form `E.M`, `E` shall denote a type that has a member `M`. It is a compile-time error for `E` to denote an instance.
+- A static field in a non-generic class identifies exactly one storage location. No matter how many instances of a non-generic class are created, there is only ever one copy of a static field. Each distinct closed constructed type ([§8.4.3](types.md#843-open-and-closed-types)) has its own set of static fields, regardless of the number of instances of the closed constructed type.
+- A static function member (method, property, event, operator, or constructor) does not operate on a specific instance, and it is a compile-time error to refer to this in such a function member.
 
 When a field, method, property, event, indexer, constructor, or finalizer declaration does not include a static modifier, it declares an instance member. (An instance member is sometimes called a non-static member.) Instance members have the following characteristics:
 
--  When an instance member `M` is referenced in a *member_access* ([§11.7.6](expressions.md#1176-member-access)) of the form `E.M`, `E` shall denote an instance of a type that has a member `M`. It is a binding-time error for E to denote a type.
--  Every instance of a class contains a separate set of all instance fields of the class.
--  An instance function member (method, property, indexer, instance constructor, or finalizer) operates on a given instance of the class, and this instance can be accessed as `this` ([§11.7.12](expressions.md#11712-this-access)).
+- When an instance member `M` is referenced in a *member_access* ([§11.7.6](expressions.md#1176-member-access)) of the form `E.M`, `E` shall denote an instance of a type that has a member `M`. It is a binding-time error for E to denote a type.
+- Every instance of a class contains a separate set of all instance fields of the class.
+- An instance function member (method, property, indexer, instance constructor, or finalizer) operates on a given instance of the class, and this instance can be accessed as `this` ([§11.7.12](expressions.md#11712-this-access)).
 
 > *Example*: The following example illustrates the rules for accessing static and instance members:
 > ```csharp
@@ -915,9 +915,9 @@ The fully qualified name ([§7.8.3](basic-concepts.md#783-fully-qualified-names)
 
 Non-nested types can have `public` or `internal` declared accessibility and have `internal` declared accessibility by default. Nested types can have these forms of declared accessibility too, plus one or more additional forms of declared accessibility, depending on whether the containing type is a class or struct:
 
--  A nested type that is declared in a class can have any of five forms of declared accessibility (`public`, `protected` `internal`, `protected`, `internal`, or `private`) and, like other class members, defaults to `private` declared accessibility.
+- A nested type that is declared in a class can have any of five forms of declared accessibility (`public`, `protected` `internal`, `protected`, `internal`, or `private`) and, like other class members, defaults to `private` declared accessibility.
 
--  A nested type that is declared in a struct can have any of three forms of declared accessibility (`public`, `internal`, or `private`) and, like other struct members, defaults to `private` declared accessibility.
+- A nested type that is declared in a struct can have any of three forms of declared accessibility (`public`, `internal`, or `private`) and, like other struct members, defaults to `private` declared accessibility.
 
 > *Example*: The example
 > ```csharp
@@ -1136,9 +1136,9 @@ To facilitate the underlying C# run-time implementation, for each source member
 The reserved names do not introduce declarations, thus they do not participate in member lookup. However, a declaration’s associated reserved method signatures do participate in inheritance ([§14.3.4](classes.md#1434-inheritance)), and can be hidden with the `new` modifier ([§14.3.5](classes.md#1435-the-new-modifier)).
 
 > *Note*: The reservation of these names serves three purposes:
-> 1.  To allow the underlying implementation to use an ordinary identifier as a method name for get or set access to the C# language feature.
-> 2.  To allow other languages to interoperate using an ordinary identifier as a method name for get or set access to the C# language feature.
-> 3.  To help ensure that the source accepted by one conforming compiler is accepted by another, by making the specifics of reserved member names consistent across all C# implementations.
+> 1. To allow the underlying implementation to use an ordinary identifier as a method name for get or set access to the C# language feature.
+> 2. To allow other languages to interoperate using an ordinary identifier as a method name for get or set access to the C# language feature.
+> 3. To help ensure that the source accepted by one conforming compiler is accepted by another, by making the specifics of reserved member names consistent across all C# implementations.
 > *end note*
 
 The declaration of a finalizer ([§14.13](classes.md#1413-finalizers)) also causes a signature to be reserved ([§14.3.10.5](classes.md#143105-member-names-reserved-for-finalizers)).
@@ -1378,8 +1378,8 @@ As explained in [§14.3.8](classes.md#1438-static-and-instance-members), each in
 
 When a *field_declaration* includes a `readonly` modifier, the fields introduced by the declaration are ***readonly fields***. Direct assignments to readonly fields can only occur as part of that declaration or in an instance constructor or static constructor in the same class. (A readonly field can be assigned to multiple times in these contexts.) Specifically, direct assignments to a readonly field are permitted only in the following contexts:
 
--  In the *variable_declarator* that introduces the field (by including a *variable_initializer* in the declaration).
--  For an instance field, in the instance constructors of the class that contains the field declaration; for a static field, in the static constructor of the class that contains the field declaration. These are also the only contexts in which it is valid to pass a readonly field as an `out` or `ref` parameter.
+- In the *variable_declarator* that introduces the field (by including a *variable_initializer* in the declaration).
+- For an instance field, in the instance constructors of the class that contains the field declaration; for a static field, in the static constructor of the class that contains the field declaration. These are also the only contexts in which it is valid to pass a readonly field as an `out` or `ref` parameter.
 
 Attempting to assign to a readonly field or pass it as an `out` or `ref` parameter in any other context is a compile-time error.
 
@@ -1444,15 +1444,15 @@ Constants and readonly fields have different binary versioning semantics. When a
 
 When a *field_declaration* includes a `volatile` modifier, the fields introduced by that declaration are ***volatile fields***. For non-volatile fields, optimization techniques that reorder instructions can lead to unexpected and unpredictable results in multi-threaded programs that access fields without synchronization such as that provided by the *lock_statement* ([§12.13](statements.md#1213-the-lock-statement)). These optimizations can be performed by the compiler, by the run-time system, or by hardware. For volatile fields, such reordering optimizations are restricted:
 
--  A read of a volatile field is called a ***volatile read***. A volatile read has “acquire semantics”; that is, it is guaranteed to occur prior to any references to memory that occur after it in the instruction sequence.
--  A write of a volatile field is called a ***volatile write***. A volatile write has “release semantics”; that is, it is guaranteed to happen after any memory references prior to the write instruction in the instruction sequence.
+- A read of a volatile field is called a ***volatile read***. A volatile read has “acquire semantics”; that is, it is guaranteed to occur prior to any references to memory that occur after it in the instruction sequence.
+- A write of a volatile field is called a ***volatile write***. A volatile write has “release semantics”; that is, it is guaranteed to happen after any memory references prior to the write instruction in the instruction sequence.
 
 These restrictions ensure that all threads will observe volatile writes performed by any other thread in the order in which they were performed. A conforming implementation is not required to provide a single total ordering of volatile writes as seen from all threads of execution. The type of a volatile field shall be one of the following:
 
--  A *reference_type*.
--  A *type_parameter* that is known to be a reference type ([§14.2.5](classes.md#1425-type-parameter-constraints)).
--  The type `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `char`, `float`, `bool`, `System.IntPtr`, or `System.UIntPtr`.
--  An *enum_type* having an *enum_base* type of `byte`, `sbyte`, `short`, `ushort`, `int`, or `uint`.
+- A *reference_type*.
+- A *type_parameter* that is known to be a reference type ([§14.2.5](classes.md#1425-type-parameter-constraints)).
+- The type `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `char`, `float`, `bool`, `System.IntPtr`, or `System.UIntPtr`.
+- An *enum_type* having an *enum_base* type of `byte`, `sbyte`, `short`, `ushort`, `int`, or `uint`.
 
 > *Example*: The example
 > ```csharp
@@ -1734,14 +1734,14 @@ A *method_declaration* may include a set of *attributes* ([§21](attributes.md#2
 
 A declaration has a valid combination of modifiers if all of the following are true:
 
--  The declaration includes a valid combination of access modifiers ([§14.3.6](classes.md#1436-access-modifiers)).
--  The declaration does not include the same modifier multiple times.
--  The declaration includes at most one of the following modifiers: `static`, `virtual`, and `override`.
--  The declaration includes at most one of the following modifiers: `new` and `override`.
--  If the declaration includes the `abstract` modifier, then the declaration does not include any of the following modifiers: `static`, `virtual`, `sealed`, or `extern`.
--  If the declaration includes the `private` modifier, then the declaration does not include any of the following modifiers: `virtual`, `override`, or `abstract`.
--  If the declaration includes the `sealed` modifier, then the declaration also includes the `override` modifier.
--  If the declaration includes the `partial` modifier, then it does not include any of the following modifiers: new, `public`, `protected`, `internal`, `private`, `virtual`, `sealed`, `override`, `abstract`, or `extern`.
+- The declaration includes a valid combination of access modifiers ([§14.3.6](classes.md#1436-access-modifiers)).
+- The declaration does not include the same modifier multiple times.
+- The declaration includes at most one of the following modifiers: `static`, `virtual`, and `override`.
+- The declaration includes at most one of the following modifiers: `new` and `override`.
+- If the declaration includes the `abstract` modifier, then the declaration does not include any of the following modifiers: `static`, `virtual`, `sealed`, or `extern`.
+- If the declaration includes the `private` modifier, then the declaration does not include any of the following modifiers: `virtual`, `override`, or `abstract`.
+- If the declaration includes the `sealed` modifier, then the declaration also includes the `override` modifier.
+- If the declaration includes the `partial` modifier, then it does not include any of the following modifiers: new, `public`, `protected`, `internal`, `private`, `virtual`, `sealed`, `override`, `abstract`, or `extern`.
 
 The *return_type* of a method declaration specifies the type of the value computed and returned by the method. The *return_type* is `void` if the method does not return a value. If the declaration includes the `partial` modifier, then the return type shall be `void` ([§14.6.9](classes.md#1469-partial-methods)). If the declaration includes the `async` modifier then the return type shall be `void` or a *task type* ([§14.15.1](classes.md#14151-general)).
 
@@ -1811,9 +1811,9 @@ A *fixed_parameter* consists of an optional set of *attributes* ([§21](attribut
 
 A parameter with a `ref`, `out` or `this` modifier cannot have a *default_argument*. The *expression* in a *default_argument* shall be one of the following:
 
--  a *constant_expression*
--  an expression of the form `new S()` where `S` is a value type
--  an expression of the form `default(S)` where `S` is a value type
+- a *constant_expression*
+- an expression of the form `new S()` where `S` is a value type
+- an expression of the form `default(S)` where `S` is a value type
 
 The *expression* shall be implicitly convertible by an identity or nullable conversion to the type of the parameter.
 
@@ -1844,10 +1844,10 @@ A method invocation ([§11.7.8.2](expressions.md#11782-method-invocations)) crea
 
 There are four kinds of formal parameters:
 
--  Value parameters, which are declared without any modifiers.
--  Reference parameters, which are declared with the `ref` modifier.
--  Output parameters, which are declared with the `out` modifier.
--  Parameter arrays, which are declared with the `params` modifier.
+- Value parameters, which are declared without any modifiers.
+- Reference parameters, which are declared with the `ref` modifier.
+- Output parameters, which are declared with the `out` modifier.
+- Parameter arrays, which are declared with the `params` modifier.
 
 > *Note*: As described in [§7.6](basic-concepts.md#76-signatures-and-overloading), the `ref` and `out` modifiers are part of a method’s signature, but the `params` modifier is not.
 
@@ -1979,8 +1979,8 @@ It is not possible to combine the `params` modifier with the modifiers `ref` and
 
 A parameter array permits arguments to be specified in one of two ways in a method invocation:
 
--  The argument given for a parameter array can be a single expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the parameter array type. In this case, the parameter array acts precisely like a value parameter.
--  Alternatively, the invocation can specify zero or more arguments for the parameter array, where each argument is an expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the element type of the parameter array. In this case, the invocation creates an instance of the parameter array type with a length corresponding to the number of arguments, initializes the elements of the array instance with the given argument values, and uses the newly created array instance as the actual argument.
+- The argument given for a parameter array can be a single expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the parameter array type. In this case, the parameter array acts precisely like a value parameter.
+- Alternatively, the invocation can specify zero or more arguments for the parameter array, where each argument is an expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the element type of the parameter array. In this case, the invocation creates an instance of the parameter array type with a length corresponding to the number of arguments, initializes the elements of the array instance with the given argument values, and uses the newly created array instance as the actual argument.
 
 Except for allowing a variable number of arguments in an invocation, a parameter array is precisely equivalent to a value parameter ([§14.6.2.2](classes.md#14622-value-parameters)) of the same type.
 
@@ -2134,16 +2134,16 @@ The implementation of a non-virtual method is invariant: The implementation is t
 
 In a virtual method invocation, the ***run-time type*** of the instance for which that invocation takes place determines the actual method implementation to invoke. In a non-virtual method invocation, the ***compile-time type*** of the instance is the determining factor. In precise terms, when a method named `N` is invoked with an argument list `A` on an instance with a compile-time type `C` and a run-time type `R` (where `R` is either `C` or a class derived from `C`), the invocation is processed as follows:
 
--  At binding-time, overload resolution is applied to `C`, `N`, and `A`, to select a specific method `M` from the set of methods declared in and inherited by `C`. This is described in [§11.7.8.2](expressions.md#11782-method-invocations).
+- At binding-time, overload resolution is applied to `C`, `N`, and `A`, to select a specific method `M` from the set of methods declared in and inherited by `C`. This is described in [§11.7.8.2](expressions.md#11782-method-invocations).
 - Then at run-time:
   - If `M` is a non-virtual method, `M` is invoked.
   - Otherwise, `M` is a virtual method, and the most derived implementation of `M` with respect to `R` is invoked.
 
 For every virtual method declared in or inherited by a class, there exists a ***most derived implementation*** of the method with respect to that class. The most derived implementation of a virtual method `M` with respect to a class `R` is determined as follows:
 
--  If `R` contains the introducing virtual declaration of `M`, then this is the most derived implementation of `M` with respect to `R`.
--  Otherwise, if `R` contains an override of `M`, then this is the most derived implementation of `M` with respect to `R`.
--  Otherwise, the most derived implementation of `M` with respect to `R` is the same as the most derived implementation of `M` with respect to the direct base class of `R`.
+- If `R` contains the introducing virtual declaration of `M`, then this is the most derived implementation of `M` with respect to `R`.
+- Otherwise, if `R` contains an override of `M`, then this is the most derived implementation of `M` with respect to `R`.
+- Otherwise, the most derived implementation of `M` with respect to `R` is the same as the most derived implementation of `M` with respect to the direct base class of `R`.
 
 > *Example*: The following example illustrates the differences between virtual and non-virtual methods:
 > ```csharp
@@ -2241,13 +2241,13 @@ The method overridden by an override declaration is known as the ***overridden b
 
 A compile-time error occurs unless all of the following are true for an override declaration:
 
--  An overridden base method can be located as described above.
--  There is exactly one such overridden base method. This restriction has effect only if the base class type is a constructed type where the substitution of type arguments makes the signature of two methods the same.
--  The overridden base method is a virtual, abstract, or override method. In other words, the overridden base method cannot be static or non-virtual.
--  The overridden base method is not a sealed method.
--  There is an identity conversion between the return type of the overridden base method and the override method.
--  The override declaration and the overridden base method have the same declared accessibility. In other words, an override declaration cannot change the accessibility of the virtual method. However, if the overridden base method is protected internal and it is declared in a different assembly than the assembly containing the override declaration then the override declaration’s declared accessibility shall be protected.
--  The override declaration does not specify any *type_parameter_constraints_clause*s. Instead, the constraints are inherited from the overridden base method. Constraints that are type parameters in the overridden method may be replaced by type arguments in the inherited constraint. This can lead to constraints that are not valid when explicitly specified, such as value types or sealed types.
+- An overridden base method can be located as described above.
+- There is exactly one such overridden base method. This restriction has effect only if the base class type is a constructed type where the substitution of type arguments makes the signature of two methods the same.
+- The overridden base method is a virtual, abstract, or override method. In other words, the overridden base method cannot be static or non-virtual.
+- The overridden base method is not a sealed method.
+- There is an identity conversion between the return type of the overridden base method and the override method.
+- The override declaration and the overridden base method have the same declared accessibility. In other words, an override declaration cannot change the accessibility of the virtual method. However, if the overridden base method is protected internal and it is declared in a different assembly than the assembly containing the override declaration then the override declaration’s declared accessibility shall be protected.
+- The override declaration does not specify any *type_parameter_constraints_clause*s. Instead, the constraints are inherited from the overridden base method. Constraints that are type parameters in the overridden method may be replaced by type arguments in the inherited constraint. This can lead to constraints that are not valid when explicitly specified, such as value types or sealed types.
 
 > *Example*: The following demonstrates how the overriding rules work for generic classes:
 > ```csharp
@@ -2467,9 +2467,9 @@ Partial methods shall not define access modifiers; they are implicitly private. 
 
 There are two kinds of partial method declarations: If the body of the method declaration is a semicolon, the declaration is said to be a ***defining partial method declaration***. If the body is given as a *block*, the declaration is said to be an ***implementing partial method declaration***. Across the parts of a type declaration, there may be only one defining partial method declaration with a given signature, and there may be only one implementing partial method declaration with a given signature. If an implementing partial method declaration is given, a corresponding defining partial method declaration shall exist, and the declarations shall match as specified in the following:
 
--  The declarations shall have the same modifiers (although not necessarily in the same order), method name, number of type parameters and number of parameters.
--  Corresponding parameters in the declarations shall have the same modifiers (although not necessarily in the same order) and the same types (modulo differences in type parameter names).
--  Corresponding type parameters in the declarations shall have the same constraints (modulo differences in type parameter names).
+- The declarations shall have the same modifiers (although not necessarily in the same order), method name, number of type parameters and number of parameters.
+- Corresponding parameters in the declarations shall have the same modifiers (although not necessarily in the same order) and the same types (modulo differences in type parameter names).
+- Corresponding type parameters in the declarations shall have the same constraints (modulo differences in type parameter names).
 
 An implementing partial method declaration can appear in the same part as the corresponding defining partial method declaration.
 
@@ -2496,21 +2496,21 @@ If no part of a partial type declaration contains an implementing declaration fo
 
 If an implementing declaration exists for a given partial method, the invocations of the partial methods are retained. The partial method gives rise to a method declaration similar to the implementing partial method declaration except for the following:
 
--  The `partial` modifier is not included.
+- The `partial` modifier is not included.
 
--  The attributes in the resulting method declaration are the combined attributes of the defining and the implementing partial method declaration in unspecified order. Duplicates are not removed.
+- The attributes in the resulting method declaration are the combined attributes of the defining and the implementing partial method declaration in unspecified order. Duplicates are not removed.
 
--  The attributes on the parameters of the resulting method declaration are the combined attributes of the corresponding parameters of the defining and the implementing partial method declaration in unspecified order. Duplicates are not removed.
+- The attributes on the parameters of the resulting method declaration are the combined attributes of the corresponding parameters of the defining and the implementing partial method declaration in unspecified order. Duplicates are not removed.
 
 If a defining declaration but not an implementing declaration is given for a partial method `M`, the following restrictions apply:
 
--  It is a compile-time error to create a delegate from `M` ([§11.7.15.6](expressions.md#117156-delegate-creation-expressions)).
+- It is a compile-time error to create a delegate from `M` ([§11.7.15.6](expressions.md#117156-delegate-creation-expressions)).
 
--  It is a compile-time error to refer to `M` inside an anonymous function that is converted to an expression tree type ([§8.6](types.md#86-expression-tree-types)).
+- It is a compile-time error to refer to `M` inside an anonymous function that is converted to an expression tree type ([§8.6](types.md#86-expression-tree-types)).
 
--  Expressions occurring as part of an invocation of `M` do not affect the definite assignment state ([§9.4](variables.md#94-definite-assignment)), which can potentially lead to compile-time errors.
+- Expressions occurring as part of an invocation of `M` do not affect the definite assignment state ([§9.4](variables.md#94-definite-assignment)), which can potentially lead to compile-time errors.
 
--  `M` cannot be the entry point for an application ([§7.1](basic-concepts.md#71-application-startup)).
+- `M` cannot be the entry point for an application ([§7.1](basic-concepts.md#71-application-startup)).
 
 Partial methods are useful for allowing one part of a type declaration to customize the behavior of another part, e.g., one that is generated by a tool. Consider the following partial class declaration:
 
@@ -2810,9 +2810,9 @@ A `set` accessor corresponds to a method with a single value parameter of the pr
 
 Based on the presence or absence of the get and set accessors, a property is classified as follows:
 
--  A property that includes both a get accessor and a set accessor is said to be a ***read-write property***.
--  A property that has only a get accessor is said to be a ***read-only property***. It is a compile-time error for a read-only property to be the target of an assignment.
--  A property that has only a set accessor is said to be a ***write-only property***. Except as the target of an assignment, it is a compile-time error to reference a write-only property in an expression.
+- A property that includes both a get accessor and a set accessor is said to be a ***read-write property***.
+- A property that has only a get accessor is said to be a ***read-only property***. It is a compile-time error for a read-only property to be the target of an assignment.
+- A property that has only a set accessor is said to be a ***write-only property***. Except as the target of an assignment, it is a compile-time error to reference a write-only property in an expression.
 
 > *Note*: The pre- and postfix `++` and `--` operators and compound assignment operators cannot be applied to write-only properties, since these operators read the old value of their operand before they write the new one. *end note*
 <!-- markdownlint-disable MD028 -->
@@ -3091,9 +3091,9 @@ The presence of an *accessor_modifier* never affects member lookup ([§11.5](exp
 
 Once a particular property or indexer has been selected, the accessibility domains of the specific accessors involved are used to determine if that usage is valid:
 
--  If the usage is as a value ([§11.2.2](expressions.md#1122-values-of-expressions)), the get accessor shall exist and be accessible.
--  If the usage is as the target of a simple assignment ([§11.18.2](expressions.md#11182-simple-assignment)), the set accessor shall exist and be accessible.
--  If the usage is as the target of compound assignment ([§11.18.3](expressions.md#11183-compound-assignment)), or as the target of the `++` or `--` operators ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators), [§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators)), both the get accessors and the set accessor shall exist and be accessible.
+- If the usage is as a value ([§11.2.2](expressions.md#1122-values-of-expressions)), the get accessor shall exist and be accessible.
+- If the usage is as the target of a simple assignment ([§11.18.2](expressions.md#11182-simple-assignment)), the set accessor shall exist and be accessible.
+- If the usage is as the target of compound assignment ([§11.18.3](expressions.md#11183-compound-assignment)), or as the target of the `++` or `--` operators ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators), [§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators)), both the get accessors and the set accessor shall exist and be accessible.
 
 > *Example*: In the following example, the property `A.Text` is hidden by the property` B.Text`, even in contexts where only the set accessor is called. In contrast, the property `B.Count` is not accessible to class `M`, so the accessible property `A.Count` is used instead.
 > ```csharp
@@ -3180,8 +3180,8 @@ An overriding property declaration may include the `sealed` modifier. Use of thi
 
 Except for differences in declaration and invocation syntax, virtual, sealed, override, and abstract accessors behave exactly like virtual, sealed, override and abstract methods. Specifically, the rules described in [§14.6.4](classes.md#1464-virtual-methods), [§14.6.5](classes.md#1465-override-methods), [§14.6.6](classes.md#1466-sealed-methods), and [§14.6.7](classes.md#1467-abstract-methods) apply as if accessors were methods of a corresponding form:
 
--  A `get` accessor corresponds to a parameterless method with a return value of the property type and the same modifiers as the containing property.
--  A `set` accessor corresponds to a method with a single value parameter of the property type, a void return type, and the same modifiers as the containing property.
+- A `get` accessor corresponds to a parameterless method with a return value of the property type and the same modifiers as the containing property.
+- A `set` accessor corresponds to a method with a single value parameter of the property type, a void return type, and the same modifiers as the containing property.
 
 > *Example*: In the following code
 > ```csharp
@@ -3566,9 +3566,9 @@ An *indexer_body* may either consist of an accessor body ([§14.7.1](classes.md#
   
 Based on the presence or absence of get and set accessors, an indexer is classified as follows:
 
--  An indexer that includes both a get accessor and a set accessor is said to be a ***read-write indexer***.
--  An indexer that has only a get accessor is said to be a ***read-only indexer***. It is a compile-time error for a read-only indexer to be the target of an assignment.
--  An indexer that has only a set accessor is said to be a ***write-only indexer***. Except as the target of an assignment, it is a compile-time error to reference a write-only indexer in an expression.
+- An indexer that includes both a get accessor and a set accessor is said to be a ***read-write indexer***.
+- An indexer that has only a get accessor is said to be a ***read-only indexer***. It is a compile-time error for a read-only indexer to be the target of an assignment.
+- An indexer that has only a set accessor is said to be a ***write-only indexer***. Except as the target of an assignment, it is a compile-time error to reference a write-only indexer in an expression.
 
 An expression body consisting of “`=>`” followed by an expression `E` and a semicolon is exactly equivalent to the block body `{ get { return E; } }`, and can therefore only be used to specify read-only indexers where the result of the get accessor is given by a single expression.
 
@@ -3580,14 +3580,14 @@ The signature of an indexer shall differ from the signatures of all other indexe
 
 Indexers and properties are very similar in concept, but differ in the following ways:
 
--  A property is identified by its name, whereas an indexer is identified by its signature.
--  A property is accessed through a *simple_name* ([§11.7.4](expressions.md#1174-simple-names)) or a *member_access* ([§11.7.6](expressions.md#1176-member-access)), whereas an indexer element is accessed through an *element_access* ([§11.7.10.3](expressions.md#117103-indexer-access)).
--  A property can be a static member, whereas an indexer is always an instance member.
--  A `get` accessor of a property corresponds to a method with no parameters, whereas a `get` accessor of an indexer corresponds to a method with the same formal parameter list as the indexer.
--  A `set` accessor of a property corresponds to a method with a single parameter named `value`, whereas a `set` accessor of an indexer corresponds to a method with the same formal parameter list as the indexer, plus an additional parameter named `value`.
--  It is a compile-time error for an indexer accessor to declare a local variable or local constant with the same name as an indexer parameter.
--  In an overriding property declaration, the inherited property is accessed using the syntax `base.P`, where `P` is the property name. In an overriding indexer declaration, the inherited indexer is accessed using the syntax `base[E]`, where `E` is a comma-separated list of expressions.
--  There is no concept of an “automatically implemented indexer”. It is an error to have a non-abstract, non-external indexer with semicolon accessors.
+- A property is identified by its name, whereas an indexer is identified by its signature.
+- A property is accessed through a *simple_name* ([§11.7.4](expressions.md#1174-simple-names)) or a *member_access* ([§11.7.6](expressions.md#1176-member-access)), whereas an indexer element is accessed through an *element_access* ([§11.7.10.3](expressions.md#117103-indexer-access)).
+- A property can be a static member, whereas an indexer is always an instance member.
+- A `get` accessor of a property corresponds to a method with no parameters, whereas a `get` accessor of an indexer corresponds to a method with the same formal parameter list as the indexer.
+- A `set` accessor of a property corresponds to a method with a single parameter named `value`, whereas a `set` accessor of an indexer corresponds to a method with the same formal parameter list as the indexer, plus an additional parameter named `value`.
+- It is a compile-time error for an indexer accessor to declare a local variable or local constant with the same name as an indexer parameter.
+- In an overriding property declaration, the inherited property is accessed using the syntax `base.P`, where `P` is the property name. In an overriding indexer declaration, the inherited indexer is accessed using the syntax `base[E]`, where `E` is a comma-separated list of expressions.
+- There is no concept of an “automatically implemented indexer”. It is an error to have a non-abstract, non-external indexer with semicolon accessors.
 
 Aside from these differences, all rules defined in [§14.7.3](classes.md#1473-accessors) and [§14.7.4](classes.md#1474-automatically-implemented-properties) apply to indexer accessors as well as to property accessors.
 
@@ -3783,11 +3783,11 @@ For `extern` operators, the *operator_body* consists simply of a semicolon. For 
 
 The following rules apply to all operator declarations:
 
--  An operator declaration shall include both a `public` and a `static` modifier.
--  The parameter(s) of an operator shall have no modifiers.
--  The signature of an operator ([§14.10.2](classes.md#14102-unary-operators), [§14.10.3](classes.md#14103-binary-operators), [§14.10.4](classes.md#14104-conversion-operators)) shall differ from the signatures of all other operators declared in the same class.
--  All types referenced in an operator declaration shall be at least as accessible as the operator itself ([§7.5.5](basic-concepts.md#755-accessibility-constraints)).
--  It is an error for the same modifier to appear multiple times in an operator declaration.
+- An operator declaration shall include both a `public` and a `static` modifier.
+- The parameter(s) of an operator shall have no modifiers.
+- The signature of an operator ([§14.10.2](classes.md#14102-unary-operators), [§14.10.3](classes.md#14103-binary-operators), [§14.10.4](classes.md#14104-conversion-operators)) shall differ from the signatures of all other operators declared in the same class.
+- All types referenced in an operator declaration shall be at least as accessible as the operator itself ([§7.5.5](basic-concepts.md#755-accessibility-constraints)).
+- It is an error for the same modifier to appear multiple times in an operator declaration.
 
 Each operator category imposes additional restrictions, as described in the following subclauses.
 
@@ -3801,9 +3801,9 @@ Additional information on conversion operators can be found in [§10.5](convers
 
 The following rules apply to unary operator declarations, where `T` denotes the instance type of the class or struct that contains the operator declaration:
 
--  A unary `+`, `-`, `!`, or `~` operator shall take a single parameter of type `T` or `T?` and can return any type.
--  A unary `++` or `--` operator shall take a single parameter of type `T` or `T?` and shall return that same type or a type derived from it.
--  A unary `true` or `false` operator shall take a single parameter of type `T` or `T?` and shall return type `bool`.
+- A unary `+`, `-`, `!`, or `~` operator shall take a single parameter of type `T` or `T?` and can return any type.
+- A unary `++` or `--` operator shall take a single parameter of type `T` or `T?` and shall return that same type or a type derived from it.
+- A unary `true` or `false` operator shall take a single parameter of type `T` or `T?` and shall return type `bool`.
 
 The signature of a unary operator consists of the operator token (`+`, `-`, `!`, `~`, `++`, `--`, `true`, or `false`) and the type of the single formal parameter. The return type is not part of a unary operator’s signature, nor is the name of the formal parameter.
 
@@ -3845,15 +3845,15 @@ The `true` and `false` unary operators require pair-wise declaration. A compile-
 
 The following rules apply to binary operator declarations, where `T` denotes the instance type of the class or struct that contains the operator declaration:
 
--  A binary non-shift operator shall take two parameters, at least one of which shall have type `T` or `T?`, and can return any type.
--  A binary `<<` or `>>` operator ([§11.10](expressions.md#1110-shift-operators)) shall take two parameters, the first of which shall have type `T` or T? and the second of which shall have type `int` or `int?`, and can return any type.
+- A binary non-shift operator shall take two parameters, at least one of which shall have type `T` or `T?`, and can return any type.
+- A binary `<<` or `>>` operator ([§11.10](expressions.md#1110-shift-operators)) shall take two parameters, the first of which shall have type `T` or T? and the second of which shall have type `int` or `int?`, and can return any type.
 The signature of a binary operator consists of the operator token (`+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, `>>`, `==`, `!=`, `>`, `<`, `>=`, or `<=`) and the types of the two formal parameters. The return type and the names of the formal parameters are not part of a binary operator’s signature.
 
 Certain binary operators require pair-wise declaration. For every declaration of either operator of a pair, there shall be a matching declaration of the other operator of the pair. Two operator declarations match if identity conversions exist between their return types and their corresponding parameter types. The following operators require pair-wise declaration:
 
--  operator `==` and operator `!=`
--  operator `>` and operator `<`
--  operator `>=` and operator `<=`
+- operator `==` and operator `!=`
+- operator `>` and operator `<`
+- operator `>=` and operator `<=`
 
 ### 14.10.4 Conversion operators
 
@@ -3867,13 +3867,13 @@ A conversion operator converts from a source type, indicated by the parameter ty
 
 For a given source type `S` and target type `T`, if `S` or `T` are nullable value types, let `S₀` and `T₀` refer to their underlying types; otherwise, `S₀` and `T₀` are equal to `S` and `T` respectively. A class or struct is permitted to declare a conversion from a source type `S` to a target type `T` only if all of the following are true:
 
--  `S₀` and `T₀` are different types.
+- `S₀` and `T₀` are different types.
 
--  Either `S₀` or `T₀` is the instance type of the class or struct that contains the operator declaration.
+- Either `S₀` or `T₀` is the instance type of the class or struct that contains the operator declaration.
 
--  Neither `S₀` nor `T₀` is an *interface_type*.
+- Neither `S₀` nor `T₀` is an *interface_type*.
 
--  Excluding user-defined conversions, a conversion does not exist from `S` to `T` or from `T` to `S`.
+- Excluding user-defined conversions, a conversion does not exist from `S` to `T` or from `T` to `S`.
 
 For the purposes of these rules, any type parameters associated with `S` or `T` are considered to be unique types that have no inheritance relationship with other types, and any constraints on those type parameters are ignored.
 
@@ -4024,8 +4024,8 @@ Instance constructors are invoked by *object_creation_expression*s ([§11.7.15.2
 
 All instance constructors (except those for class` object`) implicitly include an invocation of another instance constructor immediately before the *constructor_body*. The constructor to implicitly invoke is determined by the *constructor_initializer*:
 
--  An instance constructor initializer of the form `base(`*argument_list*`)` (where *argument_list* is optional) causes an instance constructor from the direct base class to be invoked. That constructor is selected using *argument_list* and the overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). The set of candidate instance constructors consists of all the accessible instance constructors of the direct base class. If this set is empty, or if a single best instance constructor cannot be identified, a compile-time error occurs.
--  An instance constructor initializer of the form `this(`*argument_list*`)` (where *argument_list* is optional) invokes another instance constructor from the same class. The constructor is selected using *argument_list* and the overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). The set of candidate instance constructors consists of all instance constructors declared in the class itself. If the resulting set of applicable instance constructors is empty, or if a single best instance constructor cannot be identified, a compile-time error occurs. If an instance constructor declaration invokes itself through a chain of one or more constructor initializers, a compile-time error occurs.
+- An instance constructor initializer of the form `base(`*argument_list*`)` (where *argument_list* is optional) causes an instance constructor from the direct base class to be invoked. That constructor is selected using *argument_list* and the overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). The set of candidate instance constructors consists of all the accessible instance constructors of the direct base class. If this set is empty, or if a single best instance constructor cannot be identified, a compile-time error occurs.
+- An instance constructor initializer of the form `this(`*argument_list*`)` (where *argument_list* is optional) invokes another instance constructor from the same class. The constructor is selected using *argument_list* and the overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). The set of candidate instance constructors consists of all instance constructors declared in the class itself. If the resulting set of applicable instance constructors is empty, or if a single best instance constructor cannot be identified, a compile-time error occurs. If an instance constructor declaration invokes itself through a chain of one or more constructor initializers, a compile-time error occurs.
 
 If an instance constructor has no constructor initializer, a constructor initializer of the form `base()` is implicitly provided.
 
@@ -4251,8 +4251,8 @@ Static constructors are not inherited, and cannot be called directly.
 
 The static constructor for a closed class executes at most once in a given application domain. The execution of a static constructor is triggered by the first of the following events to occur within an application domain:
 
--  An instance of the class is created.
--  Any of the static members of the class are referenced.
+- An instance of the class is created.
+- Any of the static members of the class are referenced.
 
 If a class contains the `Main` method ([§7.1](basic-concepts.md#71-application-startup)) in which execution begins, the static constructor for that class executes before the `Main` method is called.
 
@@ -4477,8 +4477,8 @@ The ***enumerable interfaces*** are the non-generic interface `System.Collection
 
 An iterator produces a sequence of values, all of the same type. This type is called the ***yield type*** of the iterator.
 
--  The yield type of an iterator that returns `IEnumerator` or `IEnumerable` is `object`.
--  The yield type of an iterator that returns `IEnumerator<T>` or `IEnumerable<T>` is `T`.
+- The yield type of an iterator that returns `IEnumerator` or `IEnumerable` is `object`.
+- The yield type of an iterator that returns `IEnumerator<T>` or `IEnumerable<T>` is `T`.
 
 ### 14.14.5 Enumerator objects
 
@@ -4486,10 +4486,10 @@ An iterator produces a sequence of values, all of the same type. This type is ca
 
 When a function member returning an enumerator interface type is implemented using an iterator block, invoking the function member does not immediately execute the code in the iterator block. Instead, an ***enumerator object*** is created and returned. This object encapsulates the code specified in the iterator block, and execution of the code in the iterator block occurs when the enumerator object’s `MoveNext` method is invoked. An enumerator object has the following characteristics:
 
--  It implements `IEnumerator` and `IEnumerator<T>`, where `T` is the yield type of the iterator.
--  It implements `System.IDisposable`.
--  It is initialized with a copy of the argument values (if any) and instance value passed to the function member.
--  It has four potential states, **before**, **running**, **suspended**, and **after**, and is initially in the **before** state.
+- It implements `IEnumerator` and `IEnumerator<T>`, where `T` is the yield type of the iterator.
+- It implements `System.IDisposable`.
+- It is initialized with a copy of the argument values (if any) and instance value passed to the function member.
+- It has four potential states, **before**, **running**, **suspended**, and **after**, and is initially in the **before** state.
 
 An enumerator object is typically an instance of a compiler-generated enumerator class that encapsulates the code in the iterator block and implements the enumerator interfaces, but other methods of implementation are possible. If an enumerator class is generated by the compiler, that class will be nested, directly or indirectly, in the class containing the function member, it will have private accessibility, and it will have a name reserved for compiler use ([§6.4.3](lexical-structure.md#643-identifiers)).
 
@@ -4560,8 +4560,8 @@ The `Dispose` method is used to clean up the iteration by bringing the enumerato
 
 When a function member returning an enumerable interface type is implemented using an iterator block, invoking the function member does not immediately execute the code in the iterator block. Instead, an ***enumerable object*** is created and returned. The enumerable object’s `GetEnumerator` method returns an enumerator object that encapsulates the code specified in the iterator block, and execution of the code in the iterator block occurs when the enumerator object’s `MoveNext` method is invoked. An enumerable object has the following characteristics:
 
--  It implements `IEnumerable` and `IEnumerable<T>`, where `T` is the yield type of the iterator.
--  It is initialized with a copy of the argument values (if any) and instance value passed to the function member.
+- It implements `IEnumerable` and `IEnumerable<T>`, where `T` is the yield type of the iterator.
+- It is initialized with a copy of the argument values (if any) and instance value passed to the function member.
 
 An enumerable object is typically an instance of a compiler-generated enumerable class that encapsulates the code in the iterator block and implements the enumerable interfaces, but other methods of implementation are possible. If an enumerable class is generated by the compiler, that class will be nested, directly or indirectly, in the class containing the function member, it will have private accessibility, and it will have a name reserved for compiler use ([§6.4.3](lexical-structure.md#643-identifiers)).
 
@@ -4595,8 +4595,8 @@ The async function body is then evaluated until it is either suspended (by reach
 
 When the body of the async function terminates, the return task is moved out of the incomplete state:
 
--  If the function body terminates as the result of reaching a return statement or the end of the body, any result value is recorded in the return task, which is put into a *succeeded* state.
--  If the function body terminates as the result of an uncaught exception ([§12.10.6](statements.md#12106-the-throw-statement)) the exception is recorded in the return task which is put into a *faulted* state.
+- If the function body terminates as the result of reaching a return statement or the end of the body, any result value is recorded in the return task, which is put into a *succeeded* state.
+- If the function body terminates as the result of an uncaught exception ([§12.10.6](statements.md#12106-the-throw-statement)) the exception is recorded in the return task which is put into a *faulted* state.
 
 ### 14.15.3 Evaluation of a void-returning async function
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1136,10 +1136,10 @@ To facilitate the underlying C# run-time implementation, for each source member
 The reserved names do not introduce declarations, thus they do not participate in member lookup. However, a declaration’s associated reserved method signatures do participate in inheritance ([§14.3.4](classes.md#1434-inheritance)), and can be hidden with the `new` modifier ([§14.3.5](classes.md#1435-the-new-modifier)).
 
 > *Note*: The reservation of these names serves three purposes:
+>
 > 1. To allow the underlying implementation to use an ordinary identifier as a method name for get or set access to the C# language feature.
 > 2. To allow other languages to interoperate using an ordinary identifier as a method name for get or set access to the C# language feature.
-> 3. To help ensure that the source accepted by one conforming compiler is accepted by another, by making the specifics of reserved member names consistent across all C# implementations.
-> *end note*
+> 3. To help ensure that the source accepted by one conforming compiler is accepted by another, by making the specifics of reserved member names consistent across all C# implementations. *end note*
 
 The declaration of a finalizer ([§14.13](classes.md#1413-finalizers)) also causes a signature to be reserved ([§14.3.10.5](classes.md#143105-member-names-reserved-for-finalizers)).
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -786,9 +786,7 @@ Not every lambda expression can be converted to expression tree types. The conve
 > - It has the `async` modifier
 > - It contains an assignment operator
 > - It contains an `out` or `ref` parameter
-> - It contains a dynamically bound expression
->
-> *end note*
+> - It contains a dynamically bound expression *end note*
 
 ## 10.8 Method group conversions
 

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -78,10 +78,10 @@ Except for instantiation, any operation that can be applied to a class or class 
 
 A method or delegate type `M` is ***compatible*** with a delegate type `D` if all of the following are true:
 
--   `D` and `M` have the same number of parameters, and each parameter in `D` has the same `ref` or `out` modifiers as the corresponding parameter in `M`.
--   For each value parameter (a parameter with no `ref` or `out` modifier), an identity conversion ([§10.2.2](conversions.md#1022-identity-conversion)) or implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)) exists from the parameter type in `D` to the corresponding parameter type in `M`.
--   For each `ref` or `out` parameter, the parameter type in `D` is the same as the parameter type in `M`.
--   An identity or implicit reference conversion exists from the return type of `M` to the return type of `D`.
+- `D` and `M` have the same number of parameters, and each parameter in `D` has the same `ref` or `out` modifiers as the corresponding parameter in `M`.
+- For each value parameter (a parameter with no `ref` or `out` modifier), an identity conversion ([§10.2.2](conversions.md#1022-identity-conversion)) or implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)) exists from the parameter type in `D` to the corresponding parameter type in `M`.
+- For each `ref` or `out` parameter, the parameter type in `D` is the same as the parameter type in `M`.
+- An identity or implicit reference conversion exists from the return type of `M` to the return type of `D`.
 
 This definition of consistency allows covariance in return type and contravariance in parameter types.
 
@@ -147,9 +147,9 @@ This definition of consistency allows covariance in return type and contravarian
 
 An instance of a delegate is created by a *delegate_creation_expression* ([§11.7.15.6](expressions.md#117156-delegate-creation-expressions)), a conversion to a delegate type, delegate combination or delegate removal. The newly created delegate instance then refers to one or more of:
 
--   The static method referenced in the *delegate_creation_expression*, or
--   The target object (which cannot be `null`) and instance method referenced in the *delegate_creation_expression*, or
--   Another delegate ([§11.7.15.6](expressions.md#117156-delegate-creation-expressions)).
+- The static method referenced in the *delegate_creation_expression*, or
+- The target object (which cannot be `null`) and instance method referenced in the *delegate_creation_expression*, or
+- Another delegate ([§11.7.15.6](expressions.md#117156-delegate-creation-expressions)).
 
 > *Example*:
 > ```csharp

--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -51,12 +51,12 @@ The text within documentation comments must be well formed according to the rule
 
 Although developers are free to create their own set of tags, a recommended set is defined in [§D.3](documentation-comments.md#d3-recommended-tags). Some of the recommended tags have special meanings:
 
--   The `<param>` tag is used to describe parameters. If such a tag is used, the documentation generator must verify that the specified parameter exists and that all parameters are described in documentation comments. If such verification fails, the documentation generator issues a warning.
+- The `<param>` tag is used to describe parameters. If such a tag is used, the documentation generator must verify that the specified parameter exists and that all parameters are described in documentation comments. If such verification fails, the documentation generator issues a warning.
 
--   The `cref` attribute can be attached to any tag to provide a reference to a code element. The documentation generator must verify that this code element exists. If the verification fails, the documentation generator issues a warning. When looking for a name described in a `cref` attribute, the documentation generator must respect namespace visibility according to using statements appearing within the source code. For code elements that are generic, the normal generic syntax (e.g., “`List<T>`”) cannot be used because it produces invalid XML. Braces can be used instead of brackets (e.g.; “`List{T}`”), or the XML escape syntax can be used (e.g., “`List&lt;T&gt;`”).
+- The `cref` attribute can be attached to any tag to provide a reference to a code element. The documentation generator must verify that this code element exists. If the verification fails, the documentation generator issues a warning. When looking for a name described in a `cref` attribute, the documentation generator must respect namespace visibility according to using statements appearing within the source code. For code elements that are generic, the normal generic syntax (e.g., “`List<T>`”) cannot be used because it produces invalid XML. Braces can be used instead of brackets (e.g.; “`List{T}`”), or the XML escape syntax can be used (e.g., “`List&lt;T&gt;`”).
 
--   The `<summary>` tag is intended to be used by a documentation viewer to display additional information about a type or member.
--   The `<include>` tag includes information from an external XML file.
+- The `<summary>` tag is intended to be used by a documentation viewer to display additional information about a type or member.
+- The `<include>` tag includes information from an external XML file.
 
 Note carefully that the documentation file does not provide full information about the type and members (for example, it does not contain any type information). To get such information about a type or member, the documentation file must be used in conjunction with reflection on the type or member.
 

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -131,8 +131,8 @@ Multiple enum members may share the same associated value.
 
 The associated value of an enum member is assigned either implicitly or explicitly. If the declaration of the enum member has a *constant_expression* initializer, the value of that constant expression, implicitly converted to the underlying type of the enum, is the associated value of the enum member. If the declaration of the enum member has no initializer, its associated value is set implicitly, as follows:
 
--   If the enum member is the first enum member declared in the enum type, its associated value is zero.
--   Otherwise, the associated value of the enum member is obtained by increasing the associated value of the textually preceding enum member by one. This increased value shall be within the range of values that can be represented by the underlying type, otherwise a compile-time error occurs.
+- If the enum member is the first enum member declared in the enum type, its associated value is zero.
+- Otherwise, the associated value of the enum member is obtained by increasing the associated value of the textually preceding enum member by one. This increased value shall be within the range of values that can be represented by the underlying type, otherwise a compile-time error occurs.
 
 > *Example*: The example
 > ```csharp
@@ -176,9 +176,9 @@ The associated value of an enum member is assigned either implicitly or explicit
 > Blue = 11
 > ```
 > for the following reasons:
-> -   the enum member `Red` is automatically assigned the value zero (since it has no initializer and is the first enum member);
-> -   the enum member `Green` is explicitly given the value `10`;
-> -   and the enum member `Blue` is automatically assigned the value one greater than the member that textually precedes it.
+> - the enum member `Red` is automatically assigned the value zero (since it has no initializer and is the first enum member);
+> - the enum member `Green` is explicitly given the value `10`;
+> - and the enum member `Blue` is automatically assigned the value one greater than the member that textually precedes it.
 > *end example*
 
 The associated value of an enum member may not, directly or indirectly, use the value of its own associated enum member. Other than this circularity restriction, enum member initializers may freely refer to other enum member initializers, regardless of their textual position. Within an enum member initializer, values of other enum members are always treated as having the type of their underlying type, so that casts are not necessary when referring to other enum members.
@@ -209,12 +209,12 @@ Enum members have the type of their containing enum type (except within other en
 
 The following operators can be used on values of enum types:
 
--   `==`, `!=`, `<`, `>`, `<=`, `>=` ([§11.11.6](expressions.md#11116-enumeration-comparison-operators))
--   binary `+` ([§11.9.5](expressions.md#1195-addition-operator))
--   binary `-` ([§11.9.6](expressions.md#1196-subtraction-operator))
--   `^`, `&`, `|` ([§11.12.3](expressions.md#11123-enumeration-logical-operators))
--   `~` ([§11.8.5](expressions.md#1185-bitwise-complement-operator))
--   `++`, `--` ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators) and [§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators))
--   `sizeof` ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator))
+- `==`, `!=`, `<`, `>`, `<=`, `>=` ([§11.11.6](expressions.md#11116-enumeration-comparison-operators))
+- binary `+` ([§11.9.5](expressions.md#1195-addition-operator))
+- binary `-` ([§11.9.6](expressions.md#1196-subtraction-operator))
+- `^`, `&`, `|` ([§11.12.3](expressions.md#11123-enumeration-logical-operators))
+- `~` ([§11.8.5](expressions.md#1185-bitwise-complement-operator))
+- `++`, `--` ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators) and [§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators))
+- `sizeof` ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator))
 
 Every enum type automatically derives from the class `System.Enum` (which, in turn, derives from `System.ValueType` and `object`). Thus, inherited methods and properties of this class can be used on values of an enum type.

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -176,10 +176,10 @@ The associated value of an enum member is assigned either implicitly or explicit
 > Blue = 11
 > ```
 > for the following reasons:
+>
 > - the enum member `Red` is automatically assigned the value zero (since it has no initializer and is the first enum member);
 > - the enum member `Green` is explicitly given the value `10`;
-> - and the enum member `Blue` is automatically assigned the value one greater than the member that textually precedes it.
-> *end example*
+> - and the enum member `Blue` is automatically assigned the value one greater than the member that textually precedes it. *end example*
 
 The associated value of an enum member may not, directly or indirectly, use the value of its own associated enum member. Other than this circularity restriction, enum member initializers may freely refer to other enum member initializers, regardless of their textual position. Within an enum member initializer, values of other enum members are always treated as having the type of their underlying type, so that casts are not necessary when referring to other enum members.
 

--- a/standard/exceptions.md
+++ b/standard/exceptions.md
@@ -8,16 +8,16 @@ Exceptions in C# provide a structured, uniform, and type-safe way of handling bo
 
 Exception can be thrown in two different ways.
 
--   A `throw` statement ([§12.10.6](statements.md#12106-the-throw-statement)) throws an exception immediately and unconditionally. Control never reaches the statement immediately following the `throw`.
--   Certain exceptional conditions that arise during the processing of C# statements and expression cause an exception in certain circumstances when the operation cannot be completed normally. See [§20.5](exceptions.md#205-common-exception-classes) for a list of the various exceptions that can occur in this way.  
+- A `throw` statement ([§12.10.6](statements.md#12106-the-throw-statement)) throws an exception immediately and unconditionally. Control never reaches the statement immediately following the `throw`.
+- Certain exceptional conditions that arise during the processing of C# statements and expression cause an exception in certain circumstances when the operation cannot be completed normally. See [§20.5](exceptions.md#205-common-exception-classes) for a list of the various exceptions that can occur in this way.  
     > *Example*: An integer division operation ([§11.9.3](expressions.md#1193-division-operator)) throws a `System.DivideByZeroException` if the denominator is zero. *end example*
 
 ## 20.3 The System.Exception class
 
 The `System.Exception` class is the base type of all exceptions. This class has a few notable properties that all exceptions share:
 
--   `Message` is a read-only property of type `string` that contains a human-readable description of the reason for the exception.
--   `InnerException` is a read-only property of type `Exception`. If its value is non-`null`, it refers to the exception that caused the current exception. (That is, the current exception was raised in a catch block handling the `InnerException`.) Otherwise, its value is `null`, indicating that this exception was not caused by another exception. The number of exception objects chained together in this manner can be arbitrary.
+- `Message` is a read-only property of type `string` that contains a human-readable description of the reason for the exception.
+- `InnerException` is a read-only property of type `Exception`. If its value is non-`null`, it refers to the exception that caused the current exception. (That is, the current exception was raised in a catch block handling the `InnerException`.) Otherwise, its value is `null`, indicating that this exception was not caused by another exception. The number of exception objects chained together in this manner can be arbitrary.
 
 The value of these properties can be specified in calls to the instance constructor for `System.Exception`.
 
@@ -31,16 +31,16 @@ Once a matching `catch` clause is found, the system prepares to transfer control
 
 If no matching `catch` clause is found:
 
--   If the search for a matching `catch` clause reaches a static constructor ([§14.12](classes.md#1412-static-constructors)) or static field initializer, then a `System.TypeInitializationException` is thrown at the point that triggered the invocation of the static constructor. The inner exception of the `System.TypeInitializationException` contains the exception that was originally thrown.
--   Otherwise, if an exception occurs during finalizer execution, and that exception is not caught, then the behavior is unspecified.
--   Otherwise, if the search for matching `catch` clauses reaches the code that initially started the thread, then execution of the thread is terminated. The impact of such termination is implementation-defined.
+- If the search for a matching `catch` clause reaches a static constructor ([§14.12](classes.md#1412-static-constructors)) or static field initializer, then a `System.TypeInitializationException` is thrown at the point that triggered the invocation of the static constructor. The inner exception of the `System.TypeInitializationException` contains the exception that was originally thrown.
+- Otherwise, if an exception occurs during finalizer execution, and that exception is not caught, then the behavior is unspecified.
+- Otherwise, if the search for matching `catch` clauses reaches the code that initially started the thread, then execution of the thread is terminated. The impact of such termination is implementation-defined.
 
 ## 20.5 Common exception classes
 
 The following exceptions are thrown by certain C# operations.
 
 **Exception Type**                       | **Description**
---------------                           | -----------
+----------------                         | -----------
 `System.ArithmeticException`             | A base class for exceptions that occur during arithmetic operations, such as `System.DivideByZeroException` and `System.OverflowException`.
 `System.ArrayTypeMismatchException`      | Thrown when a store into an array fails because the type of the stored element is incompatible with the type of the array.
 `System.DivideByZeroException`           | Thrown when an attempt to divide an integral value by zero occurs.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -164,7 +164,7 @@ When an operand occurs between two operators with the same precedence, the ***as
 
 Precedence and associativity can be controlled using parentheses.
 
-> *Example*: `x + y * z` first multiplies `y` by `z` and then adds the result to `x`, but` (x + y) * z` first adds `x` and `y` and then multiplies the result by `z`. *end example*
+> *Example*: `x + y * z` first multiplies `y` by `z` and then adds the result to `x`, but `(x + y) * z` first adds `x` and `y` and then multiplies the result by `z`. *end example*
 
 ### 11.4.3 Operator overloading
 
@@ -296,7 +296,7 @@ Unary numeric promotion occurs for the operands of the predefined `+`, `–`, an
 Binary numeric promotion occurs for the operands of the predefined `+`, `–`, `*`, `/`, `%`, `&`, `|`, `^`, `==`, `!=`, `>`, `<`, `>=`, and `<=` binary operators. Binary numeric promotion implicitly converts both operands to a common type which, in case of the non-relational operators, also becomes the result type of the operation. Binary numeric promotion consists of applying the following rules, in the order they appear here:
 
 - If either operand is of type `decimal`, the other operand is converted to type `decimal`, or a binding-time error occurs if the other operand is of type `float` or `double`.
-- Otherwise, if either operand is of type `double, the other operand is converted to type `double`.
+- Otherwise, if either operand is of type `double`, the other operand is converted to type `double`.
 - Otherwise, if either operand is of type `float`, the other operand is converted to type `float`.
 - Otherwise, if either operand is of type `ulong`, the other operand is converted to type `ulong`, or a binding-time error occurs if the other operand is of `type sbyte`, `short`, `int`, or `long`.
 - Otherwise, if either operand is of type `long`, the other operand is converted to type `long`.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4131,6 +4131,7 @@ User defined conversions are not considered by the `is` operator.
 
 <!-- markdownlint-enable MD028 -->
 > *Note*: The `is` operator can be understood in terms of compile-time types and conversions as follows, where `C` is the compile-time type of `E`:
+>
 > - If the compile-time type of `e` is the same as `T`, or if an implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)), boxing conversion ([§10.2.9](conversions.md#1029-boxing-conversions)), wrapping conversion ([§10.6](conversions.md#106-conversions-involving-nullable-types)), or an explicit unwrapping conversion ([§10.6](conversions.md#106-conversions-involving-nullable-types)) exists from the compile-time type of `E` to `T`:
 >   - If `C` is of a non-nullable value type, the result of the operation is `true`.
 >   - Otherwise, the result of the operation is equivalent to evaluating `E != null`.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -10,20 +10,20 @@ An expression is a sequence of operators and operands. This clause defines the s
 
 The result of an expression is classified as one of the following:
 
--   A value. Every value has an associated type.
--   A variable. Every variable has an associated type, namely the declared type of the variable.
--   A null literal. An expression with this classification can be implicitly converted to a reference type or nullable value type.
--   An anonymous function. An expression with this classification can be implicitly converted to a compatible delegate type or expression tree type.
--   A property access. Every property access has an associated type, namely the type of the property. Furthermore, a property access may have an associated instance expression. When an accessor of an instance property access is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)).
--   An indexer access. Every indexer access has an associated type, namely the element type of the indexer. Furthermore, an indexer access has an associated instance expression and an associated argument list. When an accessor of an indexer access is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)), and the result of evaluating the argument list becomes the parameter list of the invocation.
--   Nothing. This occurs when the expression is an invocation of a method with a return type of `void`. An expression classified as nothing is only valid in the context of a *statement_expression* ([§12.7](statements.md#127-expression-statements)) or as the body of a *lambda_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)).
+- A value. Every value has an associated type.
+- A variable. Every variable has an associated type, namely the declared type of the variable.
+- A null literal. An expression with this classification can be implicitly converted to a reference type or nullable value type.
+- An anonymous function. An expression with this classification can be implicitly converted to a compatible delegate type or expression tree type.
+- A property access. Every property access has an associated type, namely the type of the property. Furthermore, a property access may have an associated instance expression. When an accessor of an instance property access is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)).
+- An indexer access. Every indexer access has an associated type, namely the element type of the indexer. Furthermore, an indexer access has an associated instance expression and an associated argument list. When an accessor of an indexer access is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)), and the result of evaluating the argument list becomes the parameter list of the invocation.
+- Nothing. This occurs when the expression is an invocation of a method with a return type of `void`. An expression classified as nothing is only valid in the context of a *statement_expression* ([§12.7](statements.md#127-expression-statements)) or as the body of a *lambda_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)).
 
 For expressions which occur as subexpressions of larger expressions, with the noted restrictions, the result can also be classified as one of the following:
 
--   A namespace. An expression with this classification can only appear as the left-hand side of a *member_access* ([§11.7.6](expressions.md#1176-member-access)). In any other context, an expression classified as a namespace causes a compile-time error.
--   A type. An expression with this classification can only appear as the left-hand side of a *member_access* ([§11.7.6](expressions.md#1176-member-access)). In any other context, an expression classified as a type causes a compile-time error.
--   A method group, which is a set of overloaded methods resulting from a member lookup ([§11.5](expressions.md#115-member-lookup)). A method group may have an associated instance expression and an associated type argument list. When an instance method is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)). A method group is permitted in an *invocation_expression* ([§11.7.8](expressions.md#1178-invocation-expressions)) or a *delegate_creation_expression* ([§11.7.15.6](expressions.md#117156-delegate-creation-expressions)), and can be implicitly converted to a compatible delegate type ([§10.8](conversions.md#108-method-group-conversions)). In any other context, an expression classified as a method group causes a compile-time error.
--   An event access. Every event access has an associated type, namely the type of the event. Furthermore, an event access may have an associated instance expression. An event access may appear as the left-hand operand of the `+=` and `-=` operators ([§11.18.4](expressions.md#11184-event-assignment)). In any other context, an expression classified as an event access causes a compile-time error. When an accessor of an instance event access is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)).
+- A namespace. An expression with this classification can only appear as the left-hand side of a *member_access* ([§11.7.6](expressions.md#1176-member-access)). In any other context, an expression classified as a namespace causes a compile-time error.
+- A type. An expression with this classification can only appear as the left-hand side of a *member_access* ([§11.7.6](expressions.md#1176-member-access)). In any other context, an expression classified as a type causes a compile-time error.
+- A method group, which is a set of overloaded methods resulting from a member lookup ([§11.5](expressions.md#115-member-lookup)). A method group may have an associated instance expression and an associated type argument list. When an instance method is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)). A method group is permitted in an *invocation_expression* ([§11.7.8](expressions.md#1178-invocation-expressions)) or a *delegate_creation_expression* ([§11.7.15.6](expressions.md#117156-delegate-creation-expressions)), and can be implicitly converted to a compatible delegate type ([§10.8](conversions.md#108-method-group-conversions)). In any other context, an expression classified as a method group causes a compile-time error.
+- An event access. Every event access has an associated type, namely the type of the event. Furthermore, an event access may have an associated instance expression. An event access may appear as the left-hand operand of the `+=` and `-=` operators ([§11.18.4](expressions.md#11184-event-assignment)). In any other context, an expression classified as an event access causes a compile-time error. When an accessor of an instance event access is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§11.7.12](expressions.md#11712-this-access)).
 
 A property access or indexer access is always reclassified as a value by performing an invocation of the *get_accessor* or the *set_accessor*. The particular accessor is determined by the context of the property or indexer access: If the access is the target of an assignment, the *set_accessor* is invoked to assign a new value ([§11.18.2](expressions.md#11182-simple-assignment)). Otherwise, the *get_accessor* is invoked to obtain the current value ([§11.2.2](expressions.md#1122-values-of-expressions)).
 
@@ -33,9 +33,9 @@ An ***instance accessor*** is a property access on an instance, an event access 
 
 Most of the constructs that involve an expression ultimately require the expression to denote a ***value***. In such cases, if the actual expression denotes a namespace, a type, a method group, or nothing, a compile-time error occurs. However, if the expression denotes a property access, an indexer access, or a variable, the value of the property, indexer, or variable is implicitly substituted:
 
--   The value of a variable is simply the value currently stored in the storage location identified by the variable. A variable shall be considered definitely assigned ([§9.4](variables.md#94-definite-assignment)) before its value can be obtained, or otherwise a compile-time error occurs.
--   The value of a property access expression is obtained by invoking the *get_accessor* of the property. If the property has no *get_accessor*, a compile-time error occurs. Otherwise, a function member invocation ([§11.6.6](expressions.md#1166-function-member-invocation)) is performed, and the result of the invocation becomes the value of the property access expression.
--   The value of an indexer access expression is obtained by invoking the *get_accessor* of the indexer. If the indexer has no *get_accessor*, a compile-time error occurs. Otherwise, a function member invocation ([§11.6.6](expressions.md#1166-function-member-invocation)) is performed with the argument list associated with the indexer access expression, and the result of the invocation becomes the value of the indexer access expression.
+- The value of a variable is simply the value currently stored in the storage location identified by the variable. A variable shall be considered definitely assigned ([§9.4](variables.md#94-definite-assignment)) before its value can be obtained, or otherwise a compile-time error occurs.
+- The value of a property access expression is obtained by invoking the *get_accessor* of the property. If the property has no *get_accessor*, a compile-time error occurs. Otherwise, a function member invocation ([§11.6.6](expressions.md#1166-function-member-invocation)) is performed, and the result of the invocation becomes the value of the property access expression.
+- The value of an indexer access expression is obtained by invoking the *get_accessor* of the indexer. If the indexer has no *get_accessor*, a compile-time error occurs. Otherwise, a function member invocation ([§11.6.6](expressions.md#1166-function-member-invocation)) is performed with the argument list associated with the indexer access expression, and the result of the invocation becomes the value of the indexer access expression.
 
 ## 11.3 Static and Dynamic Binding
 
@@ -51,15 +51,15 @@ When an operation is dynamically bound, little or no checking is performed by th
 
 The following operations in C# are subject to binding:
 
--   Member access: `e.M`
--   Method invocation: `e.M(e₁,...,eᵥ)`
--   Delegate invocation: `e(e₁,...,eᵥ)`
--   Element access: `e[e₁,...,eᵥ]`
--   Object creation: new `C(e₁,...,eᵥ)`
--   Overloaded unary operators: `+`, `-`, `!`, `~`, `++`, `--`, `true`, `false`
--   Overloaded binary operators: `+`, `-`, `*`, `/`, `%`, `&`, `&&`, `|`, `||`, `??`, `^`, `<<`, `>>`, `==`, `!=`, `>`, `<`, `>=`, `<=`
--   Assignment operators: `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`
--   Implicit and explicit conversions
+- Member access: `e.M`
+- Method invocation: `e.M(e₁,...,eᵥ)`
+- Delegate invocation: `e(e₁,...,eᵥ)`
+- Element access: `e[e₁,...,eᵥ]`
+- Object creation: new `C(e₁,...,eᵥ)`
+- Overloaded unary operators: `+`, `-`, `!`, `~`, `++`, `--`, `true`, `false`
+- Overloaded binary operators: `+`, `-`, `*`, `/`, `%`, `&`, `&&`, `|`, `||`, `??`, `^`, `<<`, `>>`, `==`, `!=`, `>`, `<`, `>=`, `<=`
+- Assignment operators: `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`
+- Implicit and explicit conversions
 
 When no dynamic expressions are involved, C# defaults to static binding, which means that the compile-time types of subexpressions are used in the selection process. However, when one of the subexpressions in the operations listed above is a dynamic expression, the operation is instead dynamically bound.
 
@@ -95,9 +95,9 @@ When an operation is statically bound, the type of a subexpression (e.g., a rece
 
 When an operation is dynamically bound, the type of a subexpression is determined in different ways depending on the compile-time type of the subexpression:
 
--   A subexpression of compile-time type dynamic is considered to have the type of the actual value that the expression evaluates to at run-time
--   A subexpression whose compile-time type is a type parameter is considered to have the type which the type parameter is bound to at run-time
--   Otherwise, the subexpression is considered to have its compile-time type.
+- A subexpression of compile-time type dynamic is considered to have the type of the actual value that the expression evaluates to at run-time
+- A subexpression whose compile-time type is a type parameter is considered to have the type which the type parameter is bound to at run-time
+- Otherwise, the subexpression is considered to have its compile-time type.
 
 ## 11.4 Operators
 
@@ -109,9 +109,9 @@ Expressions are constructed from operands and operators. The operators of an exp
 
 There are three kinds of operators:
 
--   Unary operators. The unary operators take one operand and use either prefix notation (such as `–x`) or postfix notation (such as `x++`).
--   Binary operators. The binary operators take two operands and all use infix notation (such as `x + y`).
--   Ternary operator. Only one ternary operator, `?:`, exists; it takes three operands and uses infix notation (`c ? x : y`).
+- Unary operators. The unary operators take one operand and use either prefix notation (such as `–x`) or postfix notation (such as `x++`).
+- Binary operators. The binary operators take two operands and all use infix notation (such as `x + y`).
+- Ternary operator. Only one ternary operator, `?:`, exists; it takes three operands and uses infix notation (`c ? x : y`).
 
 The order of evaluation of operators in an expression is determined by the *precedence* and *associativity* of the operators ([§11.4.2](expressions.md#1142-operator-precedence-and-associativity)).
 
@@ -136,7 +136,7 @@ The precedence of an operator is established by the definition of its associated
 > *Note*: The following table summarizes all operators in order of precedence from highest to lowest:
 >
 > |  **Subclause**      | **Category**                     | **Operators**
-> |  ---------------    | -------------------------------  | -------------------------------------------------------
+> |  -----------------  | -------------------------------  | -------------------------------------------------------
 > |  [§11.7](expressions.md#117-primary-expressions)              | Primary                          | `x.y` `x?.y` `f(x)` `a[x]` `a?[x]` `x++` `x--` `new` `typeof` `default` `checked` `unchecked` `delegate`
 > |  [§11.8](expressions.md#118-unary-operators)              | Unary                            | `+` `-` `!` `~` `++x` `--x` `(T)x` `await x`
 > |  [§11.9](expressions.md#119-arithmetic-operators)              | Multiplicative                   | `*` `/` `%`
@@ -157,9 +157,9 @@ The precedence of an operator is established by the definition of its associated
 
 When an operand occurs between two operators with the same precedence, the ***associativity*** of the operators controls the order in which the operations are performed:
 
--   Except for the assignment operators and the null coalescing operator, all binary operators are ***left-associative***, meaning that operations are performed from left to right.
+- Except for the assignment operators and the null coalescing operator, all binary operators are ***left-associative***, meaning that operations are performed from left to right.
     > *Example*: `x + y + z` is evaluated as `(x + y) + z`. *end example*
--   The assignment operators, the null coalescing operator and the conditional operator (`?:`) are ***right-associative***, meaning that operations are performed from right to left.
+- The assignment operators, the null coalescing operator and the conditional operator (`?:`) are ***right-associative***, meaning that operations are performed from right to left.
     > *Example*: `x = y = z` is evaluated as `x = (y = z)`. *end example*
 
 Precedence and associativity can be controlled using parentheses.
@@ -226,9 +226,9 @@ The descriptions of individual operators in [§11.8](expressions.md#118-unary-op
 
 An operation of the form `«op» x` or `x «op»`, where «op» is an overloadable unary operator, and `x` is an expression of type `X`, is processed as follows:
 
--   The set of candidate user-defined operators provided by `X` for the operation `operator «op»(x)` is determined using the rules of [§11.4.6](expressions.md#1146-candidate-user-defined-operators).
--   If the set of candidate user-defined operators is not empty, then this becomes the set of candidate operators for the operation. Otherwise, the predefined binary `operator «op»` implementations, including their lifted forms, become the set of candidate operators for the operation. The predefined implementations of a given operator are specified in the description of the operator. The predefined operators provided by an enum or delegate type are only included in this set when the binding-time type—or the underlying type if it is a nullable type—of either operand is the enum or delegate type.
--   The overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution) are applied to the set of candidate operators to select the best operator with respect to the argument list `(x)`, and this operator becomes the result of the overload resolution process. If overload resolution fails to select a single best operator, a binding-time error occurs.
+- The set of candidate user-defined operators provided by `X` for the operation `operator «op»(x)` is determined using the rules of [§11.4.6](expressions.md#1146-candidate-user-defined-operators).
+- If the set of candidate user-defined operators is not empty, then this becomes the set of candidate operators for the operation. Otherwise, the predefined binary `operator «op»` implementations, including their lifted forms, become the set of candidate operators for the operation. The predefined implementations of a given operator are specified in the description of the operator. The predefined operators provided by an enum or delegate type are only included in this set when the binding-time type—or the underlying type if it is a nullable type—of either operand is the enum or delegate type.
+- The overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution) are applied to the set of candidate operators to select the best operator with respect to the argument list `(x)`, and this operator becomes the result of the overload resolution process. If overload resolution fails to select a single best operator, a binding-time error occurs.
 
 ### 11.4.5 Binary operator overload resolution
 
@@ -244,10 +244,10 @@ An operation of the form `x «op» y`, where «op» is an overloadable binary 
 
 Given a type `T` and an operation `operator «op»(A)`, where «op» is an overloadable operator and `A` is an argument list, the set of candidate user-defined operators provided by `T` for operator `«op»(A)` is determined as follows:
 
--   Determine the type `T₀`. If `T` is a nullable value type, `T₀` is its underlying type; otherwise, `T₀` is equal to `T`.
--   For all `operator «op»` declarations in `T₀` and all lifted forms of such operators, if at least one operator is applicable ([§11.6.4.2](expressions.md#11642-applicable-function-member)) with respect to the argument list `A`, then the set of candidate operators consists of all such applicable operators in `T₀`.
--   Otherwise, if `T₀` is `object`, the set of candidate operators is empty.
--   Otherwise, the set of candidate operators provided by `T₀` is the set of candidate operators provided by the direct base class of `T₀`, or the effective base class of `T₀` if `T₀` is a type parameter.
+- Determine the type `T₀`. If `T` is a nullable value type, `T₀` is its underlying type; otherwise, `T₀` is equal to `T`.
+- For all `operator «op»` declarations in `T₀` and all lifted forms of such operators, if at least one operator is applicable ([§11.6.4.2](expressions.md#11642-applicable-function-member)) with respect to the argument list `A`, then the set of candidate operators consists of all such applicable operators in `T₀`.
+- Otherwise, if `T₀` is `object`, the set of candidate operators is empty.
+- Otherwise, the set of candidate operators provided by `T₀` is the set of candidate operators provided by the direct base class of `T₀`, or the effective base class of `T₀` if `T₀` is a type parameter.
 
 ### 11.4.7 Numeric promotions
 
@@ -295,14 +295,14 @@ Unary numeric promotion occurs for the operands of the predefined `+`, `–`, an
 
 Binary numeric promotion occurs for the operands of the predefined `+`, `–`, `*`, `/`, `%`, `&`, `|`, `^`, `==`, `!=`, `>`, `<`, `>=`, and `<=` binary operators. Binary numeric promotion implicitly converts both operands to a common type which, in case of the non-relational operators, also becomes the result type of the operation. Binary numeric promotion consists of applying the following rules, in the order they appear here:
 
--   If either operand is of type `decimal`, the other operand is converted to type `decimal`, or a binding-time error occurs if the other operand is of type `float` or `double`.
--   Otherwise, if either operand is of type `double, the other operand is converted to type `double`.
--   Otherwise, if either operand is of type `float`, the other operand is converted to type `float`.
--   Otherwise, if either operand is of type `ulong`, the other operand is converted to type `ulong`, or a binding-time error occurs if the other operand is of `type sbyte`, `short`, `int`, or `long`.
--   Otherwise, if either operand is of type `long`, the other operand is converted to type `long`.
--   Otherwise, if either operand is of type `uint` and the other operand is of type `sbyte`, `short`, or `int`, both operands are converted to type `long`.
--   Otherwise, if either operand is of type `uint`, the other operand is converted to type `uint`.
--   Otherwise, both operands are converted to type `int`.
+- If either operand is of type `decimal`, the other operand is converted to type `decimal`, or a binding-time error occurs if the other operand is of type `float` or `double`.
+- Otherwise, if either operand is of type `double, the other operand is converted to type `double`.
+- Otherwise, if either operand is of type `float`, the other operand is converted to type `float`.
+- Otherwise, if either operand is of type `ulong`, the other operand is converted to type `ulong`, or a binding-time error occurs if the other operand is of `type sbyte`, `short`, `int`, or `long`.
+- Otherwise, if either operand is of type `long`, the other operand is converted to type `long`.
+- Otherwise, if either operand is of type `uint` and the other operand is of type `sbyte`, `short`, or `int`, both operands are converted to type `long`.
+- Otherwise, if either operand is of type `uint`, the other operand is converted to type `uint`.
+- Otherwise, both operands are converted to type `int`.
 
 > *Note*: The first rule disallows any operations that mix the `decimal` type with the `double` and `float` types. The rule follows from the fact that there are no implicit conversions between the `decimal` type and the `double` and `float` types. *end note*
 <!-- markdownlint-disable MD028 -->
@@ -328,10 +328,10 @@ In both of the above cases, a cast expression can be used to explicitly convert 
 
 ***Lifted operators*** permit predefined and user-defined operators that operate on non-nullable value types to also be used with nullable forms of those types. Lifted operators are constructed from predefined and user-defined operators that meet certain requirements, as described in the following:
 
--   For the unary operators `+`, `++`, `-`, `--`, `!`, and `~`, a lifted form of an operator exists if the operand and result types are both non-nullable value types. The lifted form is constructed by adding a single `?` modifier to the operand and result types. The lifted operator produces a `null` value if the operand is `null`. Otherwise, the lifted operator unwraps the operand, applies the underlying operator, and wraps the result.
--   For the binary operators `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, and `>>`, a lifted form of an operator exists if the operand and result types are all non-nullable value types. The lifted form is constructed by adding a single `?` modifier to each operand and result type. The lifted operator produces a `null` value if one or both operands are `null` (an exception being the `&` and `|` operators of the `bool?` type, as described in [§11.12.5](expressions.md#11125-nullable-boolean--and--operators)). Otherwise, the lifted operator unwraps the operands, applies the underlying operator, and wraps the result.
--   For the equality operators `==` and `!=`, a lifted form of an operator exists if the operand types are both non-nullable value types and if the result type is `bool`. The lifted form is constructed by adding a single `?` modifier to each operand type. The lifted operator considers two `null` values equal, and a `null` value unequal to any non-`null` value. If both operands are non-`null`, the lifted operator unwraps the operands and applies the underlying operator to produce the `bool` result.
--   For the relational operators `<`, `>`, `<=`, and `>=`, a lifted form of an operator exists if the operand types are both non-nullable value types and if the result type is `bool`. The lifted form is constructed by adding a single `?` modifier to each operand type. The lifted operator produces the value `false` if one or both operands are `null`. Otherwise, the lifted operator unwraps the operands and applies the underlying operator to produce the `bool` result.
+- For the unary operators `+`, `++`, `-`, `--`, `!`, and `~`, a lifted form of an operator exists if the operand and result types are both non-nullable value types. The lifted form is constructed by adding a single `?` modifier to the operand and result types. The lifted operator produces a `null` value if the operand is `null`. Otherwise, the lifted operator unwraps the operand, applies the underlying operator, and wraps the result.
+- For the binary operators `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, and `>>`, a lifted form of an operator exists if the operand and result types are all non-nullable value types. The lifted form is constructed by adding a single `?` modifier to each operand and result type. The lifted operator produces a `null` value if one or both operands are `null` (an exception being the `&` and `|` operators of the `bool?` type, as described in [§11.12.5](expressions.md#11125-nullable-boolean--and--operators)). Otherwise, the lifted operator unwraps the operands, applies the underlying operator, and wraps the result.
+- For the equality operators `==` and `!=`, a lifted form of an operator exists if the operand types are both non-nullable value types and if the result type is `bool`. The lifted form is constructed by adding a single `?` modifier to each operand type. The lifted operator considers two `null` values equal, and a `null` value unequal to any non-`null` value. If both operands are non-`null`, the lifted operator unwraps the operands and applies the underlying operator to produce the `bool` result.
+- For the relational operators `<`, `>`, `<=`, and `>=`, a lifted form of an operator exists if the operand types are both non-nullable value types and if the result type is `bool`. The lifted form is constructed by adding a single `?` modifier to each operand type. The lifted operator produces the value `false` if one or both operands are `null`. Otherwise, the lifted operator unwraps the operands and applies the underlying operator to produce the `bool` result.
 
 ## 11.5 Member lookup
 
@@ -385,14 +385,14 @@ For purposes of member lookup, a type `T` is considered to have the following b
 
 Function members are members that contain executable statements. Function members are always members of types and cannot be members of namespaces. C# defines the following categories of function members:
 
--   Methods
--   Properties
--   Events
--   Indexers
--   User-defined operators
--   Instance constructors
--   Static constructors
--   Finalizers
+- Methods
+- Properties
+- Events
+- Indexers
+- User-defined operators
+- Instance constructors
+- Static constructors
+- Finalizers
 
 Except for finalizers and static constructors (which cannot be invoked explicitly), the statements contained in function members are executed through function member invocations. The actual syntax for writing a function member invocation depends on the particular function member category.
 
@@ -507,11 +507,11 @@ Once a particular function member has been identified at binding-time, possibly 
 
 Every function member and delegate invocation includes an argument list, which provides actual values or variable references for the parameters of the function member. The syntax for specifying the argument list of a function member invocation depends on the function member category:
 
--   For instance constructors, methods, indexers and delegates, the arguments are specified as an *argument_list*, as described below. For indexers, when invoking the set accessor, the argument list additionally includes the expression specified as the right operand of the assignment operator.  
+- For instance constructors, methods, indexers and delegates, the arguments are specified as an *argument_list*, as described below. For indexers, when invoking the set accessor, the argument list additionally includes the expression specified as the right operand of the assignment operator.  
    > *Note*: This additional argument is not used for overload resolution, just during invocation of the set accessor. *end note*
--   For properties, the argument list is empty when invoking the get accessor, and consists of the expression specified as the right operand of the assignment operator when invoking the set accessor.
--   For events, the argument list consists of the expression specified as the right operand of the `+=` or `-=` operator.
--   For user-defined operators, the argument list consists of the single operand of the unary operator or the two operands of the binary operator.
+- For properties, the argument list is empty when invoking the get accessor, and consists of the expression specified as the right operand of the assignment operator when invoking the set accessor.
+- For events, the argument list consists of the expression specified as the right operand of the `+=` or `-=` operator.
+- For user-defined operators, the argument list consists of the single operand of the unary operator or the two operands of the binary operator.
 
 The arguments of properties ([§14.7](classes.md#147-properties)), events ([§14.8](classes.md#148-events)), and user-defined operators ([§14.10](classes.md#1410-operators)) are always passed as value parameters ([§14.6.2.2](classes.md#14622-value-parameters)). The arguments of indexers ([§14.9](classes.md#149-indexers)) are always passed as value parameters ([§14.6.2.2](classes.md#14622-value-parameters)) or parameter arrays ([§14.6.2.5](classes.md#14625-parameter-arrays)). Reference and output parameters are not supported for these categories of function members.
 
@@ -540,9 +540,9 @@ An *argument_list* consists of one or more *argument*s, separated by commas. Eac
 
 The *argument_value* can take one of the following forms:
 
--   An *expression*, indicating that the argument is passed as a value parameter ([§14.6.2.2](classes.md#14622-value-parameters)).
--   The keyword `ref` followed by a *variable_reference* ([§9.5](variables.md#95-variable-references)), indicating that the argument is passed as a reference parameter ([§14.6.2.3](classes.md#14623-reference-parameters)). A variable shall be definitely assigned ([§9.4](variables.md#94-definite-assignment)) before it can be passed as a reference parameter.
--   The keyword `out` followed by a *variable_reference* ([§9.5](variables.md#95-variable-references)), indicating that the argument is passed as an output parameter ([§14.6.2.4](classes.md#14624-output-parameters)). A variable is considered definitely assigned ([§9.4](variables.md#94-definite-assignment)) following a function member invocation in which the variable is passed as an output parameter.
+- An *expression*, indicating that the argument is passed as a value parameter ([§14.6.2.2](classes.md#14622-value-parameters)).
+- The keyword `ref` followed by a *variable_reference* ([§9.5](variables.md#95-variable-references)), indicating that the argument is passed as a reference parameter ([§14.6.2.3](classes.md#14623-reference-parameters)). A variable shall be definitely assigned ([§9.4](variables.md#94-definite-assignment)) before it can be passed as a reference parameter.
+- The keyword `out` followed by a *variable_reference* ([§9.5](variables.md#95-variable-references)), indicating that the argument is passed as an output parameter ([§14.6.2.4](classes.md#14624-output-parameters)). A variable is considered definitely assigned ([§9.4](variables.md#94-definite-assignment)) following a function member invocation in which the variable is passed as an output parameter.
 
 The form determines the ***parameter-passing mode*** of the argument: *value*, *reference*, or *output*, respectively.
 
@@ -554,9 +554,9 @@ For each argument in an argument list there has to be a corresponding parameter 
 
 The parameter list used in the following is determined as follows:
 
--   For virtual methods and indexers defined in classes, the parameter list is picked from the first declaration or override of the function member found when starting with the static type of the receiver, and searching through its base classes.
--   For partial methods, the parameter list of the defining partial method declaration is used.
--   For all other function members and delegates there is only a single parameter list, which is the one used.
+- For virtual methods and indexers defined in classes, the parameter list is picked from the first declaration or override of the function member found when starting with the static type of the receiver, and searching through its base classes.
+- For partial methods, the parameter list of the defining partial method declaration is used.
+- For all other function members and delegates there is only a single parameter list, which is the one used.
 
 The position of an argument or parameter is defined as the number of arguments or parameters preceding it in the argument list or parameter list.
 
@@ -575,13 +575,13 @@ The corresponding parameters for function member arguments are established as fo
 
 During the run-time processing of a function member invocation ([§11.6.6](expressions.md#1166-function-member-invocation)), the expressions or variable references of an argument list are evaluated in order, from left to right, as follows:
 
--   For a value parameter, the argument expression is evaluated and an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) to the corresponding parameter type is performed. The resulting value becomes the initial value of the value parameter in the function member invocation.
--   For a reference or output parameter, the variable reference is evaluated and the resulting storage location becomes the storage location represented by the parameter in the function member invocation. If the variable reference given as a reference or output parameter is an array element of a *reference_type*, a run-time check is performed to ensure that the element type of the array is identical to the type of the parameter. If this check fails, a `System.ArrayTypeMismatchException` is thrown.
+- For a value parameter, the argument expression is evaluated and an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) to the corresponding parameter type is performed. The resulting value becomes the initial value of the value parameter in the function member invocation.
+- For a reference or output parameter, the variable reference is evaluated and the resulting storage location becomes the storage location represented by the parameter in the function member invocation. If the variable reference given as a reference or output parameter is an array element of a *reference_type*, a run-time check is performed to ensure that the element type of the array is identical to the type of the parameter. If this check fails, a `System.ArrayTypeMismatchException` is thrown.
 
 Methods, indexers, and instance constructors may declare their right-most parameter to be a parameter array ([§14.6.2.5](classes.md#14625-parameter-arrays)). Such function members are invoked either in their normal form or in their expanded form depending on which is applicable ([§11.6.4.2](expressions.md#11642-applicable-function-member)):
 
--   When a function member with a parameter array is invoked in its normal form, the argument given for the parameter array shall be a single expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the parameter array type. In this case, the parameter array acts precisely like a value parameter.
--   When a function member with a parameter array is invoked in its expanded form, the invocation shall specify zero or more positional arguments for the parameter array, where each argument is an expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the element type of the parameter array. In this case, the invocation creates an instance of the parameter array type with a length corresponding to the number of arguments, initializes the elements of the array instance with the given argument values, and uses the newly created array instance as the actual argument.
+- When a function member with a parameter array is invoked in its normal form, the argument given for the parameter array shall be a single expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the parameter array type. In this case, the parameter array acts precisely like a value parameter.
+- When a function member with a parameter array is invoked in its expanded form, the invocation shall specify zero or more positional arguments for the parameter array, where each argument is an expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the element type of the parameter array. In this case, the invocation creates an instance of the parameter array type with a length corresponding to the number of arguments, initializes the elements of the array instance with the given argument values, and uses the newly created array instance as the actual argument.
 
 The expressions of an argument list are always evaluated in textual order.
 
@@ -690,10 +690,10 @@ Type inference takes place in phases. Each phase will try to infer type argument
 
 For each of the method arguments `Eᵢ`:
 
--   If `Eᵢ` is an anonymous function, an *explicit parameter type inference* ([§11.6.3.8](expressions.md#11638-explicit-parameter-type-inferences)) is made *from* `Eᵢ` *to* `Tᵢ`
--   Otherwise, if `Eᵢ` has a type `U` and `xᵢ` is a value parameter ([§14.6.2.2](classes.md#14622-value-parameters)) then a *lower-bound inference* ([§11.6.3.10](expressions.md#116310-lower-bound-inferences)) is made *from* `U` *to* `Tᵢ`.
--   Otherwise, if `Eᵢ` has a type `U` and `xᵢ` is a reference ([§14.6.2.3](classes.md#14623-reference-parameters)) or output ([§14.6.2.4](classes.md#14624-output-parameters)) parameter then an *exact inference* ([§11.6.3.9](expressions.md#11639-exact-inferences)) is made *from* `U` *to* `Tᵢ`.
--   Otherwise, no inference is made for this argument.
+- If `Eᵢ` is an anonymous function, an *explicit parameter type inference* ([§11.6.3.8](expressions.md#11638-explicit-parameter-type-inferences)) is made *from* `Eᵢ` *to* `Tᵢ`
+- Otherwise, if `Eᵢ` has a type `U` and `xᵢ` is a value parameter ([§14.6.2.2](classes.md#14622-value-parameters)) then a *lower-bound inference* ([§11.6.3.10](expressions.md#116310-lower-bound-inferences)) is made *from* `U` *to* `Tᵢ`.
+- Otherwise, if `Eᵢ` has a type `U` and `xᵢ` is a reference ([§14.6.2.3](classes.md#14623-reference-parameters)) or output ([§14.6.2.4](classes.md#14624-output-parameters)) parameter then an *exact inference* ([§11.6.3.9](expressions.md#11639-exact-inferences)) is made *from* `U` *to* `Tᵢ`.
+- Otherwise, no inference is made for this argument.
 
 #### 11.6.3.3 The second phase
 
@@ -725,16 +725,16 @@ An *unfixed* type variable `Xᵢ` *depends directly on* an *unfixed* type varia
 
 An *output type inference* is made *from* an expression `E` *to* a type T in the following way:
 
--   If `E` is an anonymous function with inferred return type `U` ([§11.6.3.13](expressions.md#116313-inferred-return-type)) and `T` is a delegate type or expression tree type with return type `Tₓ`, then a *lower-bound inference* ([§11.6.3.10](expressions.md#116310-lower-bound-inferences)) is made *from* `U` *to* `Tₓ`.
--   Otherwise, if `E` is a method group and `T` is a delegate type or expression tree type with parameter types `T₁...Tᵥ` and return type `Tₓ`, and overload resolution of `E` with the types `T₁...Tᵥ` yields a single method with return type `U`, then a *lower-bound inference* is made *from* `U` *to* `Tₓ`.
--   Otherwise, if `E` is an expression with type `U`, then a *lower-bound inference* is made *from* `U` *to* `T`.
--   Otherwise, no inferences are made.
+- If `E` is an anonymous function with inferred return type `U` ([§11.6.3.13](expressions.md#116313-inferred-return-type)) and `T` is a delegate type or expression tree type with return type `Tₓ`, then a *lower-bound inference* ([§11.6.3.10](expressions.md#116310-lower-bound-inferences)) is made *from* `U` *to* `Tₓ`.
+- Otherwise, if `E` is a method group and `T` is a delegate type or expression tree type with parameter types `T₁...Tᵥ` and return type `Tₓ`, and overload resolution of `E` with the types `T₁...Tᵥ` yields a single method with return type `U`, then a *lower-bound inference* is made *from* `U` *to* `Tₓ`.
+- Otherwise, if `E` is an expression with type `U`, then a *lower-bound inference* is made *from* `U` *to* `T`.
+- Otherwise, no inferences are made.
 
 #### 11.6.3.8 Explicit parameter type inferences
 
 An *explicit parameter type inference* is made *from* an expression `E` *to* a type `T` in the following way:
 
--   If `E` is an explicitly typed anonymous function with parameter types `U₁...Uᵥ` and `T` is a delegate type or expression tree type with parameter types `V₁...Vᵥ` then for each `Uᵢ` an *exact inference* ([§11.6.3.9](expressions.md#11639-exact-inferences)) is made *from* `Uᵢ` *to* the corresponding `Vᵢ`.
+- If `E` is an explicitly typed anonymous function with parameter types `U₁...Uᵥ` and `T` is a delegate type or expression tree type with parameter types `V₁...Vᵥ` then for each `Uᵢ` an *exact inference* ([§11.6.3.9](expressions.md#11639-exact-inferences)) is made *from* `Uᵢ` *to* the corresponding `Vᵢ`.
 
 #### 11.6.3.9 Exact inferences
 
@@ -792,10 +792,10 @@ An *upper-bound inference from* a type `U` *to* a type `V` is made as follows:
 
 An *unfixed* type variable `Xᵢ` with a set of bounds is *fixed* as follows:
 
--   The set of *candidate types* `Uₑ` starts out as the set of all types in the set of bounds for `Xᵢ`.
--   We then examine each bound for `Xᵢ` in turn: For each exact bound U of `Xᵢ` all types `Uₑ` that are not identical to `U` are removed from the candidate set. For each lower bound `U` of `Xᵢ` all types `Uₑ` to which there is *not* an implicit conversion from `U` are removed from the candidate set. For each upper-bound U of `Xᵢ` all types `Uₑ` from which there is *not* an implicit conversion to `U` are removed from the candidate set.
--   If among the remaining candidate types `Uₑ` there is a unique type `V` to which there is an implicit conversion from all the other candidate types, then `Xᵢ` is fixed to `V`.
--   Otherwise, type inference fails.
+- The set of *candidate types* `Uₑ` starts out as the set of all types in the set of bounds for `Xᵢ`.
+- We then examine each bound for `Xᵢ` in turn: For each exact bound U of `Xᵢ` all types `Uₑ` that are not identical to `U` are removed from the candidate set. For each lower bound `U` of `Xᵢ` all types `Uₑ` to which there is *not* an implicit conversion from `U` are removed from the candidate set. For each upper-bound U of `Xᵢ` all types `Uₑ` from which there is *not* an implicit conversion to `U` are removed from the candidate set.
+- If among the remaining candidate types `Uₑ` there is a unique type `V` to which there is an implicit conversion from all the other candidate types, then `Xᵢ` is fixed to `V`.
+- Otherwise, type inference fails.
 
 #### 11.6.3.13 Inferred return type
 
@@ -803,16 +803,16 @@ The inferred return type of an anonymous function `F` is used during type infer
 
 The ***inferred effective return type*** is determined as follows:
 
--   If the body of `F` is an *expression* that has a type, then the inferred effective return type of `F` is the type of that expression.
--   If the body of `F` is a *block* and the set of expressions in the block’s `return` statements has a best common type `T` ([§11.6.3.15](expressions.md#116315-finding-the-best-common-type-of-a-set-of-expressions)), then the inferred effective return type of `F` is `T`.
--   Otherwise, an effective return type cannot be inferred for `F`.
+- If the body of `F` is an *expression* that has a type, then the inferred effective return type of `F` is the type of that expression.
+- If the body of `F` is a *block* and the set of expressions in the block’s `return` statements has a best common type `T` ([§11.6.3.15](expressions.md#116315-finding-the-best-common-type-of-a-set-of-expressions)), then the inferred effective return type of `F` is `T`.
+- Otherwise, an effective return type cannot be inferred for `F`.
 
 The ***inferred return type*** is determined as follows:
 
--   If `F` is async and the body of `F` is either an expression classified as nothing ([§11.2](expressions.md#112-expression-classifications)), or a statement block where no `return` statements have expressions, the inferred return type is `System.Threading.Tasks.Task`.
--   If `F` is async and has an inferred effective return type `T`, the inferred return type is `System.Threading.Tasks.Task<T>`.
--   If `F` is non-async and has an inferred effective return type `T`, the inferred return type is `T`.
--   Otherwise, a return type cannot be inferred for `F`.
+- If `F` is async and the body of `F` is either an expression classified as nothing ([§11.2](expressions.md#112-expression-classifications)), or a statement block where no `return` statements have expressions, the inferred return type is `System.Threading.Tasks.Task`.
+- If `F` is async and has an inferred effective return type `T`, the inferred return type is `System.Threading.Tasks.Task<T>`.
+- If `F` is non-async and has an inferred effective return type `T`, the inferred return type is `T`.
+- Otherwise, a return type cannot be inferred for `F`.
 
 > *Example*: As an example of type inference involving anonymous functions, consider the `Select` extension method declared in the `System.Linq.Enumerable` class:
 > ```csharp
@@ -882,10 +882,10 @@ In some cases, a common type needs to be inferred for a set of expressions. In p
 
 The best common type for a set of expressions `E₁...Eᵥ` is determined as follows:
 
--   A new *unfixed* type variable `X` is introduced.
--   For each expression `Ei` an *output type inference* ([§11.6.3.7](expressions.md#11637-output-type-inferences)) is performed from it to `X`.
--   `X` is *fixed* ([§11.6.3.12](expressions.md#116312-fixing)), if possible, and the resulting type is the best common type.
--   Otherwise inference fails.
+- A new *unfixed* type variable `X` is introduced.
+- For each expression `Ei` an *output type inference* ([§11.6.3.7](expressions.md#11637-output-type-inferences)) is performed from it to `X`.
+- `X` is *fixed* ([§11.6.3.12](expressions.md#116312-fixing)), if possible, and the resulting type is the best common type.
+- Otherwise inference fails.
 
 > *Note*: Intuitively this inference is equivalent to calling a method
 > `void M<X>(X x₁ ... X xᵥ)`
@@ -897,17 +897,17 @@ The best common type for a set of expressions `E₁...Eᵥ` is determined as fol
 
 Overload resolution is a binding-time mechanism for selecting the best function member to invoke given an argument list and a set of candidate function members. Overload resolution selects the function member to invoke in the following distinct contexts within C#:
 
--   Invocation of a method named in an *invocation_expression* ([§11.7.8](expressions.md#1178-invocation-expressions)).
--   Invocation of an instance constructor named in an *object_creation_expression* ([§11.7.15.2](expressions.md#117152-object-creation-expressions)).
--   Invocation of an indexer accessor through an *element_access* ([§11.7.10](expressions.md#11710-element-access)).
--   Invocation of a predefined or user-defined operator referenced in an expression ([§11.4.4](expressions.md#1144-unary-operator-overload-resolution) and [§11.4.5](expressions.md#1145-binary-operator-overload-resolution)).
+- Invocation of a method named in an *invocation_expression* ([§11.7.8](expressions.md#1178-invocation-expressions)).
+- Invocation of an instance constructor named in an *object_creation_expression* ([§11.7.15.2](expressions.md#117152-object-creation-expressions)).
+- Invocation of an indexer accessor through an *element_access* ([§11.7.10](expressions.md#11710-element-access)).
+- Invocation of a predefined or user-defined operator referenced in an expression ([§11.4.4](expressions.md#1144-unary-operator-overload-resolution) and [§11.4.5](expressions.md#1145-binary-operator-overload-resolution)).
 
 Each of these contexts defines the set of candidate function members and the list of arguments in its own unique way. For instance, the set of candidates for a method invocation does not include methods marked override ([§11.5](expressions.md#115-member-lookup)), and methods in a base class are not candidates if any method in a derived class is applicable ([§11.7.8.2](expressions.md#11782-method-invocations)).
 
 Once the candidate function members and the argument list have been identified, the selection of the best function member is the same in all cases:
 
--   First, the set of candidate function members is reduced to those function members that are applicable with respect to the given argument list ([§11.6.4.2](expressions.md#11642-applicable-function-member)). If this reduced set is empty, a compile-time error occurs.
--   Then, the best function member from the set of applicable candidate function members is located. If the set contains only one function member, then that function member is the best function member. Otherwise, the best function member is the one function member that is better than all other function members with respect to the given argument list, provided that each function member is compared to all other function members using the rules in [§11.6.4.3](expressions.md#11643-better-function-member). If there is not exactly one function member that is better than all other function members, then the function member invocation is ambiguous and a binding-time error occurs.
+- First, the set of candidate function members is reduced to those function members that are applicable with respect to the given argument list ([§11.6.4.2](expressions.md#11642-applicable-function-member)). If this reduced set is empty, a compile-time error occurs.
+- Then, the best function member from the set of applicable candidate function members is located. If the set contains only one function member, then that function member is the best function member. Otherwise, the best function member is the one function member that is better than all other function members with respect to the given argument list, provided that each function member is compared to all other function members using the rules in [§11.6.4.3](expressions.md#11643-better-function-member). If there is not exactly one function member that is better than all other function members, then the function member invocation is ambiguous and a binding-time error occurs.
 
 The following subclauses define the exact meanings of the terms *applicable function member* and *better function member*.
 
@@ -933,14 +933,14 @@ For the purposes of determining the better function member, a stripped-down argu
 
 Parameter lists for each of the candidate function members are constructed in the following way:
 
--   The expanded form is used if the function member was applicable only in the expanded form.
--   Optional parameters with no corresponding arguments are removed from the parameter list
--   The parameters are reordered so that they occur at the same position as the corresponding argument in the argument list.
+- The expanded form is used if the function member was applicable only in the expanded form.
+- Optional parameters with no corresponding arguments are removed from the parameter list
+- The parameters are reordered so that they occur at the same position as the corresponding argument in the argument list.
 
 Given an argument list `A` with a set of argument expressions `{E₁, E₂, ..., Eᵥ}` and two applicable function members `Mᵥ` and `Mₓ` with parameter types `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂, ..., Qᵥ}`, `Mᵥ` is defined to be a ***better function member*** than `Mₓ` if
 
--   for each argument, the implicit conversion from `Eᵥ` to `Qᵥ` is not better than the implicit conversion from `Eᵥ` to `Pᵥ`, and
--   for at least one argument, the conversion from `Eᵥ` to `Pᵥ` is better than the conversion from `Eᵥ` to `Qᵥ`.
+- for each argument, the implicit conversion from `Eᵥ` to `Qᵥ` is not better than the implicit conversion from `Eᵥ` to `Pᵥ`, and
+- for at least one argument, the conversion from `Eᵥ` to `Pᵥ` is better than the conversion from `Eᵥ` to `Qᵥ`.
 
 In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂, ..., Qᵥ}` are equivalent (i.e., each `Pᵢ` has an identity conversion to the corresponding `Qᵢ`), the following tie-breaking rules are applied, in order, to determine the better function member.
 
@@ -1022,23 +1022,23 @@ Given an expression `E` and two types `T₁` and `T₂`, `T₁` is a ***better c
 
 Even though overload resolution of a dynamically bound operation takes place at run-time, it is sometimes possible at compile-time to know the list of function members from which an overload will be chosen:
 
--   For a delegate invocation ([§11.7.8.4](expressions.md#11784-delegate-invocations)), the list is a single function member with the same parameter list as the *delegate_type* of the invocation
--   For a method invocation ([§11.7.8.2](expressions.md#11782-method-invocations)) on a type, or on a value whose static type is not dynamic, the set of accessible methods in the method group is known at compile-time.
--   For an object creation expression ([§11.7.15.2](expressions.md#117152-object-creation-expressions)) the set of accessible constructors in the type is known at compile-time.
--   For an indexer access ([§11.7.10.3](expressions.md#117103-indexer-access)) the set of accessible indexers in the receiver is known at compile-time.
+- For a delegate invocation ([§11.7.8.4](expressions.md#11784-delegate-invocations)), the list is a single function member with the same parameter list as the *delegate_type* of the invocation
+- For a method invocation ([§11.7.8.2](expressions.md#11782-method-invocations)) on a type, or on a value whose static type is not dynamic, the set of accessible methods in the method group is known at compile-time.
+- For an object creation expression ([§11.7.15.2](expressions.md#117152-object-creation-expressions)) the set of accessible constructors in the type is known at compile-time.
+- For an indexer access ([§11.7.10.3](expressions.md#117103-indexer-access)) the set of accessible indexers in the receiver is known at compile-time.
 
 In these cases a limited compile-time check is performed on each member in the known set of function members, to see if it can be known for certain never to be invoked at run-time. For each function member `F` a modified parameter and argument list are constructed:
 
--   First, if `F` is a generic method and type arguments were provided, then those are substituted for the type parameters in the parameter list. However, if type arguments were not provided, no such substitution happens.
--   Then, any parameter whose type is open (i.e., contains a type parameter; see [§8.4.3](types.md#843-open-and-closed-types)) is elided, along with its corresponding parameter(s).
+- First, if `F` is a generic method and type arguments were provided, then those are substituted for the type parameters in the parameter list. However, if type arguments were not provided, no such substitution happens.
+- Then, any parameter whose type is open (i.e., contains a type parameter; see [§8.4.3](types.md#843-open-and-closed-types)) is elided, along with its corresponding parameter(s).
 
 For `F` to pass the check, all of the following shall hold:
 
--   The modified parameter list for `F` is applicable to the modified argument list in terms of [§11.6.4.2](expressions.md#11642-applicable-function-member).
--   All constructed types in the modified parameter list satisfy their constraints ([§8.4.5](types.md#845-satisfying-constraints)).
--   If the type parameters of `F` were substituted in the step above, their constraints are satisfied.
--   If `F` is a static method, the method group shall not have resulted from a *member_access* whose receiver is known at compile-time to be a variable or value.
--   If `F` is an instance method, the method group shall not have resulted from a *member_access* whose receiver is known at compile-time to be a type.
+- The modified parameter list for `F` is applicable to the modified argument list in terms of [§11.6.4.2](expressions.md#11642-applicable-function-member).
+- All constructed types in the modified parameter list satisfy their constraints ([§8.4.5](types.md#845-satisfying-constraints)).
+- If the type parameters of `F` were substituted in the step above, their constraints are satisfied.
+- If `F` is a static method, the method group shall not have resulted from a *member_access* whose receiver is known at compile-time to be a variable or value.
+- If `F` is an instance method, the method group shall not have resulted from a *member_access* whose receiver is known at compile-time to be a type.
 
 If no candidate passes this test, a compile-time error occurs.
 
@@ -1050,8 +1050,8 @@ This subclause describes the process that takes place at run-time to invoke a pa
 
 For purposes of describing the invocation process, function members are divided into two categories:
 
--   Static function members. These are static methods, static property accessors, and user-defined operators. Static function members are always non-virtual.
--   Instance function members. These are instance methods, instance constructors, instance property accessors, and indexer accessors. Instance function members are either non-virtual or virtual, and are always invoked on a particular instance. The instance is computed by an instance expression, and it becomes accessible within the function member as `this` ([§11.7.12](expressions.md#11712-this-access)). For an instance constructor, the instance expression is taken to be the newly allocated object.
+- Static function members. These are static methods, static property accessors, and user-defined operators. Static function members are always non-virtual.
+- Instance function members. These are instance methods, instance constructors, instance property accessors, and indexer accessors. Instance function members are either non-virtual or virtual, and are always invoked on a particular instance. The instance is computed by an instance expression, and it becomes accessible within the function member as `this` ([§11.7.12](expressions.md#11712-this-access)). For an instance constructor, the instance expression is taken to be the newly allocated object.
 
 The run-time processing of a function member invocation consists of the following steps, where `M` is the function member and, if `M` is an instance member, `E` is the instance expression:
 
@@ -1072,7 +1072,7 @@ The run-time processing of a function member invocation consists of the followin
     - If the binding-time type of `E` is an interface, the function member to invoke is the implementation of `M` provided by the run-time type of the instance referenced by `E`. This function member is determined by applying the interface mapping rules ([§17.6.5](interfaces.md#1765-interface-mapping)) to determine the implementation of `M` provided by the run-time type of the instance referenced by `E`.
     - Otherwise, if `M` is a virtual function member, the function member to invoke is the implementation of `M` provided by the run-time type of the instance referenced by `E`. This function member is determined by applying the rules for determining the most derived implementation ([§14.6.4](classes.md#1464-virtual-methods)) of `M` with respect to the run-time type of the instance referenced by `E`.
     - Otherwise, `M` is a non-virtual function member, and the function member to invoke is `M` itself.
-  -   The function member implementation determined in the step above is invoked. The object referenced by `E` becomes the object referenced by this.
+  - The function member implementation determined in the step above is invoked. The object referenced by `E` becomes the object referenced by this.
 
 The result of the invocation of an instance constructor ([§11.7.15.2](expressions.md#117152-object-creation-expressions)) is the value created. The result of the invocation of any other function member is the value, if any, returned ([§12.10.5](statements.md#12105-the-return-statement)) from its body.
 
@@ -1268,7 +1268,7 @@ fragment Close_Brace_Escape_Sequence
 Six of the lexical rules defined above are *context sensitive* as follows:
 
 | **Rule** | **Contextual Requirements** |
-| :--- | :---------------------- |
+| :------- | :-------------------------- |
 | *Interpolated_Regular_String_Mid* | Only recognised after an *Interpolated_Regular_String_Start*, between any following interpolations, and before the corresponding *Interpolated_Regular_String_End*. |
 | *Regular_Interpolation_Format* | Only recognised within a *regular_interpolation* and when the starting colon (:) is not nested within any kind of bracket (parentheses/braces/square). |
 | *Interpolated_Regular_String_End* | Only recognised after an *Interpolated_Regular_String_Start* and only if any intervening tokens are either *Interpolated_Regular_String_Mid*s or tokens that can be part of *regular_interpolation*s, including tokens for any *interpolated_regular_string_expression*s contained within such interpolations. |
@@ -1456,7 +1456,7 @@ The *member_access* is evaluated and classified as follows:
   - If `I` identifies an instance event:
     - If the reference occurs within the class or struct in which the event is declared, and the event was declared without *event_accessor_declarations* ([§14.8.1](classes.md#1481-general)), and the reference does not occur as the left-hand side of `a +=` or `-=` operator, then `E.I` is processed exactly as if `I` was an instance field.
     - Otherwise, the result is an event access with an associated instance expression of `E`.
--   Otherwise, an attempt is made to process `E.I` as an extension method invocation ([§11.7.8.3](expressions.md#11783-extension-method-invocations)). If this fails, `E.I` is an invalid member reference, and a binding-time error occurs.
+- Otherwise, an attempt is made to process `E.I` as an extension method invocation ([§11.7.8.3](expressions.md#11783-extension-method-invocations)). If this fails, `E.I` is an invalid member reference, and a binding-time error occurs.
 
 #### 11.7.6.2 Identical simple names and type names
 
@@ -1548,8 +1548,8 @@ invocation_expression
 
 An *invocation_expression* is dynamically bound ([§11.3.3](expressions.md#1133-dynamic-binding)) if at least one of the following holds:
 
--   The *primary_expression* has compile-time type `dynamic`.
--   At least one argument of the optional *argument_list* has compile-time type `dynamic`.
+- The *primary_expression* has compile-time type `dynamic`.
+- At least one argument of the optional *argument_list* has compile-time type `dynamic`.
 
 In this case, the compiler classifies the *invocation_expression* as a value of type `dynamic`. The rules below to determine the meaning of the *invocation_expression* are then applied at run-time, using the run-time type instead of the compile-time type of those of the *primary_expression* and arguments that have the compile-time type `dynamic`. If the *primary_expression* does not have compile-time type `dynamic`, then the method invocation undergoes a limited compile-time check as described in [§11.6.5](expressions.md#1165-compile-time-checking-of-dynamic-member-invocation).
 
@@ -1559,8 +1559,8 @@ The optional *argument_list* ([§11.6.2](expressions.md#1162-argument-lists)) pr
 
 The result of evaluating an *invocation_expression* is classified as follows:
 
--   If the *invocation_expression* invokes a method or delegate that returns void, the result is nothing. An expression that is classified as nothing is permitted only in the context of a *statement_expression* ([§12.7](statements.md#127-expression-statements)) or as the body of a *lambda_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)). Otherwise a binding-time error occurs.
--   Otherwise, the result is a value, with an associated type of the return type of the method or delegate after any type argument substitutions ([§11.7.8.2](expressions.md#11782-method-invocations)) have been performed. If the invocation is of an instance method, and the receiver is of a class type `T`, the associated type is picked from the first declaration or override of the method found when starting with `T` and searching through its base classes.
+- If the *invocation_expression* invokes a method or delegate that returns void, the result is nothing. An expression that is classified as nothing is permitted only in the context of a *statement_expression* ([§12.7](statements.md#127-expression-statements)) or as the body of a *lambda_expression* ([§11.16](expressions.md#1116-anonymous-function-expressions)). Otherwise a binding-time error occurs.
+- Otherwise, the result is a value, with an associated type of the return type of the method or delegate after any type argument substitutions ([§11.7.8.2](expressions.md#11782-method-invocations)) have been performed. If the invocation is of an instance method, and the receiver is of a class type `T`, the associated type is picked from the first declaration or override of the method found when starting with `T` and searching through its base classes.
 
 #### 11.7.8.2 Method invocations
 
@@ -1614,10 +1614,10 @@ C . «identifier» < «typeargs» > ( «expr» , «args» )
 
 An extension method `Cᵢ.Mₑ` is ***eligible*** if:
 
--   `Cᵢ` is a non-generic, non-nested class
--   The name of `Mₑ` is *identifier*
--   `Mₑ` is accessible and applicable when applied to the arguments as a static method as shown above
--   An implicit identity, reference or boxing conversion exists from *expr* to the type of the first parameter of `Mₑ`.
+- `Cᵢ` is a non-generic, non-nested class
+- The name of `Mₑ` is *identifier*
+- `Mₑ` is accessible and applicable when applied to the arguments as a static method as shown above
+- An implicit identity, reference or boxing conversion exists from *expr* to the type of the first parameter of `Mₑ`.
 
 The search for `C` proceeds as follows:
 
@@ -1720,10 +1720,10 @@ For a delegate invocation, the *primary_expression* of the *invocation_expressio
 
 The run-time processing of a delegate invocation of the form `D(A)`, where `D` is a *primary_expression* of a *delegate_type* and `A` is an optional *argument_list*, consists of the following steps:
 
--   `D` is evaluated. If this evaluation causes an exception, no further steps are executed.
--   The argument list `A` is evaluated. If this evaluation causes an exception, no further steps are executed.
--   The value of `D` is checked to be valid. If the value of `D` is `null`, a `System.NullReferenceException` is thrown and no further steps are executed.
--   Otherwise, `D` is a reference to a delegate instance. Function member invocations ([§11.6.6](expressions.md#1166-function-member-invocation)) are performed on each of the callable entities in the invocation list of the delegate. For callable entities consisting of an instance and instance method, the instance for the invocation is the instance contained in the callable entity.
+- `D` is evaluated. If this evaluation causes an exception, no further steps are executed.
+- The argument list `A` is evaluated. If this evaluation causes an exception, no further steps are executed.
+- The value of `D` is checked to be valid. If the value of `D` is `null`, a `System.NullReferenceException` is thrown and no further steps are executed.
+- Otherwise, `D` is a reference to a delegate instance. Function member invocations ([§11.6.6](expressions.md#1166-function-member-invocation)) are performed on each of the callable entities in the invocation list of the delegate. For callable entities consisting of an instance and instance method, the instance for the invocation is the instance contained in the callable entity.
 
 See [§19.6](delegates.md#196-delegate-invocation) for details of multiple invocation lists without parameters.
 
@@ -1779,8 +1779,8 @@ The *argument_list* of an *element_access* is not allowed to contain `ref` or `o
 
 An *element_access* is dynamically bound ([§11.3.3](expressions.md#1133-dynamic-binding)) if at least one of the following holds:
 
--   The *primary_no_array_creation_expression* has compile-time type `dynamic`.
--   At least one expression of the *argument_list* has compile-time type `dynamic` and the *primary_no_array_creation_expression* does not have an array type.
+- The *primary_no_array_creation_expression* has compile-time type `dynamic`.
+- At least one expression of the *argument_list* has compile-time type `dynamic` and the *primary_no_array_creation_expression* does not have an array type.
 
 In this case, the compiler classifies the *element_access* as a value of type `dynamic`. The rules below to determine the meaning of the *element_access* are then applied at run-time, using the run-time type instead of the compile-time type of those of the *primary_no_array_creation_expression* and *argument_list* expressions which have the compile-time type `dynamic`. If the *primary_no_array_creation_expression* does not have compile-time type `dynamic`, then the element access undergoes a limited compile-time check as described in [§11.6.5](expressions.md#1165-compile-time-checking-of-dynamic-member-invocation).
 
@@ -1794,11 +1794,11 @@ The result of evaluating an array access is a variable of the element type of th
 
 The run-time processing of an array access of the form `P[A]`, where `P` is a *primary_no_array_creation_expression* of an *array_type* and `A` is an *argument_list*, consists of the following steps:
 
--   `P` is evaluated. If this evaluation causes an exception, no further steps are executed.
--   The index expressions of the *argument_list* are evaluated in order, from left to right. Following evaluation of each index expression, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) to one of the following types is performed: `int`, `uint`, `long`, `ulong`. The first type in this list for which an implicit conversion exists is chosen. For instance, if the index expression is of type `short` then an implicit conversion to `int` is performed, since implicit conversions from `short` to `int` and from `short` to `long` are possible. If evaluation of an index expression or the subsequent implicit conversion causes an exception, then no further index expressions are evaluated and no further steps are executed.
--   The value of `P` is checked to be valid. If the value of `P` is `null`, a `System.NullReferenceException` is thrown and no further steps are executed.
--   The value of each expression in the *argument_list* is checked against the actual bounds of each dimension of the array instance referenced by `P`. If one or more values are out of range, a `System.IndexOutOfRangeException` is thrown and no further steps are executed.
--   The location of the array element given by the index expression(s) is computed, and this location becomes the result of the array access.
+- `P` is evaluated. If this evaluation causes an exception, no further steps are executed.
+- The index expressions of the *argument_list* are evaluated in order, from left to right. Following evaluation of each index expression, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) to one of the following types is performed: `int`, `uint`, `long`, `ulong`. The first type in this list for which an implicit conversion exists is chosen. For instance, if the index expression is of type `short` then an implicit conversion to `int` is performed, since implicit conversions from `short` to `int` and from `short` to `long` are possible. If evaluation of an index expression or the subsequent implicit conversion causes an exception, then no further index expressions are evaluated and no further steps are executed.
+- The value of `P` is checked to be valid. If the value of `P` is `null`, a `System.NullReferenceException` is thrown and no further steps are executed.
+- The value of each expression in the *argument_list* is checked against the actual bounds of each dimension of the array instance referenced by `P`. If one or more values are out of range, a `System.IndexOutOfRangeException` is thrown and no further steps are executed.
+- The location of the array element given by the index expression(s) is computed, and this location becomes the result of the array access.
 
 #### 11.7.10.3 Indexer access
 
@@ -1940,9 +1940,9 @@ The `new` operator is used to create new instances of types.
 
 There are three forms of new expressions:
 
--   Object creation expressions and anonymous object creation expressions are used to create new instances of class types and value types.
--   Array creation expressions are used to create new instances of array types.
--   Delegate creation expressions are used to obtain instances of delegate types.
+- Object creation expressions and anonymous object creation expressions are used to create new instances of class types and value types.
+- Array creation expressions are used to create new instances of array types.
+- Delegate creation expressions are used to obtain instances of delegate types.
 
 The `new` operator implies creation of an instance of a type, but does not necessarily imply allocation of memory. In particular, instances of value types require no additional memory beyond the variables in which they reside, and no allocations occur when `new` is used to create instances of value types.
 
@@ -2233,11 +2233,11 @@ Array initializers are described further in [§16.7](arrays.md#167-array-initial
 
 The result of evaluating an array creation expression is classified as a value, namely a reference to the newly allocated array instance. The run-time processing of an array creation expression consists of the following steps:
 
--   The dimension length expressions of the *expression_list* are evaluated in order, from left to right. Following evaluation of each expression, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) to one of the following types is performed: `int`, `uint`, `long`, `ulong`. The first type in this list for which an implicit conversion exists is chosen. If evaluation of an expression or the subsequent implicit conversion causes an exception, then no further expressions are evaluated and no further steps are executed.
--   The computed values for the dimension lengths are validated, as follows: If one or more of the values are less than zero, a `System.OverflowException` is thrown and no further steps are executed.
--   An array instance with the given dimension lengths is allocated. If there is not enough memory available to allocate the new instance, a `System.OutOfMemoryException` is thrown and no further steps are executed.
--   All elements of the new array instance are initialized to their default values ([§9.3](variables.md#93-default-values)).
--   If the array creation expression contains an array initializer, then each expression in the array initializer is evaluated and assigned to its corresponding array element. The evaluations and assignments are performed in the order the expressions are written in the array initializer—in other words, elements are initialized in increasing index order, with the rightmost dimension increasing first. If evaluation of a given expression or the subsequent assignment to the corresponding array element causes an exception, then no further elements are initialized (and the remaining elements will thus have their default values).
+- The dimension length expressions of the *expression_list* are evaluated in order, from left to right. Following evaluation of each expression, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) to one of the following types is performed: `int`, `uint`, `long`, `ulong`. The first type in this list for which an implicit conversion exists is chosen. If evaluation of an expression or the subsequent implicit conversion causes an exception, then no further expressions are evaluated and no further steps are executed.
+- The computed values for the dimension lengths are validated, as follows: If one or more of the values are less than zero, a `System.OverflowException` is thrown and no further steps are executed.
+- An array instance with the given dimension lengths is allocated. If there is not enough memory available to allocate the new instance, a `System.OutOfMemoryException` is thrown and no further steps are executed.
+- All elements of the new array instance are initialized to their default values ([§9.3](variables.md#93-default-values)).
+- If the array creation expression contains an array initializer, then each expression in the array initializer is evaluated and assigned to its corresponding array element. The evaluations and assignments are performed in the order the expressions are written in the array initializer—in other words, elements are initialized in increasing index order, with the rightmost dimension increasing first. If evaluation of a given expression or the subsequent assignment to the corresponding array element causes an exception, then no further elements are initialized (and the remaining elements will thus have their default values).
 
 An array creation expression permits instantiation of an array with elements of an array type, but the elements of such an array shall be manually initialized.
 
@@ -2314,10 +2314,10 @@ If the *expression* has the compile-time type `dynamic`, the *delegate_creation_
 
 The binding-time processing of a *delegate_creation_expression* of the form new `D(E)`, where `D` is a *delegate_type* and `E` is an *expression*, consists of the following steps:
 
--   If `E` is a method group, the delegate creation expression is processed in the same way as a method group conversion ([§10.8](conversions.md#108-method-group-conversions)) from `E` to `D`.
+- If `E` is a method group, the delegate creation expression is processed in the same way as a method group conversion ([§10.8](conversions.md#108-method-group-conversions)) from `E` to `D`.
 
--   If `E` is an anonymous function, the delegate creation expression is processed in the same way as an anonymous function conversion ([§10.7](conversions.md#107-anonymous-function-conversions)) from `E` to `D`.
--   If `E` is a value, `E` shall be compatible ([§19.2](delegates.md#192-delegate-declarations)) with `D`, and the result is a reference to a newly created delegate with a single-entry invocation list that invokes  `E`.
+- If `E` is an anonymous function, the delegate creation expression is processed in the same way as an anonymous function conversion ([§10.7](conversions.md#107-anonymous-function-conversions)) from `E` to `D`.
+- If `E` is a value, `E` shall be compatible ([§19.2](delegates.md#192-delegate-declarations)) with `D`, and the result is a reference to a newly created delegate with a single-entry invocation list that invokes  `E`.
 
 The run-time processing of a *delegate_creation_expression* of the form new `D(E)`, where `D` is a *delegate_type* and `E` is an *expression*, consists of the following steps:
 
@@ -2468,9 +2468,9 @@ The second form of *typeof_expression* consists of a `typeof` keyword followed b
 
 When the operand of a *typeof_expression* is a sequence of tokens that satisfies the grammars of both *unbound_type_name* and *type_name*, namely when it contains neither a *generic_dimension_specifier* nor a *type_argument_list*, the sequence of tokens is considered to be a *type_name*. The meaning of an *unbound_type_name* is determined as follows:
 
--   Convert the sequence of tokens to a *type_name* by replacing each *generic_dimension_specifier* with a *type_argument_list* having the same number of commas and the keyword `object` as each *type_argument*.
--   Evaluate the resulting *type_name*, while ignoring all type parameter constraints.
--   The *unbound_type_name* resolves to the unbound generic type associated with the resulting constructed type ([§8.4](types.md#84-constructed-types)).
+- Convert the sequence of tokens to a *type_name* by replacing each *generic_dimension_specifier* with a *type_argument_list* having the same number of commas and the keyword `object` as each *type_argument*.
+- Evaluate the resulting *type_name*, while ignoring all type parameter constraints.
+- The *unbound_type_name* resolves to the unbound generic type associated with the resulting constructed type ([§8.4](types.md#84-constructed-types)).
 
 The result of the *typeof_expression* is the `System.Type` object for the resulting unbound generic type.
 
@@ -2579,15 +2579,15 @@ The overflow checking context can also be controlled through the `checked` and `
 
 The following operations are affected by the overflow checking context established by the checked and unchecked operators and statements:
 
--   The predefined `++` and `--` operators ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators) and [§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators)), when the operand is of an integral or enum type.
--   The predefined `-` unary operator ([§11.8.3](expressions.md#1183-unary-minus-operator)), when the operand is of an integral type.
--   The predefined `+`, `-`, `\`, and `/` binary operators ([§11.9](expressions.md#119-arithmetic-operators)), when both operands are of integral or enum types.
--   Explicit numeric conversions ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)) from one integral or enumtype to another integral or enum type, or from `float` or `double` to an integral or enum type.
+- The predefined `++` and `--` operators ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators) and [§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators)), when the operand is of an integral or enum type.
+- The predefined `-` unary operator ([§11.8.3](expressions.md#1183-unary-minus-operator)), when the operand is of an integral type.
+- The predefined `+`, `-`, `\`, and `/` binary operators ([§11.9](expressions.md#119-arithmetic-operators)), when both operands are of integral or enum types.
+- Explicit numeric conversions ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)) from one integral or enumtype to another integral or enum type, or from `float` or `double` to an integral or enum type.
 
 When one of the above operations produces a result that is too large to represent in the destination type, the context in which the operation is performed controls the resulting behavior:
 
--   In a `checked` context, if the operation is a constant expression ([§11.20](expressions.md#1120-constant-expressions)), a compile-time error occurs. Otherwise, when the operation is performed at run-time, a `System.OverflowException` is thrown.
--   In an `unchecked` context, the result is truncated by discarding any high-order bits that do not fit in the destination type.
+- In a `checked` context, if the operation is a constant expression ([§11.20](expressions.md#1120-constant-expressions)), a compile-time error occurs. Otherwise, when the operation is performed at run-time, a `System.OverflowException` is thrown.
+- In an `unchecked` context, the result is truncated by discarding any high-order bits that do not fit in the destination type.
 
 For non-constant expressions ([§11.20](expressions.md#1120-constant-expressions)) (expressions that are evaluated at run-time) that are not enclosed by any `checked` or `unchecked` operators or statements, the default overflow checking context is unchecked, unless external factors (such as compiler switches and execution environment configuration) call for checked evaluation.
 
@@ -2921,8 +2921,8 @@ The grammar for a *cast_expression* leads to certain syntactic ambiguities.
 
 To resolve *cast_expression* ambiguities, the following rule exists: A sequence of one or more tokens ([§6.4](lexical-structure.md#64-tokens)) enclosed in parentheses is considered the start of a *cast_expression* only if at least one of the following are true:
 
--   The sequence of tokens is correct grammar for a type, but not for an expression.
--   The sequence of tokens is correct grammar for a type, and the token immediately following the closing parentheses is the token “`~`”, the token “`!`”, the token “`(`”, an identifier ([§6.4.3](lexical-structure.md#643-identifiers)), a literal ([§6.4.5](lexical-structure.md#645-literals)), or any keyword ([§6.4.4](lexical-structure.md#644-keywords)) except `as` and `is`.
+- The sequence of tokens is correct grammar for a type, but not for an expression.
+- The sequence of tokens is correct grammar for a type, and the token immediately following the closing parentheses is the token “`~`”, the token “`!`”, the token “`(`”, an identifier ([§6.4.3](lexical-structure.md#643-identifiers)), a literal ([§6.4.5](lexical-structure.md#645-literals)), or any keyword ([§6.4.4](lexical-structure.md#644-keywords)) except `as` and `is`.
 
 The term “correct grammar” above means only that the sequence of tokens shall conform to the particular grammatical production. It specifically does not consider the actual meaning of any constituent identifiers.
 
@@ -2946,10 +2946,10 @@ await_expression
 
 An *await_expression* is only allowed in the body of an async function ([§14.15](classes.md#1415-async-functions)). Within the nearest enclosing async function, an *await_expression* shall not occur in these places:
 
--   Inside a nested (non-async) anonymous function
--   Inside the block of a *lock_statement*
--   In an anonymous function conversion to an expression tree type ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types))
--   In an unsafe context
+- Inside a nested (non-async) anonymous function
+- Inside the block of a *lock_statement*
+- In an anonymous function conversion to an expression tree type ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types))
+- In an unsafe context
 
 > *Note*: An *await_expression* cannot occur in most places within a *query_expression*, because those are syntactically transformed to use non-async lambda expressions. *end note*
 
@@ -3977,9 +3977,9 @@ Unless one of these conditions is true, a binding-time error occurs.
 
 > *Note*: Notable implications of these rules are:
 >
-> -   It is a binding-time error to use the predefined reference type equality operators to compare two references that are known to be different at binding-time. For example, if the binding-time types of the operands are two class types, and if neither derives from the other, then it would be impossible for the two operands to reference the same object. Thus, the operation is considered a binding-time error.
-> -   The predefined reference type equality operators do not permit value type operands to be compared (except when type parameters are compared to `null`, which is handled specially).
-> -   Operands of predefined reference type equality operators are never boxed. It would be meaningless to perform such boxing operations, since references to the newly allocated boxed instances would necessarily differ from all other references.
+> - It is a binding-time error to use the predefined reference type equality operators to compare two references that are known to be different at binding-time. For example, if the binding-time types of the operands are two class types, and if neither derives from the other, then it would be impossible for the two operands to reference the same object. Thus, the operation is considered a binding-time error.
+> - The predefined reference type equality operators do not permit value type operands to be compared (except when type parameters are compared to `null`, which is handled specially).
+> - Operands of predefined reference type equality operators are never boxed. It would be meaningless to perform such boxing operations, since references to the newly allocated boxed instances would necessarily differ from all other references.
 >
 > For an operation of the form `x == y` or `x != y`, if any applicable user-defined `operator ==` or `operator !=` exists, the operator overload resolution rules ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) will select that operator instead of the predefined reference type equality operator. It is always possible to select the predefined reference type equality operator by explicitly casting one or both of the operands to type `object`. *end note*
 <!-- markdownlint-disable MD028 -->
@@ -4057,8 +4057,8 @@ bool operator !=(string x, string y);
 
 Two `string` values are considered equal when one of the following is true:
 
--   Both values are `null`.
--   Both values are non-`null` references to string instances that have identical lengths and identical characters in each character position.
+- Both values are `null`.
+- Both values are non-`null` references to string instances that have identical lengths and identical characters in each character position.
 
 The string equality operators compare string values rather than string references. When two separate string instances contain the exact same sequence of characters, the values of the strings are equal, but the references are different.
 
@@ -4075,15 +4075,15 @@ bool operator !=(System.Delegate x, System.Delegate y);
 
 Two delegate instances are considered equal as follows:
 
--   If either of the delegate instances is `null`, they are equal if and only if both are `null`.
--   If the delegates have different run-time type, they are never equal.
--   If both of the delegate instances have an invocation list ([§19.2](delegates.md#192-delegate-declarations)), those instances are equal if and only if their invocation lists are the same length, and each entry in one’s invocation list is equal (as defined below) to the corresponding entry, in order, in the other’s invocation list.
+- If either of the delegate instances is `null`, they are equal if and only if both are `null`.
+- If the delegates have different run-time type, they are never equal.
+- If both of the delegate instances have an invocation list ([§19.2](delegates.md#192-delegate-declarations)), those instances are equal if and only if their invocation lists are the same length, and each entry in one’s invocation list is equal (as defined below) to the corresponding entry, in order, in the other’s invocation list.
 
 The following rules govern the equality of invocation list entries:
 
--   If two invocation list entries both refer to the same static method then the entries are equal.
--   If two invocation list entries both refer to the same non-static method on the same target object (as defined by the reference equality operators) then the entries are equal.
--   Invocation list entries produced from evaluation of semantically identical anonymous functions ([§11.16](expressions.md#1116-anonymous-function-expressions)) with the same (possibly empty) set of captured outer variable instances are permitted (but not required) to be equal.
+- If two invocation list entries both refer to the same static method then the entries are equal.
+- If two invocation list entries both refer to the same non-static method on the same target object (as defined by the reference equality operators) then the entries are equal.
+- Invocation list entries produced from evaluation of semantically identical anonymous functions ([§11.16](expressions.md#1116-anonymous-function-expressions)) with the same (possibly empty) set of captured outer variable instances are permitted (but not required) to be equal.
 
 If operator overload resolution resolves to either delegate equality operator, and the binding-time types of both operands are delegate types as described in [§19](delegates.md#19-delegates) rather than `System.Delegate`, and there is no identity conversion between the binding-type operand types, a binding-time error occurs.
 
@@ -4144,9 +4144,9 @@ The `as` operator is used to explicitly convert a value to a given reference typ
 
 In an operation of the form `E as T`, `E` shall be an expression and `T` shall be a reference type, a type parameter known to be a reference type, or a nullable value type. Furthermore, at least one of the following shall be true, or otherwise a compile-time error occurs:
 
--   An identity ([§10.2.2](conversions.md#1022-identity-conversion)), implicit nullable ([§10.2.6](conversions.md#1026-implicit-nullable-conversions)), implicit reference ([§10.2.8](conversions.md#1028-implicit-reference-conversions)), boxing ([§10.2.9](conversions.md#1029-boxing-conversions)), explicit nullable ([§10.3.4](conversions.md#1034-explicit-nullable-conversions)), explicit reference ([§10.3.5](conversions.md#1035-explicit-reference-conversions)), or wrapping ([§8.3.11](types.md#8311-nullable-value-types)) conversion exists from `E` to `T`.
--   The type of `E` or `T` is an open type.
--   `E` is the `null` literal.
+- An identity ([§10.2.2](conversions.md#1022-identity-conversion)), implicit nullable ([§10.2.6](conversions.md#1026-implicit-nullable-conversions)), implicit reference ([§10.2.8](conversions.md#1028-implicit-reference-conversions)), boxing ([§10.2.9](conversions.md#1029-boxing-conversions)), explicit nullable ([§10.3.4](conversions.md#1034-explicit-nullable-conversions)), explicit reference ([§10.3.5](conversions.md#1035-explicit-reference-conversions)), or wrapping ([§8.3.11](types.md#8311-nullable-value-types)) conversion exists from `E` to `T`.
+- The type of `E` or `T` is an open type.
+- `E` is the `null` literal.
 
 If the compile-time type of `E` is not `dynamic`, the operation `E` as `T` produces the same result as
 
@@ -4318,8 +4318,8 @@ conditional_or_expression
 
 The `&&` and `||` operators are conditional versions of the `&` and `|` operators:
 
--   The operation `x && y` corresponds to the operation `x & y`, except that `y` is evaluated only if `x` is not `false`.
--   The operation `x || y` corresponds to the operation `x | y`, except that `y` is evaluated only if `x` is not `true`.
+- The operation `x && y` corresponds to the operation `x & y`, except that `y` is evaluated only if `x` is not `false`.
+- The operation `x || y` corresponds to the operation `x | y`, except that `y` is evaluated only if `x` is not `true`.
 
 > *Note*: The reason that short circuiting uses the ‘not true’ and ‘not false’ conditions is to enable user-defined conditional operators to define when short circuiting applies. User-defined types could be in a state where `operator true` returns `false` and `operator false` returns `false`. In those cases, neither `&&` nor `||` would short circuit. *end note*
 
@@ -4327,9 +4327,9 @@ If an operand of a conditional logical operator has the compile-time type `dynam
 
 An operation of the form `x && y` or `x || y` is processed by applying overload resolution ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) as if the operation was written `x & y` or `x | y`. Then,
 
--   If overload resolution fails to find a single best operator, or if overload resolution selects one of the predefined integer logical operators or nullable Boolean logical operators ([§11.12.5](expressions.md#11125-nullable-boolean--and--operators)), a binding-time error occurs.
--   Otherwise, if the selected operator is one of the predefined Boolean logical operators ([§11.12.4](expressions.md#11124-boolean-logical-operators)), the operation is processed as described in [§11.13.2](expressions.md#11132-boolean-conditional-logical-operators).
--   Otherwise, the selected operator is a user-defined operator, and the operation is processed as described in [§11.13.3](expressions.md#11133-user-defined-conditional-logical-operators).
+- If overload resolution fails to find a single best operator, or if overload resolution selects one of the predefined integer logical operators or nullable Boolean logical operators ([§11.12.5](expressions.md#11125-nullable-boolean--and--operators)), a binding-time error occurs.
+- Otherwise, if the selected operator is one of the predefined Boolean logical operators ([§11.12.4](expressions.md#11124-boolean-logical-operators)), the operation is processed as described in [§11.13.2](expressions.md#11132-boolean-conditional-logical-operators).
+- Otherwise, the selected operator is a user-defined operator, and the operation is processed as described in [§11.13.3](expressions.md#11133-user-defined-conditional-logical-operators).
 
 It is not possible to directly overload the conditional logical operators. However, because the conditional logical operators are evaluated in terms of the regular logical operators, overloads of the regular logical operators are, with certain restrictions, also considered overloads of the conditional logical operators. This is described further in [§11.13.3](expressions.md#11133-user-defined-conditional-logical-operators).
 
@@ -4337,20 +4337,20 @@ It is not possible to directly overload the conditional logical operators. Howev
 
 When the operands of `&&` or `||` are of type `bool`, or when the operands are of types that do not define an applicable `operator &` or `operator |`, but do define implicit conversions to `bool`, the operation is processed as follows:
 
--   The operation `x && y` is evaluated as `x ? y : false`. In other words, `x` is first evaluated and converted to type `bool`. Then, if `x` is `true`, `y` is evaluated and converted to type `bool`, and this becomes the result of the operation. Otherwise, the result of the operation is `false`.
--   The operation `x || y` is evaluated as `x ? true : y`. In other words, `x` is first evaluated and converted to type `bool`. Then, if `x` is `true`, the result of the operation is `true`. Otherwise, `y` is evaluated and converted to type `bool`, and this becomes the result of the operation.
+- The operation `x && y` is evaluated as `x ? y : false`. In other words, `x` is first evaluated and converted to type `bool`. Then, if `x` is `true`, `y` is evaluated and converted to type `bool`, and this becomes the result of the operation. Otherwise, the result of the operation is `false`.
+- The operation `x || y` is evaluated as `x ? true : y`. In other words, `x` is first evaluated and converted to type `bool`. Then, if `x` is `true`, the result of the operation is `true`. Otherwise, `y` is evaluated and converted to type `bool`, and this becomes the result of the operation.
 
 ### 11.13.3 User-defined conditional logical operators
 
 When the operands of `&&` or `||` are of types that declare an applicable user-defined `operator &` or `operator |`, both of the following shall be true, where `T` is the type in which the selected operator is declared:
 
--   The return type and the type of each parameter of the selected operator shall be `T`. In other words, the operator shall compute the logical AND or the logical OR of two operands of type `T`, and shall return a result of type `T`.
--   `T` shall contain declarations of `operator true` and `operator false`.
+- The return type and the type of each parameter of the selected operator shall be `T`. In other words, the operator shall compute the logical AND or the logical OR of two operands of type `T`, and shall return a result of type `T`.
+- `T` shall contain declarations of `operator true` and `operator false`.
 
 A binding-time error occurs if either of these requirements is not satisfied. Otherwise, the `&&` or `||` operation is evaluated by combining the user-defined `operator true` or `operator false` with the selected user-defined operator:
 
--   The operation `x && y` is evaluated as `T.false(x) ? x : T.&(x, y)`, where `T.false(x)` is an invocation of the `operator false` declared in `T`, and `T.&(x, y)` is an invocation of the selected `operator &`. In other words, `x` is first evaluated and `operator false` is invoked on the result to determine if `x` is definitely false. Then, if `x` is definitely false, the result of the operation is the value previously computed for `x`. Otherwise, `y` is evaluated, and the selected `operator &` is invoked on the value previously computed for `x` and the value computed for `y` to produce the result of the operation.
--   The operation `x || y` is evaluated as `T.true(x) ? x : T.|(x, y)`, where `T.true(x)` is an invocation of the `operator true` declared in `T`, and `T.|(x, y)` is an invocation of the selected `operator |`. In other words, `x` is first evaluated and `operator true` is invoked on the result to determine if `x` is definitely true. Then, if `x` is definitely true, the result of the operation is the value previously computed for `x`. Otherwise, `y` is evaluated, and the selected `operator |` is invoked on the value previously computed for `x` and the value computed for `y` to produce the result of the operation.
+- The operation `x && y` is evaluated as `T.false(x) ? x : T.&(x, y)`, where `T.false(x)` is an invocation of the `operator false` declared in `T`, and `T.&(x, y)` is an invocation of the selected `operator &`. In other words, `x` is first evaluated and `operator false` is invoked on the result to determine if `x` is definitely false. Then, if `x` is definitely false, the result of the operation is the value previously computed for `x`. Otherwise, `y` is evaluated, and the selected `operator &` is invoked on the value previously computed for `x` and the value computed for `y` to produce the result of the operation.
+- The operation `x || y` is evaluated as `T.true(x) ? x : T.|(x, y)`, where `T.true(x)` is an invocation of the `operator true` declared in `T`, and `T.|(x, y)` is an invocation of the selected `operator |`. In other words, `x` is first evaluated and `operator true` is invoked on the result to determine if `x` is definitely true. Then, if `x` is definitely true, the result of the operation is the value previously computed for `x`. Otherwise, `y` is evaluated, and the selected `operator |` is invoked on the value previously computed for `x` and the value computed for `y` to produce the result of the operation.
 
 In either of these operations, the expression given by `x` is only evaluated once, and the expression given by `y` is either not evaluated or evaluated exactly once.
 
@@ -4373,12 +4373,12 @@ The null coalescing operator is right-associative, meaning that operations are g
 
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
--   If `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
--   Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
--   Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
--   Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, a is first evaluated. If a is not null, a becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.
--   Otherwise, if `A` exists and is a nullable value type, `b` has a type `B` and an implicit conversion exists from `A₀` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀` and converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
--   Otherwise, if `b` has a type `B` and an implicit conversion exists from `a` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
+- If `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
+- Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
+- Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
+- Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, a is first evaluated. If a is not null, a becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.
+- Otherwise, if `A` exists and is a nullable value type, `b` has a type `B` and an implicit conversion exists from `A₀` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀` and converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
+- Otherwise, if `b` has a type `B` and an implicit conversion exists from `a` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
 
 Otherwise, `a` and `b` are incompatible, and `a` compile-time error occurs.
 
@@ -4522,10 +4522,10 @@ A *block* body of an anonymous function is always reachable ([§12.2](statements
 
 The behavior of *lambda_expression*s and *anonymous_method_expression*s is the same except for the following points:
 
--   *anonymous_method_expression*s permit the parameter list to be omitted entirely, yielding convertibility to delegate types of any list of value parameters.
--   *lambda_expression*s permit parameter types to be omitted and inferred whereas *anonymous_method_expression*s require parameter types to be explicitly stated.
--   The body of a *lambda_expression* can be an expression or a statement block whereas the body of an *anonymous_method_expression* shall be a statement block.
--   Only *lambda_expression*s have conversions to compatible expression tree types ([§8.6](types.md#86-expression-tree-types)).
+- *anonymous_method_expression*s permit the parameter list to be omitted entirely, yielding convertibility to delegate types of any list of value parameters.
+- *lambda_expression*s permit parameter types to be omitted and inferred whereas *anonymous_method_expression*s require parameter types to be explicitly stated.
+- The body of a *lambda_expression* can be an expression or a statement block whereas the body of an *anonymous_method_expression* shall be a statement block.
+- Only *lambda_expression*s have conversions to compatible expression tree types ([§8.6](types.md#86-expression-tree-types)).
 
 ### 11.16.2 Anonymous function signatures
 
@@ -4541,12 +4541,12 @@ Note also that conversion to an expression tree type, even if compatible, may st
 
 The body (*expression* or *block*) of an anonymous function is subject to the following rules:
 
--   If the anonymous function includes a signature, the parameters specified in the signature are available in the body. If the anonymous function has no signature it can be converted to a delegate type or expression type having parameters ([§10.7](conversions.md#107-anonymous-function-conversions)), but the parameters cannot be accessed in the body.
--   Except for `ref` or `out` parameters specified in the signature (if any) of the nearest enclosing anonymous function, it is a compile-time error for the body to access a `ref` or `out` parameter.
--   When the type of `this` is a struct type, it is a compile-time error for the body to access `this`. This is true whether the access is explicit (as in `this.x`) or implicit (as in `x` where `x` is an instance member of the struct). This rule simply prohibits such access and does not affect whether member lookup results in a member of the struct.
--   The body has access to the outer variables ([§11.16.6](expressions.md#11166-outer-variables)) of the anonymous function. Access of an outer variable will reference the instance of the variable that is active at the time the *lambda_expression* or *anonymous_method_expression* is evaluated ([§11.16.7](expressions.md#11167-evaluation-of-anonymous-function-expressions)).
--   It is a compile-time error for the body to contain a `goto` statement, a `break` statement, or a `continue` statement whose target is outside the body or within the body of a contained anonymous function.
--   A `return` statement in the body returns control from an invocation of the nearest enclosing anonymous function, not from the enclosing function member.
+- If the anonymous function includes a signature, the parameters specified in the signature are available in the body. If the anonymous function has no signature it can be converted to a delegate type or expression type having parameters ([§10.7](conversions.md#107-anonymous-function-conversions)), but the parameters cannot be accessed in the body.
+- Except for `ref` or `out` parameters specified in the signature (if any) of the nearest enclosing anonymous function, it is a compile-time error for the body to access a `ref` or `out` parameter.
+- When the type of `this` is a struct type, it is a compile-time error for the body to access `this`. This is true whether the access is explicit (as in `this.x`) or implicit (as in `x` where `x` is an instance member of the struct). This rule simply prohibits such access and does not affect whether member lookup results in a member of the struct.
+- The body has access to the outer variables ([§11.16.6](expressions.md#11166-outer-variables)) of the anonymous function. Access of an outer variable will reference the instance of the variable that is active at the time the *lambda_expression* or *anonymous_method_expression* is evaluated ([§11.16.7](expressions.md#11167-evaluation-of-anonymous-function-expressions)).
+- It is a compile-time error for the body to contain a `goto` statement, a `break` statement, or a `continue` statement whose target is outside the body or within the body of a contained anonymous function.
+- A `return` statement in the body returns control from an invocation of the nearest enclosing anonymous function, not from the enclosing function member.
 
 It is explicitly unspecified whether there is any way to execute the block of an anonymous function other than through evaluation and invocation of the *lambda_expression* or *anonymous_method_expression*. In particular, the compiler may choose to implement an anonymous function by synthesizing one or more named methods or types. The names of any such synthesized elements shall be of a form reserved for compiler use ([§6.4.3](lexical-structure.md#643-identifiers)).
 
@@ -5547,9 +5547,9 @@ Certain translations inject range variables with ***transparent identifiers*** d
 
 When a query translation injects a transparent identifier, further translation steps propagate the transparent identifier into anonymous functions and anonymous object initializers. In those contexts, transparent identifiers have the following behavior:
 
--   When a transparent identifier occurs as a parameter in an anonymous function, the members of the associated anonymous type are automatically in scope in the body of the anonymous function.
--   When a member with a transparent identifier is in scope, the members of that member are in scope as well.
--   When a transparent identifier occurs as a member declarator in an anonymous object initializer, it introduces a member with a transparent identifier.
+- When a transparent identifier occurs as a parameter in an anonymous function, the members of the associated anonymous type are automatically in scope in the body of the anonymous function.
+- When a member with a transparent identifier is in scope, the members of that member are in scope as well.
+- When a transparent identifier occurs as a member declarator in an anonymous object initializer, it introduces a member with a transparent identifier.
 
 In the translation steps described above, transparent identifiers are always introduced together with anonymous types, with the intent of capturing multiple range variables as members of a single object. An implementation of C# is permitted to use a different mechanism than anonymous types to group together multiple range variables. The following translation examples assume that anonymous types are used, and shows one possible translation of transparent identifiers.
 
@@ -5821,9 +5821,9 @@ If the left operand of a compound assignment is of the form `E.P` or `E[Ei]` whe
 
 An operation of the form `x «op»= y` is processed by applying binary operator overload resolution ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) as if the operation was written `x «op» y`. Then,
 
--   If the return type of the selected operator is implicitly convertible to the type of `x`, the operation is evaluated as `x = x «op» y`, except that `x` is evaluated only once.
--   Otherwise, if the selected operator is a predefined operator, if the return type of the selected operator is explicitly convertible to the type of `x` , and if `y` is implicitly convertible to the type of `x`  or the operator is a shift operator, then the operation is evaluated as `x = (T)(x «op» y)`, where `T` is the type of `x`, except that `x` is evaluated only once.
--   Otherwise, the compound assignment is invalid, and a binding-time error occurs.
+- If the return type of the selected operator is implicitly convertible to the type of `x`, the operation is evaluated as `x = x «op» y`, except that `x` is evaluated only once.
+- Otherwise, if the selected operator is a predefined operator, if the return type of the selected operator is explicitly convertible to the type of `x` , and if `y` is implicitly convertible to the type of `x`  or the operator is a shift operator, then the operation is evaluated as `x = (T)(x «op» y)`, where `T` is the type of `x`, except that `x` is evaluated only once.
+- Otherwise, the compound assignment is invalid, and a binding-time error occurs.
 
 The term “evaluated only once” means that in the evaluation of `x «op» y`, the results of any constituent expressions of `x` are temporarily saved and then reused when performing the assignment to `x`.
 
@@ -5857,9 +5857,9 @@ The intuitive effect of the rule for predefined operators is simply that `x «op
 
 If the left operand of `a += or -=` operator is classified as an event access, then the expression is evaluated as follows:
 
--   The instance expression, if any, of the event access is evaluated.
--   The right operand of the `+=` or `-=` operator is evaluated, and, if required, converted to the type of the left operand through an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)).
--   An event accessor of the event is invoked, with an argument list consisting of the value computed in the previous step. If the operator was `+=`, the add accessor is invoked; if the operator was `-=`, the remove accessor is invoked.
+- The instance expression, if any, of the event access is evaluated.
+- The right operand of the `+=` or `-=` operator is evaluated, and, if required, converted to the type of the left operand through an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)).
+- An event accessor of the event is invoked, with an argument list consisting of the value computed in the previous step. If the operator was `+=`, the add accessor is invoked; if the operator was `-=`, the remove accessor is invoked.
 
 An event assignment expression does not yield a value. Thus, an event assignment expression is valid only in the context of a *statement_expression* ([§12.7](statements.md#127-expression-statements)).
 
@@ -5894,27 +5894,27 @@ A constant expression may be either a value type or a reference type. If a const
 
 Only the following constructs are permitted in constant expressions:
 
--   Literals (including the `null` literal).
--   References to `const` members of class and struct types.
--   References to members of enumeration types.
--   References to `const` parameters or local variables
--   Parenthesized subexpressions, which are themselves constant expressions.
--   Cast expressions.
--   `checked` and `unchecked` expressions.
--   `nameof` expressions
--   The predefined `+`, `–`, `!`, and `~` unary operators.
--   The predefined `+`, `–`, `*`, `/`, `%`, `<<`, `>>`, `&`, `|`, `^`, `&&`, `||`, `==`, `!=`, `<`, `>`, `<=`, and `>=` binary operators.
--   The `?:` conditional operator.
--   `sizeof` expressions, provided the unmanaged-type is one of the types specified in [§22.6.9](unsafe-code.md#2269-the-sizeof-operator) for which `sizeof` returns a constant value.
--   Default value expressions, provided the type is one of the types listed above.
+- Literals (including the `null` literal).
+- References to `const` members of class and struct types.
+- References to members of enumeration types.
+- References to `const` parameters or local variables
+- Parenthesized subexpressions, which are themselves constant expressions.
+- Cast expressions.
+- `checked` and `unchecked` expressions.
+- `nameof` expressions
+- The predefined `+`, `–`, `!`, and `~` unary operators.
+- The predefined `+`, `–`, `*`, `/`, `%`, `<<`, `>>`, `&`, `|`, `^`, `&&`, `||`, `==`, `!=`, `<`, `>`, `<=`, and `>=` binary operators.
+- The `?:` conditional operator.
+- `sizeof` expressions, provided the unmanaged-type is one of the types specified in [§22.6.9](unsafe-code.md#2269-the-sizeof-operator) for which `sizeof` returns a constant value.
+- Default value expressions, provided the type is one of the types listed above.
 
 The following conversions are permitted in constant expressions:
 
--   Identity conversions
--   Numeric conversions
--   Enumeration conversions
--   Constant expression conversions
--   Implicit and explicit reference conversions, provided the source of the conversions is a constant expression that evaluates to the `null` value.
+- Identity conversions
+- Numeric conversions
+- Enumeration conversions
+- Constant expression conversions
+- Implicit and explicit reference conversions, provided the source of the conversions is a constant expression that evaluates to the `null` value.
 
 > *Note*: Other conversions including boxing, unboxing, and implicit reference conversions of non-`null` values are not permitted in constant expressions. *end note*
 <!-- markdownlint-disable MD028 -->
@@ -5938,13 +5938,13 @@ Unless a constant expression is explicitly placed in an `unchecked` context, ove
 
 Constant expressions are required in the contexts listed below and this is indicated in the grammar by using *constant_expression*. In these contexts, a compile-time error occurs if an expression cannot be fully evaluated at compile-time.
 
--   Constant declarations ([§14.4](classes.md#144-constants))
--   Enumeration member declarations ([§18.4](enums.md#184-enum-members))
--   Default arguments of formal parameter lists ([§14.6.2](classes.md#1462-method-parameters))
--   `case` labels of a `switch` statement ([§12.8.3](statements.md#1283-the-switch-statement)).
--   `goto case` statements ([§12.10.4](statements.md#12104-the-goto-statement))
--   Dimension lengths in an array creation expression ([§11.7.15.5](expressions.md#117155-array-creation-expressions)) that includes an initializer.
--   Attributes ([§21](attributes.md#21-attributes))
+- Constant declarations ([§14.4](classes.md#144-constants))
+- Enumeration member declarations ([§18.4](enums.md#184-enum-members))
+- Default arguments of formal parameter lists ([§14.6.2](classes.md#1462-method-parameters))
+- `case` labels of a `switch` statement ([§12.8.3](statements.md#1283-the-switch-statement)).
+- `goto case` statements ([§12.10.4](statements.md#12104-the-goto-statement))
+- Dimension lengths in an array creation expression ([§11.7.15.5](expressions.md#117155-array-creation-expressions)) that includes an initializer.
+- Attributes ([§21](attributes.md#21-attributes))
 
 An implicit constant expression conversion ([§10.2.11](conversions.md#10211-implicit-constant-expression-conversions)) permits a constant expression of type `int` to be converted to `sbyte`, `byte`, `short`, `ushort`, `uint`, or `ulong`, provided the value of the constant expression is within the range of the destination type.
 
@@ -5962,6 +5962,6 @@ The controlling conditional expression of an *if_statement* ([§12.8.2](statemen
 
 A *boolean_expression* `E` is required to be able to produce a value of type `bool`, as follows:
 
--   If E is implicitly convertible to `bool` then at run-time that implicit conversion is applied.
--   Otherwise, unary operator overload resolution ([§11.4.4](expressions.md#1144-unary-operator-overload-resolution)) is used to find a unique best implementation of `operator true` on `E`, and that implementation is applied at run-time.
--   If no such operator is found, a binding-time error occurs.
+- If E is implicitly convertible to `bool` then at run-time that implicit conversion is applied.
+- Otherwise, unary operator overload resolution ([§11.4.4](expressions.md#1144-unary-operator-overload-resolution)) is used to find a unique best implementation of `operator true` on `E`, and that implementation is applied at run-time.
+- If no such operator is found, a binding-time error occurs.

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -592,9 +592,7 @@ It is a compile-time error for an explicit interface method implementation to in
 > Explicit interface member implementations serve two primary purposes:
 >
 > - Because explicit interface member implementations are not accessible through class or struct instances, they allow interface implementations to be excluded from the public interface of a class or struct. This is particularly useful when a class or struct implements an internal interface that is of no interest to a consumer of that class or struct.
-> - Explicit interface member implementations allow disambiguation of interface members with the same signature. Without explicit interface member implementations it would be impossible for a class or struct to have different implementations of interface members with the same signature and return type, as would it be impossible for a class or struct to have any implementation at all of interface members with the same signature but with different return types.
->
-> *end note*
+> - Explicit interface member implementations allow disambiguation of interface members with the same signature. Without explicit interface member implementations it would be impossible for a class or struct to have different implementations of interface members with the same signature and return type, as would it be impossible for a class or struct to have any implementation at all of interface members with the same signature but with different return types. *end note*
 
 For an explicit interface member implementation to be valid, the class or struct shall name an interface in its base class list that contains a member whose qualified interface member name, type, number of type parameters, and parameter types exactly match those of the explicit interface member implementation. If an interface function member has a parameter array, the corresponding parameter of an associated explicit interface member implementation is allowed, but not required, to have the `params` modifier. If the interface function member does not have a parameter array then an associated explicit interface member implementation shall not have a parameter array.
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -715,8 +715,8 @@ A Unicode escape sequence ([§6.4.2](lexical-structure.md#642-unicode-character-
 
 A simple escape sequence represents a Unicode character, as described in the table below.
 
-| __Escape sequence__ | __Character name__ | __Unicode code point__ |
-|---------------------|--------------------|----------------------|
+| **Escape sequence** | **Character name** | **Unicode code point** |
+|---------------------|--------------------|--------------------|
 | `\'`                | Single quote       | U+0027             |
 | `\"`                | Double quote       | U+0022             |
 | `\\`                | Backslash          | U+005C             |

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -6,9 +6,9 @@ A C# ***program*** consists of one or more source files, known formally as ***c
 
 Conceptually speaking, a program is compiled using three steps:
 
-1.  Transformation, which converts a file from a particular character repertoire and encoding scheme into a sequence of Unicode characters.
-1.  Lexical analysis, which translates a stream of Unicode input characters into a stream of tokens.
-1.  Syntactic analysis, which translates the stream of tokens into executable code.
+1. Transformation, which converts a file from a particular character repertoire and encoding scheme into a sequence of Unicode characters.
+1. Lexical analysis, which translates a stream of Unicode input characters into a stream of tokens.
+1. Syntactic analysis, which translates the stream of tokens into executable code.
 
 Conforming implementations shall accept Unicode compilation units encoded with the UTF-8 encoding form (as defined by the Unicode standard), and transform them into a sequence of Unicode characters. Implementations can choose to accept and transform additional character encoding schemes (such as UTF-16, UTF-32, or non-Unicode character mappings).
 
@@ -161,8 +161,8 @@ New_Line
 
 For compatibility with source code editing tools that add end-of-file markers, and to enable a compilation unit to be viewed as a sequence of properly terminated lines, the following transformations are applied, in order, to every compilation unit in a C# program:
 
--   If the last character of the compilation unit is a Control-Z character (U+001A), this character is deleted.
--   A carriage-return character (U+000D) is added to the end of the compilation unit if that compilation unit is non-empty and if the last character of the compilation unit is not a carriage return (U+000D), a line feed (U+000A), a next line character (U+0085), a line separator (U+2028), or a paragraph separator (U+2029).
+- If the last character of the compilation unit is a Control-Z character (U+001A), this character is deleted.
+- A carriage-return character (U+000D) is added to the end of the compilation unit if that compilation unit is non-empty and if the last character of the compilation unit is not a carriage return (U+000D), a line feed (U+000A), a next line character (U+0085), a line separator (U+2028), or a paragraph separator (U+2029).
 
 > *Note*: The additional carriage-return allows a program to end in a *PP_Directive* ([§6.5](lexical-structure.md#65-pre-processing-directives)) that does not have a terminating *New_Line*. *end note*
 
@@ -486,9 +486,9 @@ The prefix “`@`” enables the use of keywords as identifiers, which is usefu
 
 Two identifiers are considered the same if they are identical after the following transformations are applied, in order:
 
--   The prefix “`@`”, if used, is removed.
--   Each *Unicode_Escape_Sequence* is transformed into its corresponding Unicode character.
--   Any *Formatting_Character*s are removed.
+- The prefix “`@`”, if used, is removed.
+- Each *Unicode_Escape_Sequence* is transformed into its corresponding Unicode character.
+- Any *Formatting_Character*s are removed.
 
 Identifiers containing two consecutive underscore characters (`U+005F`) are reserved for use by the implementation; however, no diagnostic is required if such an identifier is defined.
 
@@ -611,10 +611,10 @@ fragment Hex_Digit
 
 The type of an integer literal is determined as follows:
 
--   If the literal has no suffix, it has the first of these types in which its value can be represented: `int`, `uint`, `long`, `ulong`.
--   If the literal is suffixed by `U` or `u`, it has the first of these types in which its value can be represented: `uint`, `ulong`.
--   If the literal is suffixed by `L` or `l`, it has the first of these types in which its value can be represented: `long`, `ulong`.
--   If the literal is suffixed by `UL`, `Ul`, `uL`, `ul`, `LU`, `Lu`, `lU`, or `lu`, it is of type `ulong`.
+- If the literal has no suffix, it has the first of these types in which its value can be represented: `int`, `uint`, `long`, `ulong`.
+- If the literal is suffixed by `U` or `u`, it has the first of these types in which its value can be represented: `uint`, `ulong`.
+- If the literal is suffixed by `L` or `l`, it has the first of these types in which its value can be represented: `long`, `ulong`.
+- If the literal is suffixed by `UL`, `Ul`, `uL`, `ul`, `LU`, `Lu`, `lU`, or `lu`, it is of type `ulong`.
 
 If the value represented by an integer literal is outside the range of the `ulong` type, a compile-time error occurs.
 
@@ -622,8 +622,8 @@ If the value represented by an integer literal is outside the range of the `ulon
 
 To permit the smallest possible `int` and `long` values to be written as integer literals, the following two rules exist:
 
--   When an *Integer_Literal* representing the value `2147483648` (2³¹) and no *Integer_Type_Suffix* appears as the token immediately following a unary minus operator token ([§11.8.3](expressions.md#1183-unary-minus-operator)), the result (of both tokens) is a constant of type int with the value `−2147483648` (−2³¹). In all other situations, such an *Integer_Literal* is of type `uint`.
--   When an *Integer_Literal* representing the value `9223372036854775808` (2⁶³) and no *Integer_Type_Suffix* or the *Integer_Type_Suffix* `L` or `l` appears as the token immediately following a unary minus operator token ([§11.8.3](expressions.md#1183-unary-minus-operator)), the result (of both tokens) is a constant of type `long` with the value `−9223372036854775808` (−2⁶³). In all other situations, such an *Integer_Literal* is of type `ulong`.
+- When an *Integer_Literal* representing the value `2147483648` (2³¹) and no *Integer_Type_Suffix* appears as the token immediately following a unary minus operator token ([§11.8.3](expressions.md#1183-unary-minus-operator)), the result (of both tokens) is a constant of type int with the value `−2147483648` (−2³¹). In all other situations, such an *Integer_Literal* is of type `uint`.
+- When an *Integer_Literal* representing the value `9223372036854775808` (2⁶³) and no *Integer_Type_Suffix* or the *Integer_Type_Suffix* `L` or `l` appears as the token immediately following a unary minus operator token ([§11.8.3](expressions.md#1183-unary-minus-operator)), the result (of both tokens) is a constant of type `long` with the value `−9223372036854775808` (−2⁶³). In all other situations, such an *Integer_Literal* is of type `ulong`.
 
 #### 6.4.5.4 Real literals
 
@@ -916,12 +916,12 @@ fragment PP_New_Line
 
 The following pre-processing directives are available:
 
--   `#define` and `#undef`, which are used to define and undefine, respectively, conditional compilation symbols ([§6.5.4](lexical-structure.md#654-definition-directives)).
--   `#if`, `#elif`, `#else`, and `#endif`, which are used to skip conditionally sections of source code ([§6.5.5](lexical-structure.md#655-conditional-compilation-directives)).
--   `#line`, which is used to control line numbers emitted for errors and warnings ([§6.5.8](lexical-structure.md#658-line-directives)).
--   `#error`, which is used to issue errors ([§6.5.6](lexical-structure.md#656-diagnostic-directives)).
--   `#region` and `#endregion`, which are used to explicitly mark sections of source code ([§6.5.7](lexical-structure.md#657-region-directives)).
--   `#pragma`, which is used to specify optional contextual information to a compiler ([§6.5.9](lexical-structure.md#659-pragma-directives)).
+- `#define` and `#undef`, which are used to define and undefine, respectively, conditional compilation symbols ([§6.5.4](lexical-structure.md#654-definition-directives)).
+- `#if`, `#elif`, `#else`, and `#endif`, which are used to skip conditionally sections of source code ([§6.5.5](lexical-structure.md#655-conditional-compilation-directives)).
+- `#line`, which is used to control line numbers emitted for errors and warnings ([§6.5.8](lexical-structure.md#658-line-directives)).
+- `#error`, which is used to issue errors ([§6.5.6](lexical-structure.md#656-diagnostic-directives)).
+- `#region` and `#endregion`, which are used to explicitly mark sections of source code ([§6.5.7](lexical-structure.md#657-region-directives)).
+- `#pragma`, which is used to specify optional contextual information to a compiler ([§6.5.9](lexical-structure.md#659-pragma-directives)).
 
 A pre-processing directive always occupies a separate line of source code and always begins with a `#` character and a pre-processing directive name. White space may occur before the `#` character and between the `#` character and the directive name.
 
@@ -971,8 +971,8 @@ fragment PP_Conditional_Symbol
 
 Two conditional compilation symbols are considered the same if they are identical after the following transformations are applied, in order:
 
--   Each *Unicode_Escape_Sequence* is transformed into its corresponding Unicode character.
--   Any *Formatting_Characters* are removed.
+- Each *Unicode_Escape_Sequence* is transformed into its corresponding Unicode character.
+- Any *Formatting_Characters* are removed.
 
 A conditional compilation symbol has two possible states: ***defined*** or ***undefined***. At the beginning of the lexical processing of a compilation unit, a conditional compilation symbol is undefined unless it has been explicitly defined by an external mechanism (such as a command-line compiler option). When a `#define` directive is processed, the conditional compilation symbol named in that directive becomes defined in that compilation unit. The symbol remains defined until a `#undef` directive for that same symbol is processed, or until the end of the compilation unit is reached. An implication of this is that `#define` and `#undef` directives in one compilation unit have no effect on other compilation units in the same program.
 
@@ -1136,9 +1136,9 @@ Conditional compilation directives shall be written in groups consisting of, in 
 
 At most one of the contained conditional sections is selected for normal lexical processing:
 
--   The *PP_Expression*s of the `#if` and `#elif` directives are evaluated in order until one yields `true`. If an expression yields `true`, the conditional section following  the corresponding directive is selected.
--   If all *PP_Expression*s yield `false`, and if a `#else` directive is present, the conditional section following the `#else` directive is selected.
--   Otherwise, no conditional section is selected.
+- The *PP_Expression*s of the `#if` and `#elif` directives are evaluated in order until one yields `true`. If an expression yields `true`, the conditional section following  the corresponding directive is selected.
+- If all *PP_Expression*s yield `false`, and if a `#else` directive is present, the conditional section following the `#else` directive is selected.
+- Otherwise, no conditional section is selected.
 
 The selected conditional section, if any, is processed as a normal *input_section*: the source code contained in the section shall adhere to the lexical grammar; tokens are generated from the source code in the section; and pre-processing directives in the section have the prescribed effects.
 
@@ -1323,9 +1323,9 @@ A `#line hidden` directive has no effect on the compilation unit and line number
 The `#pragma` preprocessing directive is used to specify contextual information to a compiler.
 
 > *Note*: For example, a compiler might provide `#pragma` directives that
-> -   Enable or disable particular warning messages when compiling subsequent code.
-> -   Specify which optimizations to apply to subsequent code.
-> -   Specify information to be used by a debugger.
+> - Enable or disable particular warning messages when compiling subsequent code.
+> - Specify which optimizations to apply to subsequent code.
+> - Specify information to be used by a debugger.
 *end note*
 
 ```ANTLR

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -312,7 +312,7 @@ fragment Unicode_Escape_Sequence
     ;
 ```
 
-A Unicode character escape sequence represents the single Unicode code point formed by the hexadecimal number following the “\u” or “\U” characters. Since C# uses a 16-bit encoding of Unicode code points in character and string values, a Unicode code point in the range `U+10000` to `U+10FFFF` is represented using two Unicode surrogate code units. Unicode code points above `U+FFFF` are not permitted in character literals. Unicode code points above` U+10FFFF` are invalid and are not supported.
+A Unicode character escape sequence represents the single Unicode code point formed by the hexadecimal number following the “\u” or “\U” characters. Since C# uses a 16-bit encoding of Unicode code points in character and string values, a Unicode code point in the range `U+10000` to `U+10FFFF` is represented using two Unicode surrogate code units. Unicode code points above `U+FFFF` are not permitted in character literals. Unicode code points above `U+10FFFF` are invalid and are not supported.
 
 Multiple translations are not performed. For instance, the string literal `"\u005Cu005C"` is equivalent to `"\u005C"` rather than `"\"`.
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -441,9 +441,7 @@ fragment Formatting_Character
 >   - ANTLR considers these implicit rules before the explicit lexical rules in the grammar.
 >   - Therefore fragment *Available_Identifier* will not match keywords or contextual keywords as the lexical rules for those precede it.
 > - Fragment *Escaped_Identifier* includes escaped keywords and contextual keywords as they are part of the longer token starting with an `@` and lexical processing always forms the longest possible lexical element ([§6.3.1](lexical-structure.md#631-general)).
-> - How an implementation enforces the restrictions on the allowable *Unicode_Escape_Sequence* values is an implementation issue.
->
-> *end note*
+> - How an implementation enforces the restrictions on the allowable *Unicode_Escape_Sequence* values is an implementation issue. *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -910,9 +908,9 @@ fragment PP_New_Line
 ```
 
 > *Note*:
+>
 > - The pre-processor grammar defines a single lexical token `PP_Directive` used for all pre-processing directives. The semantics of each of the pre-processing directives are defined in this language specification but not how to implement them.
-> - The `PP_Start` fragment must only be recognised at the start of a line, the `getCharPositionInLine() == 0` ANTLR lexical predicate above suggests one way in which this may be achieved and is informative *only*, an implementation may use a different strategy.
-> *end note*
+> - The `PP_Start` fragment must only be recognised at the start of a line, the `getCharPositionInLine() == 0` ANTLR lexical predicate above suggests one way in which this may be achieved and is informative *only*, an implementation may use a different strategy. *end note*
 
 The following pre-processing directives are available:
 
@@ -1323,10 +1321,10 @@ A `#line hidden` directive has no effect on the compilation unit and line number
 The `#pragma` preprocessing directive is used to specify contextual information to a compiler.
 
 > *Note*: For example, a compiler might provide `#pragma` directives that
+>
 > - Enable or disable particular warning messages when compiling subsequent code.
 > - Specify which optimizations to apply to subsequent code.
-> - Specify information to be used by a debugger.
-*end note*
+> - Specify information to be used by a debugger. *end note*
 
 ```ANTLR
 fragment PP_Pragma

--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -665,9 +665,9 @@ A type declared within a class or struct is called a nested type ([§14.3.9](cla
 
 The permitted access modifiers and the default access for a type declaration depend on the context in which the declaration takes place ([§7.5.2](basic-concepts.md#752-declared-accessibility)):
 
--   Types declared in compilation units or namespaces can have `public` or `internal` access. The default is `internal` access.
--   Types declared in classes can have `public`, `protected internal`, `protected`, `internal`, or `private` access. The default is `private` access.
--   Types declared in structs can have `public`, `internal`, or `private` access. The default is `private` access.
+- Types declared in compilation units or namespaces can have `public` or `internal` access. The default is `internal` access.
+- Types declared in classes can have `public`, `protected internal`, `protected`, `internal`, or `private` access. The default is `private` access.
+- Types declared in structs can have `public`, `internal`, or `private` access. The default is `private` access.
 
 ## 13.8 Qualified alias member
 
@@ -689,8 +689,8 @@ A *qualified_alias_member* consists of two identifiers, referred to as the left-
 
 A *qualified_alias_member* has one of two forms:
 
--   `N::I<A₁, ..., Aₑ>`, where `N` and `I` represent identifiers, and `<A₁, ..., Aₑ>` is a type argument list. (`e` is always at least one.)
--   `N::I`, where `N` and `I` represent identifiers. (In this case, `e` is considered to be zero.)
+- `N::I<A₁, ..., Aₑ>`, where `N` and `I` represent identifiers, and `<A₁, ..., Aₑ>` is a type argument list. (`e` is always at least one.)
+- `N::I`, where `N` and `I` represent identifiers. (In this case, `e` is considered to be zero.)
 
 Using this notation, the meaning of a *qualified_alias_member* is determined as follows:
 

--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -10,54 +10,54 @@ This annex collects some information about portability that appears in this spec
 
 The behavior is undefined in the following circumstances:
 
-1.  The behavior of the enclosing async function when an awaiter’s implementation of the interface methods `INotifyCompletion.OnCompleted` and `ICriticalNotifyCompletion.UnsafeOnCompleted` does not cause the resumption delegate to be invoked at most once ([§11.8.8.4](expressions.md#11884-run-time-evaluation-of-await-expressions)).
-1.  Passing pointers as `ref` or `out` parameters ([§22.3](unsafe-code.md#223-pointer-types)).
-1.  When dereferencing the result of converting one pointer type to another and the resulting pointer is not correctly aligned for the pointed-to type. ([§22.5.1](unsafe-code.md#2251-general)).
-1.  When the unary `*` operator is applied to a pointer containing an invalid value ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
-1.  When a pointer is subscripted to access an out-of-bounds element ([§22.6.4](unsafe-code.md#2264-pointer-element-access)).
-1.  Modifying objects of managed type through fixed pointers ([§22.7](unsafe-code.md#227-the-fixed-statement)).
-1.  The content of memory newly allocated by `stackalloc` ([§22.9](unsafe-code.md#229-stack-allocation)).
-1.  Attempting to allocate a negative number of items using `stackalloc`([§22.9](unsafe-code.md#229-stack-allocation)).
+1. The behavior of the enclosing async function when an awaiter’s implementation of the interface methods `INotifyCompletion.OnCompleted` and `ICriticalNotifyCompletion.UnsafeOnCompleted` does not cause the resumption delegate to be invoked at most once ([§11.8.8.4](expressions.md#11884-run-time-evaluation-of-await-expressions)).
+1. Passing pointers as `ref` or `out` parameters ([§22.3](unsafe-code.md#223-pointer-types)).
+1. When dereferencing the result of converting one pointer type to another and the resulting pointer is not correctly aligned for the pointed-to type. ([§22.5.1](unsafe-code.md#2251-general)).
+1. When the unary `*` operator is applied to a pointer containing an invalid value ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
+1. When a pointer is subscripted to access an out-of-bounds element ([§22.6.4](unsafe-code.md#2264-pointer-element-access)).
+1. Modifying objects of managed type through fixed pointers ([§22.7](unsafe-code.md#227-the-fixed-statement)).
+1. The content of memory newly allocated by `stackalloc` ([§22.9](unsafe-code.md#229-stack-allocation)).
+1. Attempting to allocate a negative number of items using `stackalloc`([§22.9](unsafe-code.md#229-stack-allocation)).
 
 ## B.3 Implementation-defined behavior
 
 A conforming implementation is required to document its choice of behavior in each of the areas listed in this subclause. The following are implementation-defined:
 
-1.  The behavior when an identifier not in Normalization Form C is encountered ([§6.4.3](lexical-structure.md#643-identifiers)).
-1.  The interpretation of the *input_characters* in the *pp_pragma-text* of a #pragma directive ([§6.5.9](lexical-structure.md#659-pragma-directives)).
-1.  The values of any application parameters passed to `Main` by the host environment prior to application startup ([§7.1](basic-concepts.md#71-application-startup)).
-1.  The precise structure of the expression tree, as well as the exact process for creating it, when an anonymous function is converted to an expression-tree ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
-1.  Whether a `System.ArithmeticException` (or a subclass thereof) is thrown or the overflow goes unreported with the resulting value being that of the left operand, when in an `unchecked` context and the left operand of an integer division is the maximum negative `int` or `long` value and the right operand is `–1` ([§11.9.3](expressions.md#1193-division-operator)).
-1.  When a `System.ArithmeticException` (or a subclass thereof) is thrown when performing a decimal remainder operation ([§11.9.4](expressions.md#1194-remainder-operator)).
-1.  The impact of thread termination when a thread has no handler for an exception, and the thread is itself terminated ([§12.10.6](statements.md#12106-the-throw-statement)).
-1.  The impact of thread termination when no matching `catch` clause is found for an exception and the code that initially started that thread is reached. ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
-1.  The mappings between pointers and integers ([§22.5.1](unsafe-code.md#2251-general)).
-1.  The effect of applying the unary `*` operator to a `null` pointer ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
-1.  The behavior when pointer arithmetic overflows the domain of the pointer type ([§22.6.6](unsafe-code.md#2266-pointer-increment-and-decrement), [§22.6.7](unsafe-code.md#2267-pointer-arithmetic)).
-1.  The result of the `sizeof` operator for non-pre-defined value types ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
-1.  The behavior of the `fixed` statement if the array expression is `null` or if the array has zero elements ([§22.7](unsafe-code.md#227-the-fixed-statement)).
-1.  The behavior of the `fixed` statement if the string expression is `null` ([§22.7](unsafe-code.md#227-the-fixed-statement)).
-1.  The value returned when a stack allocation of size zero is made ([§22.9](unsafe-code.md#229-stack-allocation)).
+1. The behavior when an identifier not in Normalization Form C is encountered ([§6.4.3](lexical-structure.md#643-identifiers)).
+1. The interpretation of the *input_characters* in the *pp_pragma-text* of a #pragma directive ([§6.5.9](lexical-structure.md#659-pragma-directives)).
+1. The values of any application parameters passed to `Main` by the host environment prior to application startup ([§7.1](basic-concepts.md#71-application-startup)).
+1. The precise structure of the expression tree, as well as the exact process for creating it, when an anonymous function is converted to an expression-tree ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
+1. Whether a `System.ArithmeticException` (or a subclass thereof) is thrown or the overflow goes unreported with the resulting value being that of the left operand, when in an `unchecked` context and the left operand of an integer division is the maximum negative `int` or `long` value and the right operand is `–1` ([§11.9.3](expressions.md#1193-division-operator)).
+1. When a `System.ArithmeticException` (or a subclass thereof) is thrown when performing a decimal remainder operation ([§11.9.4](expressions.md#1194-remainder-operator)).
+1. The impact of thread termination when a thread has no handler for an exception, and the thread is itself terminated ([§12.10.6](statements.md#12106-the-throw-statement)).
+1. The impact of thread termination when no matching `catch` clause is found for an exception and the code that initially started that thread is reached. ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
+1. The mappings between pointers and integers ([§22.5.1](unsafe-code.md#2251-general)).
+1. The effect of applying the unary `*` operator to a `null` pointer ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
+1. The behavior when pointer arithmetic overflows the domain of the pointer type ([§22.6.6](unsafe-code.md#2266-pointer-increment-and-decrement), [§22.6.7](unsafe-code.md#2267-pointer-arithmetic)).
+1. The result of the `sizeof` operator for non-pre-defined value types ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
+1. The behavior of the `fixed` statement if the array expression is `null` or if the array has zero elements ([§22.7](unsafe-code.md#227-the-fixed-statement)).
+1. The behavior of the `fixed` statement if the string expression is `null` ([§22.7](unsafe-code.md#227-the-fixed-statement)).
+1. The value returned when a stack allocation of size zero is made ([§22.9](unsafe-code.md#229-stack-allocation)).
 
 ## B.4 Unspecified behavior
 
-1.  The time at which the finalizer (if any) for an object is run, once that object has become eligible for finalization ([§7.9](basic-concepts.md#79-automatic-memory-management)).
-1.  The value of the result when converting out-of-range values from `float` or `double` values to an integral type in an `unchecked` context ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)).
-1.  The exact target object and target method of the delegate produced from an *anonymous_method_expression* contains ([§10.7.2](conversions.md#1072-evaluation-of-anonymous-function-conversions-to-delegate-types)).
-1.  The layout of arrays, except in an unsafe context ([§11.7.15.5](expressions.md#117155-array-creation-expressions)).
-1.  Whether there is any way to execute the *block* of an anonymous function other than through evaluation and invocation of the *lambda_expression* or *anonymous_method-expression* ([§11.16.3](expressions.md#11163-anonymous-function-bodies)).
-1.  The exact timing of static field initialization ([§14.5.6.2](classes.md#14562-static-field-initialization)).
-1.  The result of invoking `MoveNext` when an enumerator object is running ([§14.14.5.2](classes.md#141452-the-movenext-method)).
-1.  The result of accessing `Current` when an enumerator object is in the before, running, or after states ([§14.14.5.3](classes.md#141453-the-current-property)).
-1.  The result of invoking `Dispose` when an enumerator object is in the running state ([§14.14.5.4](classes.md#141454-the-dispose-method)).
-1.  The attributes of a type declared in multiple parts are determined by combining, in an unspecified order, the attributes of each of its parts ([§21.3](attributes.md#213-attribute-specification)).
-1.  The order in which members are packed into a struct ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
-1.  An exception occurs during finalizer execution, and that execution is not caught ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
-1.  If more than one member matches, which member is the implementation of I.M. ([§17.6.5](interfaces.md#1765-interface-mapping))
+1. The time at which the finalizer (if any) for an object is run, once that object has become eligible for finalization ([§7.9](basic-concepts.md#79-automatic-memory-management)).
+1. The value of the result when converting out-of-range values from `float` or `double` values to an integral type in an `unchecked` context ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)).
+1. The exact target object and target method of the delegate produced from an *anonymous_method_expression* contains ([§10.7.2](conversions.md#1072-evaluation-of-anonymous-function-conversions-to-delegate-types)).
+1. The layout of arrays, except in an unsafe context ([§11.7.15.5](expressions.md#117155-array-creation-expressions)).
+1. Whether there is any way to execute the *block* of an anonymous function other than through evaluation and invocation of the *lambda_expression* or *anonymous_method-expression* ([§11.16.3](expressions.md#11163-anonymous-function-bodies)).
+1. The exact timing of static field initialization ([§14.5.6.2](classes.md#14562-static-field-initialization)).
+1. The result of invoking `MoveNext` when an enumerator object is running ([§14.14.5.2](classes.md#141452-the-movenext-method)).
+1. The result of accessing `Current` when an enumerator object is in the before, running, or after states ([§14.14.5.3](classes.md#141453-the-current-property)).
+1. The result of invoking `Dispose` when an enumerator object is in the running state ([§14.14.5.4](classes.md#141454-the-dispose-method)).
+1. The attributes of a type declared in multiple parts are determined by combining, in an unspecified order, the attributes of each of its parts ([§21.3](attributes.md#213-attribute-specification)).
+1. The order in which members are packed into a struct ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
+1. An exception occurs during finalizer execution, and that execution is not caught ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
+1. If more than one member matches, which member is the implementation of I.M. ([§17.6.5](interfaces.md#1765-interface-mapping))
 
 ## B.5 Other Issues
 
-1.  The exact results of floating-point expression evaluation can vary from one implementation to another, because an implementation is permitted to evaluate such expressions using a greater range and/or precision than is required. ([§8.3.7](types.md#837-floating-point-types))
-1.  The CLI reserves certain signatures for compatibility with other programming languages. ([§14.3.9.7](classes.md#14397-nested-types-in-generic-classes))
+1. The exact results of floating-point expression evaluation can vary from one implementation to another, because an implementation is permitted to evaluate such expressions using a greater range and/or precision than is required. ([§8.3.7](types.md#837-floating-point-types))
+1. The CLI reserves certain signatures for compatibility with other programming languages. ([§14.3.9.7](classes.md#14397-nested-types-in-generic-classes))
 
 **End of informative text.**

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -101,11 +101,11 @@ The *block* of a function member or an anonymous function is always considered r
 > }
 > ```
 > the reachability of the second `Console.WriteLine` is determined as follows:
+>
 > - The first `Console.WriteLine` expression statement is reachable because the block of the `F` method is reachable ([§12.3](statements.md#123-blocks)).
 > - The end point of the first `Console.WriteLine` expression statement is reachable because that statement is reachable ([§12.7](statements.md#127-expression-statements) and [§12.3](statements.md#123-blocks)).
 > - The `if` statement is reachable because the end point of the first `Console.WriteLine` expression statement is reachable ([§12.7](statements.md#127-expression-statements) and [§12.3](statements.md#123-blocks)).
-> - The second `Console.WriteLine` expression statement is reachable because the Boolean expression of the `if` statement does not have the constant value `false`.
-> *end example*
+> - The second `Console.WriteLine` expression statement is reachable because the Boolean expression of the `if` statement does not have the constant value `false`. *end example*
 
 There are two situations in which it is a compile-time error for the end point of a statement to be reachable:
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -1612,4 +1612,4 @@ A `yield break` statement is executed as follows:
 - If the `yield break` statement is enclosed by one or more `try` blocks with associated `finally` blocks, control is initially transferred to the `finally` block of the innermost `try` statement. When and if control reaches the end point of a `finally` block, control is transferred to the `finally` block of the next enclosing `try` statement. This process is repeated until the `finally` blocks of all enclosing `try` statements have been executed.
 - Control is returned to the caller of the iterator block. This is either the `MoveNext` method or `Dispose` method of the enumerator object.
 
-Because a `yield break statement unconditionally transfers control elsewhere, the end point of a `yield break` statement is never reachable.
+Because a `yield break` statement unconditionally transfers control elsewhere, the end point of a `yield break` statement is never reachable.

--- a/standard/types.md
+++ b/standard/types.md
@@ -280,9 +280,7 @@ Because a simple type aliases a struct type, every simple type has members.
 > - Most simple types permit values to be created by writing *literals* ([§6.4.5](lexical-structure.md#645-literals)), although C# makes no provision for literals of struct types in general. *Example*: `123` is a literal of type `int` and `'a'` is a literal of type `char`. *end example*
 > - When the operands of an expression are all simple type constants, it is possible for the compiler to evaluate the expression at compile-time. Such an expression is known as a *constant_expression* ([§11.20](expressions.md#1120-constant-expressions)). Expressions involving operators defined by other struct types are not considered to be constant expressions.
 > - Through `const` declarations, it is possible to declare constants of the simple types ([§14.4](classes.md#144-constants)). It is not possible to have constants of other struct types, but a similar effect is provided by static readonly fields.
-> - Conversions involving simple types can participate in evaluation of conversion operators defined by other struct types, but a user-defined conversion operator can never participate in evaluation of another user-defined conversion operator ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)).
->
-> *end note*.
+> - Conversions involving simple types can participate in evaluation of conversion operators defined by other struct types, but a user-defined conversion operator can never participate in evaluation of another user-defined conversion operator ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)). *end note*.
 
 ### 8.3.6 Integral types
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -160,14 +160,14 @@ The default value of a variable depends on the type of the variable and is deter
 At a given location in the executable code of a function member or an anonymous function, a variable is said to be ***definitely assigned*** if the compiler can prove, by a particular static flow analysis ([§9.4.4](variables.md#944-precise-rules-for-determining-definite-assignment)), that the variable has been automatically initialized or has been the target of at least one assignment.
 
 > *Note*: Informally stated, the rules of definite assignment are:
+>
 > - An initially assigned variable ([§9.4.2](variables.md#942-initially-assigned-variables)) is always considered definitely assigned.
 > - An initially unassigned variable ([§9.4.3](variables.md#943-initially-unassigned-variables)) is considered definitely assigned at a given location if all possible execution paths leading to that location contain at least one of the following:
 >   - A simple assignment ([§11.18.2](expressions.md#11182-simple-assignment)) in which the variable is the left operand.
 >   - An invocation expression ([§11.7.8](expressions.md#1178-invocation-expressions)) or object creation expression ([§11.7.15.2](expressions.md#117152-object-creation-expressions) that passes the variable as an output parameter.
 >   - For a local variable, a local variable declaration for the variable ([§12.6.2](statements.md#1262-local-variable-declarations)) that includes a variable initializer.
 >
-> The formal specification underlying the above informal rules is described in [§9.4.2](variables.md#942-initially-assigned-variables), [§9.4.3](variables.md#943-initially-unassigned-variables), and [§9.4.4](variables.md#944-precise-rules-for-determining-definite-assignment).
-> *end note*
+> The formal specification underlying the above informal rules is described in [§9.4.2](variables.md#942-initially-assigned-variables), [§9.4.3](variables.md#943-initially-unassigned-variables), and [§9.4.4](variables.md#944-precise-rules-for-determining-definite-assignment). *end note*
 
 The definite assignment states of instance variables of a *struct_type* variable are tracked individually as well as collectively. In additional to the rules above, the following rules apply to *struct_type* variables and their instance variables:
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -622,7 +622,7 @@ For an expression *expr* of the form:
   - If the state of *v* after *expr_first* is definitely assigned, then the state of *v* after *expr* is definitely assigned.
   - Otherwise, if the state of *v* after *expr_second* is definitely assigned, and the state of *v* after *expr_first* is “definitely assigned after true expression”, then the state of *v* after *expr* is definitely assigned.
   - Otherwise, if the state of *v* after *expr_second* is definitely assigned or “definitely assigned after false expression”, then the state of *v* after *expr* is “definitely assigned after false expression”.
-  -  Otherwise, if the state of *v* after *expr_first* is “definitely assigned after true expression”, and the state of *v* after *expr_ second* is “definitely assigned after true expression”, then the state of *v* after *expr* is “definitely assigned after true expression”.
+  - Otherwise, if the state of *v* after *expr_first* is “definitely assigned after true expression”, and the state of *v* after *expr_ second* is “definitely assigned after true expression”, then the state of *v* after *expr* is “definitely assigned after true expression”.
   - Otherwise, the state of *v* after *expr* is not definitely assigned.
 
 > *Example*: In the following code


### PR DESCRIPTION
- [MD030](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md030---spaces-after-list-markers): Spaces after list markers (there should be 1).
- [MD032](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md032---lists-should-be-surrounded-by-blank-lines) - lists should be surrounded by blank lines.
  - Most of these are notes and examples. In most cases, the trailing *end note* was on a separate line not separated by a blank line. In many, they were at the end of the last bullet item. I normalized all to be on the last bullet item.
- [MO037](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md037---spaces-inside-emphasis-markers) spaces inside emphasis markers.
- [MD038](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md038---spaces-inside-code-span-elements): extra spaces in code span elements.
- [MD040](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md040---fenced-code-blocks-should-have-a-language-specified) Code fences should have a language specified.
  - The only occurrences are in the tools/GetGrammar folder. These files are added by the tool, and insert the closing codefence. They are false positives. So, disable checking in that folder. We'll catch any mistakes there by linting the tool output on the automated PRs.
- [MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md041---first-line-in-a-file-should-be-a-top-level-heading) First line in a file should be a top level heading. No occurrences in the standard. Only in our admin tools and tools include files.
- [MD047](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md047---files-should-end-with-a-single-newline-character): Files should end with a newline character. I suspect these are also either in the tools folder, or fixed in previous edits.
- [MD050](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md050---strong-style-should-be-consistent): strong style should be consistent.

I moved [MD036](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md036---emphasis-used-instead-of-a-heading) (Using emphasis instead of heading) to the section of warnings we globally disable. The only instances were single paragraphs that were intentionally bold or italic, but not meant to be headings.  (For example, in the documentation comments clause on the example, or some "*end example*" text that appears as its own paragraph.)

Note that I skipped MD031 in this PR. It should be a single PR due to the *very* large number of occurrences.

Notes for reviewers: 

It will be easiest to review using a combination of hide whitespace, and going commit by commit.

1. The commit that fixes MD030 is *all* whitespace changes. 
1. The commit that fixes MD032 adds blank lines above lists, and often combines the *end note* with the last bullet item.
1. The commit that fixes MD037 is all removing whitespace.
1. The commit that fixes MD038 moves one of the backticks so the space isn't codefenced. In a couple instances, the closing back tick was missing.
1. The commits for MD040  and MD041 were all in the YML config.
1. There was only one instance of MD050.

