### PR TITLE
Format endnote and endexample markers

### DIFF
--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -92,7 +92,9 @@ Similarly, a single-dimensional array `T[]` also implements the interface `Syste
 > }
 > ```
 >
-> The assignment `lst2 = oa1` generates a compile-time error since the conversion from `object[]` to `IList<string>` is an explicit conversion, not implicit. The cast `(IList<string>)oa1` will cause an exception to be thrown at run-time since `oa1` references an `object[]` and not a `string[]`. However the cast (`IList<string>)oa2` will not cause an exception to be thrown since `oa2` references a `string[]`. *end example*
+> The assignment `lst2 = oa1` generates a compile-time error since the conversion from `object[]` to `IList<string>` is an explicit conversion, not implicit. The cast `(IList<string>)oa1` will cause an exception to be thrown at run-time since `oa1` references an `object[]` and not a `string[]`. However the cast (`IList<string>)oa2` will not cause an exception to be thrown since `oa2` references a `string[]`.
+>
+> *end example*
 
 Whenever there is an implicit or explicit reference conversion from `S[]` to `IList<T>`, there is also an explicit reference conversion from `IList<T>` and its base interfaces to `S[]` ([§10.3.5](conversions.md#1035-explicit-reference-conversions)).
 
@@ -147,7 +149,9 @@ Because of array covariance, assignments to elements of reference type arrays in
 > }
 > ```
 >
-> The assignment to `array[i]` in the `Fill` method implicitly includes a run-time check, which ensures that `value` is either a `null` reference or a reference to an object of a type that is compatible with the actual element type of `array`. In `Main`, the first two invocations of `Fill` succeed, but the third invocation causes a `System.ArrayTypeMismatchException` to be thrown upon executing the first assignment to `array[i]`. The exception occurs because a boxed `int` cannot be stored in a `string` array. *end example*
+> The assignment to `array[i]` in the `Fill` method implicitly includes a run-time check, which ensures that `value` is either a `null` reference or a reference to an object of a type that is compatible with the actual element type of `array`. In `Main`, the first two invocations of `Fill` succeed, but the third invocation causes a `System.ArrayTypeMismatchException` to be thrown upon executing the first assignment to `array[i]`. The exception occurs because a boxed `int` cannot be stored in a `string` array.
+>
+> *end example*
 
 Array covariance specifically does not extend to arrays of *value_type*s. For example, no conversion exists that permits an `int[]` to be treated as an `object[]`.
 
@@ -248,7 +252,9 @@ When an array creation expression includes both explicit dimension lengths and a
 > int[] z = new int[3] {0, 1, 2, 3}; // Error, length/initializer mismatch
 > ```
 >
-> Here, the initializer for `y` results in a compile-time error because the dimension length expression is not a constant, and the initializer for `z` results in a compile-time error because the length and the number of elements in the initializer do not agree. *end example*
+> Here, the initializer for `y` results in a compile-time error because the dimension length expression is not a constant, and the initializer for `z` results in a compile-time error because the length and the number of elements in the initializer do not agree.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -94,7 +94,9 @@ The attribute `AttributeUsage` ([§21.5.2](attributes.md#2152-the-attributeusage
 > }
 > ```
 >
-> shows a class declaration with two uses of the `Author` attribute. *end example*
+> shows a class declaration with two uses of the `Author` attribute.
+>
+> *end example*
 
 `AttributeUsage` has another named parameter ([§21.2.3](attributes.md#2123-positional-and-named-parameters)), called `Inherited`, which indicates whether the attribute, when specified on a base class, is also inherited by classes that derive from that base class. If `Inherited` for an attribute class is true, then that attribute is inherited. If `Inherited` for an attribute class is false then that attribute is not inherited. If it is unspecified, its default value is true.
 
@@ -318,7 +320,7 @@ In all other contexts, inclusion of an *attribute_target_specifier* is permitted
 > class Class2 {}
 > ```
 >
-> *end example*.]
+> *end example*.
 
 An implementation can accept other *attribute_target*s, the purposes of which are implementation defined. An implementation that does not recognize such an *attribute_target* shall issue a warning and ignore the containing *attribute_section*.
 
@@ -399,7 +401,9 @@ It is a compile-time error to use a single-use attribute class more than once on
 > public class Class1 {}
 > ```
 >
-> results in a compile-time error because it attempts to use `HelpString`, which is a single-use attribute class, more than once on the declaration of `Class1`. *end example*
+> results in a compile-time error because it attempts to use `HelpString`, which is a single-use attribute class, more than once on the declaration of `Class1`.
+>
+> *end example*
 
 An expression `E` is an *attribute_argument_expression* if all of the following statements are true:
 
@@ -578,7 +582,9 @@ A method decorated with the `Conditional` attribute is a conditional method. Eac
 > }
 > ```
 >
-> declares `Eg.M` as a conditional method associated with the two conditional compilation symbols `ALPHA` and `BETA`. *end example*
+> declares `Eg.M` as a conditional method associated with the two conditional compilation symbols `ALPHA` and `BETA`.
+>
+> *end example*
 
 A call to a conditional method is included if one or more of its associated conditional compilation symbols is defined at the point of call, otherwise the call is omitted.
 
@@ -617,7 +623,9 @@ In addition, a compile-time error occurs if a delegate is created from a conditi
 > }
 > ```
 >
-> declares `Class1.M` as a conditional method. `Class2`’s `Test` method calls this method. Since the conditional compilation symbol `DEBUG` is defined, if `Class2.Test` is called, it will call `M`. If the symbol `DEBUG` had not been defined, then `Class2.Test` would not call `Class1.M`. *end example*
+> declares `Class1.M` as a conditional method. `Class2`’s `Test` method calls this method. Since the conditional compilation symbol `DEBUG` is defined, if `Class2.Test` is called, it will call `M`. If the symbol `DEBUG` had not been defined, then `Class2.Test` would not call `Class1.M`.
+>
+> *end example*
 
 It is important to understand that the inclusion or exclusion of a call to a conditional method is controlled by the conditional compilation symbols at the point of the call.
 
@@ -657,7 +665,9 @@ It is important to understand that the inclusion or exclusion of a call to a con
 > }
 > ```
 >
-> the classes `Class2` and `Class3` each contain calls to the conditional method `Class1.F`, which is conditional based on whether or not `DEBUG` is defined. Since this symbol is defined in the context of `Class2` but not `Class3`, the call to `F` in `Class2` is included, while the call to `F` in `Class3` is omitted. *end example*
+> the classes `Class2` and `Class3` each contain calls to the conditional method `Class1.F`, which is conditional based on whether or not `DEBUG` is defined. Since this symbol is defined in the context of `Class2` but not `Class3`, the call to `F` in `Class2` is included, while the call to `F` in `Class3` is omitted.
+>
+> *end example*
 
 The use of conditional methods in an inheritance chain can be confusing. Calls made to a conditional method through `base`, of the form `base.M`, are subject to the normal conditional method call rules.
 
@@ -699,7 +709,9 @@ The use of conditional methods in an inheritance chain can be confusing. Calls m
 > }
 > ```
 >
-> `Class2` includes a call to the `M` defined in its base class. This call is omitted because the base method is conditional based on the presence of the symbol `DEBUG`, which is undefined. Thus, the method writes to the console “`Class2.M executed`” only. Judicious use of *pp_declaration*s can eliminate such problems. *end example*
+> `Class2` includes a call to the `M` defined in its base class. This call is omitted because the base method is conditional based on the presence of the symbol `DEBUG`, which is undefined. Thus, the method writes to the console “`Class2.M executed`” only. Judicious use of *pp_declaration*s can eliminate such problems.
+>
+> *end example*
 
 #### 21.5.3.3 Conditional attribute classes
 
@@ -716,7 +728,9 @@ An attribute class ([§21.2](attributes.md#212-attribute-classes)) decorated wit
 > public class TestAttribute : Attribute {}
 > ```
 >
-> declares `TestAttribute` as a conditional attribute class associated with the conditional compilations symbols `ALPHA` and `BETA`. *end example*
+> declares `TestAttribute` as a conditional attribute class associated with the conditional compilations symbols `ALPHA` and `BETA`.
+>
+> *end example*
 
 Attribute specifications ([§21.3](attributes.md#213-attribute-specification)) of a conditional attribute are included if one or more of its associated conditional compilation symbols is defined at the point of specification, otherwise the attribute specification is omitted.
 
@@ -743,7 +757,9 @@ It is important to note that the inclusion or exclusion of an attribute specific
 > class Class2 {}
 > ```
 >
-> the classes `Class1` and `Class2` are each decorated with attribute `Test`, which is conditional based on whether or not `DEBUG` is defined. Since this symbol is defined in the context of `Class1` but not `Class2`, the specification of the Test attribute on `Class1` is included, while the specification of the `Test` attribute on `Class2` is omitted. *end example*
+> the classes `Class1` and `Class2` are each decorated with attribute `Test`, which is conditional based on whether or not `DEBUG` is defined. Since this symbol is defined in the context of `Class1` but not `Class2`, the specification of the Test attribute on `Class1` is included, while the specification of the `Test` attribute on `Class2` is omitted.
+>
+> *end example*
 
 ### 21.5.4 The Obsolete attribute
 
@@ -775,7 +791,9 @@ If a program uses a type or member that is decorated with the `Obsolete` attribu
 > }
 > ```
 >
-> the class `A` is decorated with the `Obsolete` attribute. Each use of `A` in `Main` results in a warning that includes the specified message, “This class is obsolete; use class `B` instead”. *end example*
+> the class `A` is decorated with the `Obsolete` attribute. Each use of `A` in `Main` results in a warning that includes the specified message, “This class is obsolete; use class `B` instead”.
+>
+> *end example*
 
 ### 21.5.5 Caller-info attributes
 
@@ -804,7 +822,9 @@ When an optional parameter is annotated with one of the caller-info attributes, 
 > }
 > ```
 >
-> A call to `Log()` with no arguments would print the line number and file path of the call, as well as the name of the member within which the call occurred. *end example*
+> A call to `Log()` with no arguments would print the line number and file path of the call, as well as the name of the member within which the call occurred.
+>
+> *end example*
 
 Caller-info attributes can occur on optional parameters anywhere, including in delegate declarations. However, the specific caller-info attributes have restrictions on the types of the parameters they can attribute, so that there will always be an implicit conversion from a substituted value to the parameter type.
 
@@ -871,4 +891,5 @@ For interoperation with other languages, an indexer may be implemented using ind
 > ```
 >
 > Now, the indexer’s name is `TheItem`.
+>
 > *end example*

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -94,7 +94,9 @@ The textual order in which names are declared is generally of no significance. I
 > }
 > ```
 >
-> The two namespace declarations above contribute to the same declaration space, in this case declaring two classes with the fully qualified names `Megacorp.Data.Customer` and `Megacorp.Data.Order`. Because the two declarations contribute to the same declaration space, it would have caused a compile-time error if each contained a declaration of a class with the same name. *end example*
+> The two namespace declarations above contribute to the same declaration space, in this case declaring two classes with the fully qualified names `Megacorp.Data.Customer` and `Megacorp.Data.Order`. Because the two declarations contribute to the same declaration space, it would have caused a compile-time error if each contained a declaration of a class with the same name.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -312,7 +314,9 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 > - The accessibility domain of `B.C.Z` is the program text of `B.C`.
 > - The accessibility domain of `B.D.X` and `B.D.Y` is the program text of `B`, including the program text of `B.C` and `B.D`.
 > - The accessibility domain of `B.D.Z` is the program text of `B.D`.
-> As the example illustrates, the accessibility domain of a member is never larger than that of a containing type. For example, even though all `X` members have public declared accessibility, all but `A.X` have accessibility domains that are constrained by a containing type. *end example*
+> As the example illustrates, the accessibility domain of a member is never larger than that of a containing type. For example, even though all `X` members have public declared accessibility, all but `A.X` have accessibility domains that are constrained by a containing type.
+>
+> *end example*
 
 As described in [§7.4](basic-concepts.md#74-members), all members of a base class, except for instance constructors, finalizers, and static constructors, are inherited by derived types. This includes even private members of a base class. However, the accessibility domain of a private member includes only the program text of the type in which the member is declared.
 
@@ -338,7 +342,9 @@ As described in [§7.4](basic-concepts.md#74-members), all members of a base cla
 > }
 > ```
 >
-> the `B` class inherits the private member `x` from the `A` class. Because the member is private, it is only accessible within the *class_body* of `A`. Thus, the access to `b.x` succeeds in the `A.F` method, but fails in the `B.F` method. *end example*
+> the `B` class inherits the private member `x` from the `A` class. Because the member is private, it is only accessible within the *class_body* of `A`. Thus, the access to `b.x` succeeds in the `A.F` method, but fails in the `B.F` method.
+>
+> *end example*
 
 ### 7.5.4 Protected access
 
@@ -377,7 +383,9 @@ In addition to these forms of access, a derived class can access a protected ins
 > }
 > ```
 >
-> within `A`, it is possible to access `x` through instances of both `A` and `B`, since in either case the access takes place *through* an instance of `A` or a class derived from `A`. However, within `B`, it is not possible to access `x` through an instance of `A`, since `A` does not derive from `B`. *end example*
+> within `A`, it is possible to access `x` through instances of both `A` and `B`, since in either case the access takes place *through* an instance of `A` or a class derived from `A`. However, within `B`, it is not possible to access `x` through an instance of `A`, since `A` does not derive from `B`.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -403,7 +411,9 @@ In addition to these forms of access, a derived class can access a protected ins
 > }
 > ```
 >
-> Here, the three assignments to `x` are permitted because they all take place through instances of class types constructed from the generic type. *end example*
+> Here, the three assignments to `x` are permitted because they all take place through instances of class types constructed from the generic type.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -452,7 +462,9 @@ The following accessibility constraints exist:
 > public class B: A {...}
 > ```
 >
-> the `B` class results in a compile-time error because `A` is not at least as accessible as `B`. *end example*
+> the `B` class results in a compile-time error because `A` is not at least as accessible as `B`.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -469,7 +481,9 @@ The following accessibility constraints exist:
 > }
 > ```
 >
-> the `H` method in `B` results in a compile-time error because the return type `A` is not at least as accessible as the method. *end example*
+> the `H` method in `B` results in a compile-time error because the return type `A` is not at least as accessible as the method.
+>
+> *end example*
 
 ## 7.6 Signatures and overloading
 
@@ -519,7 +533,9 @@ The types `object` and `dynamic` are not distinguished when comparing signatures
 > }
 > ```
 >
-> Note that any `ref` and `out` parameter modifiers ([§14.6.2](classes.md#1462-method-parameters)) are part of a signature. Thus, `F(int)`, `F(ref int)`, and `F(out int)` are all unique signatures. However, `F(ref int)` and `F(out int)` cannot be declared within the same interface because their signatures differ solely by `ref` and `out`. Also, note that the return type and the `params` modifier are not part of a signature, so it is not possible to overload solely based on return type or on the inclusion or exclusion of the `params` modifier. As such, the declarations of the methods `F(int)` and `F(params string[])` identified above, result in a compile-time error. *end example*
+> Note that any `ref` and `out` parameter modifiers ([§14.6.2](classes.md#1462-method-parameters)) are part of a signature. Thus, `F(int)`, `F(ref int)`, and `F(out int)` are all unique signatures. However, `F(ref int)` and `F(out int)` cannot be declared within the same interface because their signatures differ solely by `ref` and `out`. Also, note that the return type and the `params` modifier are not part of a signature, so it is not possible to overload solely based on return type or on the inclusion or exclusion of the `params` modifier. As such, the declarations of the methods `F(int)` and `F(params string[])` identified above, result in a compile-time error.
+>
+> *end example*
 
 ## 7.7 Scopes
 
@@ -570,7 +586,9 @@ Within the scope of a namespace, class, struct, or enumeration member it is poss
 > }
 > ```
 >
-> Here, it is valid for `F` to refer to `i` before it is declared. *end example*
+> Here, it is valid for `F` to refer to `i` before it is declared.
+>
+> *end example*
 
 Within the scope of a local variable, it is a compile-time error to refer to the local variable in a textual position that precedes the *local_variable_declarator* of the local variable.
 
@@ -600,7 +618,9 @@ Within the scope of a local variable, it is a compile-time error to refer to the
 > }
 > ```
 >
-> In the `F` method above, the first assignment to `i` specifically does not refer to the field declared in the outer scope. Rather, it refers to the local variable and it results in a compile-time error because it textually precedes the declaration of the variable. In the `G` method, the use of `j` in the initializer for the declaration of `j` is valid because the use does not precede the *local_variable_declarator*. In the `H` method, a subsequent *local_variable_declarator* correctly refers to a local variable declared in an earlier *local_variable_declarator* within the same *local_variable_declaration*. *end example*
+> In the `F` method above, the first assignment to `i` specifically does not refer to the field declared in the outer scope. Rather, it refers to the local variable and it results in a compile-time error because it textually precedes the declaration of the variable. In the `G` method, the use of `j` in the initializer for the declaration of `j` is valid because the use does not precede the *local_variable_declarator*. In the `H` method, a subsequent *local_variable_declarator* correctly refers to a local variable declared in an earlier *local_variable_declarator* within the same *local_variable_declaration*.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -658,7 +678,9 @@ Name hiding through nesting can occur as a result of nesting namespaces or types
 > }
 > ```
 >
-> within the `F` method, the instance variable `i` is hidden by the local variable `i`, but within the `G` method, `i` still refers to the instance variable. *end example*
+> within the `F` method, the instance variable `i` is hidden by the local variable `i`, but within the `G` method, `i` still refers to the instance variable.
+>
+> *end example*
 
 When a name in an inner scope hides a name in an outer scope, it hides all overloaded occurrences of that name.
 
@@ -683,7 +705,9 @@ When a name in an inner scope hides a name in an outer scope, it hides all overl
 > }
 > ```
 >
-> the call `F(1)` invokes the `F` declared in `Inner` because all outer occurrences of `F` are hidden by the inner declaration. For the same reason, the call `F("Hello")` results in a compile-time error. *end example*
+> the call `F(1)` invokes the `F` declared in `Inner` because all outer occurrences of `F` are hidden by the inner declaration. For the same reason, the call `F("Hello")` results in a compile-time error.
+>
+> *end example*
 
 #### 7.7.2.3 Hiding through inheritance
 
@@ -711,7 +735,9 @@ Contrary to hiding a name from an outer scope, hiding a visible name from an inh
 > }
 > ```
 >
-> the declaration of `F` in `Derived` causes a warning to be reported. Hiding an inherited name is specifically not an error, since that would preclude separate evolution of base classes. For example, the above situation might have come about because a later version of `Base` introduced an `F` method that wasn’t present in an earlier version of the class. *end example*
+> the declaration of `F` in `Derived` causes a warning to be reported. Hiding an inherited name is specifically not an error, since that would preclude separate evolution of base classes. For example, the above situation might have come about because a later version of `Base` introduced an `F` method that wasn’t present in an earlier version of the class.
+>
+> *end example*
 
 The warning caused by hiding an inherited name can be eliminated through use of the `new` modifier:
 
@@ -729,7 +755,9 @@ The warning caused by hiding an inherited name can be eliminated through use of 
 > }
 > ```
 >
-> The `new` modifier indicates that the `F` in `Derived` is “new”, and that it is indeed intended to hide the inherited member. *end example*
+> The `new` modifier indicates that the `F` in `Derived` is “new”, and that it is indeed intended to hide the inherited member.
+>
+> *end example*
 
 A declaration of a new member hides an inherited member only within the scope of the new member.
 
@@ -755,7 +783,9 @@ A declaration of a new member hides an inherited member only within the scope of
 > }
 > ```
 >
-> In the example above, the declaration of `F` in `Derived` hides the `F` that was inherited from `Base`, but since the new `F` in `Derived` has private access, its scope does not extend to `MoreDerived`. Thus, the call `F()` in `MoreDerived.G` is valid and will invoke `Base.F`. *end example*
+> In the example above, the declaration of `F` in `Derived` hides the `F` that was inherited from `Base`, but since the new `F` in `Derived` has private access, its scope does not extend to `MoreDerived`. Thus, the call `F()` in `MoreDerived.G` is valid and will invoke `Base.F`.
+>
+> *end example*
 
 ## 7.8 Namespace and type names
 
@@ -1013,7 +1043,9 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 > RefA is not null
 > ```
 >
-> Note that although the instance of `A` was not in use and `A`’s finalizer was run, it is still possible for methods of `A` (in this case, `F`) to be called from another finalizer. Also, note that running of a finalizer might cause an object to become usable from the mainline program again. In this case, the running of `B`’s finalizer caused an instance of `A` that was previously not in use, to become accessible from the live reference `Test.RefA`. After the call to `WaitForPendingFinalizers`, the instance of `B` is eligible for collection, but the instance of `A` is not, because of the reference `Test.RefA`. *end example*
+> Note that although the instance of `A` was not in use and `A`’s finalizer was run, it is still possible for methods of `A` (in this case, `F`) to be called from another finalizer. Also, note that running of a finalizer might cause an object to become usable from the mainline program again. In this case, the running of `B`’s finalizer caused an instance of `A` that was previously not in use, to become accessible from the live reference `Test.RefA`. After the call to `WaitForPendingFinalizers`, the instance of `B` is eligible for collection, but the instance of `A` is not, because of the reference `Test.RefA`.
+>
+> *end example*
 
 ## 7.10 Execution order
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1212,7 +1212,9 @@ The reserved names do not introduce declarations, thus they do not participate i
 >
 > 1. To allow the underlying implementation to use an ordinary identifier as a method name for get or set access to the C# language feature.
 > 2. To allow other languages to interoperate using an ordinary identifier as a method name for get or set access to the C# language feature.
-> 3. To help ensure that the source accepted by one conforming compiler is accepted by another, by making the specifics of reserved member names consistent across all C# implementations. *end note*
+> 3. To help ensure that the source accepted by one conforming compiler is accepted by another, by making the specifics of reserved member names consistent across all C# implementations.
+>
+> *end note*
 
 The declaration of a finalizer ([§14.13](classes.md#1413-finalizers)) also causes a signature to be reserved ([§14.3.10.5](classes.md#143105-member-names-reserved-for-finalizers)).
 
@@ -2674,7 +2676,9 @@ Only a defining partial method participates in overload resolution. Thus, whethe
 > }
 > ```
 >
-> is **invalid** as the invocation uses the argument name from the implementing and not the defining partial method declaration. *end note*
+> is **invalid** as the invocation uses the argument name from the implementing and not the defining partial method declaration.
+>
+> *end note*
 
 If no part of a partial type declaration contains an implementing declaration for a given partial method, any expression statement invoking it is simply removed from the combined type declaration. Thus the invocation expression, including any subexpressions, has no effect at run-time. The partial method itself is also removed and will not be a member of the combined type declaration.
 
@@ -3662,7 +3666,9 @@ When compiling a field-like event, the compiler automatically creates storage to
 > }
 > ```
 
-Within the class `X`, references to `Ev` on the left-hand side of the `+=` and `–=` operators cause the add and remove accessors to be invoked. All other references to `Ev` are compiled to reference the hidden field `__Ev` instead ([§11.7.6](expressions.md#1176-member-access)). The name “`__Ev`” is arbitrary; the hidden field could have any name or no name at all. *end note*
+Within the class `X`, references to `Ev` on the left-hand side of the `+=` and `–=` operators cause the add and remove accessors to be invoked. All other references to `Ev` are compiled to reference the hidden field `__Ev` instead ([§11.7.6](expressions.md#1176-member-access)). The name “`__Ev`” is arbitrary; the hidden field could have any name or no name at all.
+>
+> *end note*
 
 ### 14.8.3 Event accessors
 
@@ -4471,7 +4477,9 @@ If a class contains no instance constructor declarations, a default instance con
 > public C(): base() {}
 > ```
 >
-> where `C` is the name of the class. *end note*
+> where `C` is the name of the class.
+>
+> *end note*
 
 If overload resolution is unable to determine a unique best candidate for the base-class constructor initializer then a compile-time error occurs.
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -87,7 +87,9 @@ When a non-abstract class is derived from an abstract class, the non-abstract cl
 > }
 > ```
 >
-> the abstract class `A` introduces an abstract method `F`. Class `B` introduces an additional method `G`, but since it doesn’t provide an implementation of `F`, `B` shall also be declared abstract. Class `C` overrides `F` and provides an actual implementation. Since there are no abstract members in `C`, `C` is permitted (but not required) to be non-abstract. *end example*
+> the abstract class `A` introduces an abstract method `F`. Class `B` introduces an additional method `G`, but since it doesn’t provide an implementation of `F`, `B` shall also be declared abstract. Class `C` overrides `F` and provides an actual implementation. Since there are no abstract members in `C`, `C` is permitted (but not required) to be non-abstract.
+>
+> *end example*
 
 If one or more parts of a partial type declaration ([§14.2.7](classes.md#1427-partial-declarations)) of a class include the `abstract` modifier, the class is abstract. Otherwise, the class is non-abstract.
 
@@ -188,7 +190,9 @@ When a *class_type* is included in the *class_base*, it specifies the direct bas
 > class B : A {}
 > ```
 >
-> Class `A` is said to be the direct base class of `B`, and `B` is said to be derived from `A`. Since `A` does not explicitly specify a direct base class, its direct base class is implicitly `object`. *end example*
+> Class `A` is said to be the direct base class of `B`, and `B` is said to be derived from `A`. Since `A` does not explicitly specify a direct base class, its direct base class is implicitly `object`.
+>
+> *end example*
 
 For a constructed class type, including a nested type declared within a generic type declaration ([§14.3.9.7](classes.md#14397-nested-types-in-generic-classes)), if a base class is specified in the generic class declaration, the base class of the constructed type is obtained by substituting, for each *type_parameter* in the base class declaration, the corresponding *type_argument* of the constructed type.
 
@@ -199,7 +203,9 @@ For a constructed class type, including a nested type declared within a generic 
 > class G<T> : B<string,T[]> {...}
 > ```
 >
-> the base class of the constructed type `G<int>` would be `B<string,int[]>`. *end example*
+> the base class of the constructed type `G<int>` would be `B<string,int[]>`.
+>
+> *end example*
 
 The base class specified in a class declaration can be a constructed class type ([§8.4](types.md#84-constructed-types)). A base class cannot be a type parameter on its own ([§8.5](types.md#85-type-parameters)), though it can involve the type parameters that are in scope.
 
@@ -231,7 +237,9 @@ In determining the meaning of the direct base class specification `A` of a clas
 > class Z : X<Z.Y> {}
 > ```
 >
-> is in error since in the base class specification `X<Z.Y>` the direct base class of `Z` is considered to be `object`, and hence (by the rules of [§7.8](basic-concepts.md#78-namespace-and-type-names)) `Z` is not considered to have a member `Y`. *end example*
+> is in error since in the base class specification `X<Z.Y>` the direct base class of `Z` is considered to be `object`, and hence (by the rules of [§7.8](basic-concepts.md#78-namespace-and-type-names)) `Z` is not considered to have a member `Y`.
+>
+> *end example*
 
 The base classes of a class are the direct base class and its base classes. In other words, the set of base classes is the transitive closure of the direct base class relationship.
 
@@ -244,7 +252,9 @@ The base classes of a class are the direct base class and its base classes. In o
 > class D<T> : C<T[]> {...}
 > ```
 >
-> the base classes of `D<int>` are `C<int[]>`, `B<IComparable<int[]>>`, `A`, and `object`. *end example*
+> the base classes of `D<int>` are `C<int[]>`, `B<IComparable<int[]>>`, `A`, and `object`.
+>
+> *end example*
 
 Except for class `object`, every class has exactly one direct base class. The `object` class has no direct base class and is the ultimate base class of all other classes.
 
@@ -274,7 +284,9 @@ It is a compile-time error for a class to depend on itself. For the purpose of t
 > }
 > ```
 >
-> results in a compile-time error because A depends on `B.C` (its direct base class), which depends on `B` (its immediately enclosing class), which circularly depends on `A`. *end example*
+> results in a compile-time error because A depends on `B.C` (its direct base class), which depends on `B` (its immediately enclosing class), which circularly depends on `A`.
+>
+> *end example*
 
 A class does not depend on the classes that are nested within it.
 
@@ -287,7 +299,9 @@ A class does not depend on the classes that are nested within it.
 > }
 > ```
 >
-> `B` depends on `A` (because `A` is both its direct base class and its immediately enclosing class), but `A` does not depend on `B` (since `B` is neither a base class nor an enclosing class of `A`). Thus, the example is valid. *end example*
+> `B` depends on `A` (because `A` is both its direct base class and its immediately enclosing class), but `A` does not depend on `B` (since `B` is neither a base class nor an enclosing class of `A`). Thus, the example is valid.
+>
+> *end example*
 
 It is not possible to derive from a sealed class.
 > *Example*: In the following code
@@ -297,7 +311,9 @@ It is not possible to derive from a sealed class.
 > class B : A {} // Error, cannot derive from a sealed class
 > ```
 >
-> Class `B` is in error because it attempts to derive from the sealed class `A`. *end example*
+> Class `B` is in error because it attempts to derive from the sealed class `A`.
+>
+> *end example*
 
 #### 14.2.4.3 Interface implementations
 
@@ -313,7 +329,9 @@ The set of interfaces for a type declared in multiple parts ([§14.2.7](classes.
 > partial class C : IA, IB {...}
 > ```
 >
-> the set of base interfaces for class `C` is `IA`, `IB`, and `IC`. *end example*
+> the set of base interfaces for class `C` is `IA`, `IB`, and `IC`.
+>
+> *end example*
 
 Typically, each part provides an implementation of the interface(s) declared on that part; however, this is not a requirement. A part can provide the implementation for an interface declared on a different part.
 
@@ -574,7 +592,9 @@ Values of a constrained type parameter type can be used to access the instance m
 > }
 > ```
 >
-> the methods of `IPrintable` can be invoked directly on `x` because `T` is constrained to always implement `IPrintable`. *end example*
+> the methods of `IPrintable` can be invoked directly on `x` because `T` is constrained to always implement `IPrintable`.
+>
+> *end example*
 
 When a partial generic type declaration includes constraints, the constraints shall agree with all other parts that include constraints. Specifically, each part that includes constraints shall have constraints for the same set of type parameters, and for each type parameter, the sets of primary, secondary, and constructor constraints shall be equivalent. Two sets of constraints are equivalent if they contain the same members. If no part of a partial generic type specifies type parameter constraints, the type parameters are considered unconstrained.
 
@@ -601,7 +621,9 @@ When a partial generic type declaration includes constraints, the constraints sh
 > }
 > ```
 >
-> is correct because those parts that include constraints (the first two) effectively specify the same set of primary, secondary, and constructor constraints for the same set of type parameters, respectively. *end example*
+> is correct because those parts that include constraints (the first two) effectively specify the same set of primary, secondary, and constructor constraints for the same set of type parameters, respectively.
+>
+> *end example*
 
 ### 14.2.6 Class body
 
@@ -804,7 +826,9 @@ The non-inherited members of a constructed type are obtained by substituting, fo
 > public int H(double d) {...}
 > ```
 >
-> The type of the member `a` in the generic class declaration `Gen` is “two-dimensional array of `T`”, so the type of the member `a` in the constructed type above is “two-dimensional array of single-dimensional array of `int`”, or `int[,][]`. *end example*
+> The type of the member `a` in the generic class declaration `Gen` is “two-dimensional array of `T`”, so the type of the member `a` in the constructed type above is “two-dimensional array of single-dimensional array of `int`”, or `int[,][]`.
+>
+> *end example*
 
 Within instance function members, the type of `this` is the instance type ([§14.3.2](classes.md#1432-the-instance-type)) of the containing declaration.
 
@@ -872,7 +896,9 @@ The inherited members of a constructed class type are the members of the immedia
 > }
 > ```
 >
-> In the code above, the constructed type `D<int>` has a non-inherited member public `int` `G(string s)` obtained by substituting the type argument `int` for the type parameter `T`. `D<int>` also has an inherited member from the class declaration `B`. This inherited member is determined by first determining the base class type `B<int[]>` of `D<int>` by substituting `int` for `T` in the base class specification `B<T[]>`. Then, as a type argument to `B`, `int[]` is substituted for `U` in `public U F(long index)`, yielding the inherited member `public int[] F(long index)`. *end example*
+> In the code above, the constructed type `D<int>` has a non-inherited member public `int` `G(string s)` obtained by substituting the type argument `int` for the type parameter `T`. `D<int>` also has an inherited member from the class declaration `B`. This inherited member is determined by first determining the base class type `B<int[]>` of `D<int>` by substituting `int` for `T` in the base class specification `B<T[]>`. Then, as a type argument to `B`, `int[]` is substituted for `U` in `public U F(long index)`, yielding the inherited member `public int[] F(long index)`.
+>
+> *end example*
 
 ### 14.3.5 The new modifier
 
@@ -938,7 +964,9 @@ When a field, method, property, event, indexer, constructor, or finalizer declar
 > }
 > ```
 >
-> The `F` method shows that in an instance function member, a *simple_name* ([§11.7.4](expressions.md#1174-simple-names)) can be used to access both instance members and static members. The `G` method shows that in a static function member, it is a compile-time error to access an instance member through a *simple_name*. The `Main` method shows that in a *member_access* ([§11.7.6](expressions.md#1176-member-access)), instance members shall be accessed through instances, and static members shall be accessed through types. *end example*
+> The `F` method shows that in an instance function member, a *simple_name* ([§11.7.4](expressions.md#1174-simple-names)) can be used to access both instance members and static members. The `G` method shows that in a static function member, it is a compile-time error to access an instance member through a *simple_name*. The `Main` method shows that in a *member_access* ([§11.7.6](expressions.md#1176-member-access)), instance members shall be accessed through instances, and static members shall be accessed through types.
+>
+> *end example*
 
 ### 14.3.9 Nested types
 
@@ -963,7 +991,9 @@ A type declared within a class or struct is called a ***nested type***. A type t
 > }
 > ```
 >
-> class `B` is a nested type because it is declared within class `A`, and class `A` is a non-nested type because it is declared within a compilation unit. *end example*
+> class `B` is a nested type because it is declared within class `A`, and class `A` is a non-nested type because it is declared within a compilation unit.
+>
+> *end example*
 
 #### 14.3.9.2 Fully qualified name
 
@@ -1007,7 +1037,9 @@ Non-nested types can have `public` or `internal` declared accessibility and have
 > }
 > ```
 >
-> declares a private nested class `Node`. *end example*
+> declares a private nested class `Node`.
+>
+> *end example*
 
 #### 14.3.9.4 Hiding
 
@@ -1045,7 +1077,9 @@ A nested type may hide ([§7.7.2.2](basic-concepts.md#7722-hiding-through-nestin
 > }
 > ```
 >
-> shows a nested class `M` that hides the method `M` defined in `Base`. *end example*
+> shows a nested class `M` that hides the method `M` defined in `Base`.
+>
+> *end example*
 
 #### 14.3.9.5 this access
 
@@ -1092,7 +1126,9 @@ A nested type and its containing type do not have a special relationship with re
 > }
 > ```
 >
-> shows this technique. An instance of `C` creates an instance of `Nested`, and passes its own this to `Nested`’s constructor in order to provide subsequent access to `C`’s instance members. *end example*
+> shows this technique. An instance of `C` creates an instance of `Nested`, and passes its own this to `Nested`’s constructor in order to provide subsequent access to `C`’s instance members.
+>
+> *end example*
 
 #### 14.3.9.6 Access to private and protected members of the containing type
 
@@ -1119,7 +1155,9 @@ A nested type has access to all of the members that are accessible to its contai
 > }
 > ```
 >
-> shows a class `C` that contains a nested class `Nested`. Within `Nested`, the method `G` calls the static method `F` defined in `C`, and `F` has private declared accessibility. *end example*
+> shows a class `C` that contains a nested class `Nested`. Within `Nested`, the method `G` calls the static method `F` defined in `C`, and `F` has private declared accessibility.
+>
+> *end example*
 
 A nested type also may access protected members defined in a base type of its containing type.
 
@@ -1154,7 +1192,9 @@ A nested type also may access protected members defined in a base type of its co
 > }
 > ```
 >
-> the nested class `Derived.Nested` accesses the protected method `F` defined in `Derived`’s base class, `Base`, by calling through an instance of `Derived`. *end example*
+> the nested class `Derived.Nested` accesses the protected method `F` defined in `Derived`’s base class, `Base`, by calling through an instance of `Derived`.
+>
+> *end example*
 
 #### 14.3.9.7 Nested types in generic classes
 
@@ -1384,11 +1424,15 @@ Constants are permitted to depend on other constants within the same program as 
 > }
 > ```
 >
-> the compiler first evaluates `A.Y`, then evaluates `B.Z`, and finally evaluates `A.X`, producing the values `10`, `11`, and `12`. *end example*
+> the compiler first evaluates `A.Y`, then evaluates `B.Z`, and finally evaluates `A.X`, producing the values `10`, `11`, and `12`.
+>
+> *end example*
 
 Constant declarations may depend on constants from other programs, but such dependencies are only possible in one direction.
 
-> *Example*: Referring to the example above, if `A` and `B` were declared in separate programs, it would be possible for `A.X` to depend on `B.Z`, but `B.Z` could then not simultaneously depend on `A.Y`. *end example*
+> *Example*: Referring to the example above, if `A` and `B` were declared in separate programs, it would be possible for `A.X` to depend on `B.Z`, but `B.Z` could then not simultaneously depend on `A.Y`.
+>
+> *end example*
 
 ## 14.5 Fields
 
@@ -1499,7 +1543,9 @@ A static readonly field is useful when a symbolic name for a constant value is d
 > }
 > ```
 >
-> the `Black`, `White`, `Red`, `Green`, and `Blue` members cannot be declared as const members because their values cannot be computed at compile-time. However, declaring them `static readonly` instead has much the same effect. *end example*
+> the `Black`, `White`, `Red`, `Green`, and `Blue` members cannot be declared as const members because their values cannot be computed at compile-time. However, declaring them `static readonly` instead has much the same effect.
+>
+> *end example*
 
 #### 14.5.3.3 Versioning of constants and static readonly fields
 
@@ -1534,7 +1580,9 @@ Constants and readonly fields have different binary versioning semantics. When a
 > }
 > ```
 >
-> The `Program1` and `Program2` namespaces denote two programs that are compiled separately. Because `Program1.Utils.X` is declared as a `static readonly` field, the value output by the `Console.WriteLine` statement is not known at compile-time, but rather is obtained at run-time. Thus, if the value of `X` is changed and `Program1` is recompiled, the `Console.WriteLine` statement will output the new value even if `Program2` isn’t recompiled. However, had `X` been a constant, the value of `X` would have been obtained at the time `Program2` was compiled, and would remain unaffected by changes in `Program1` until `Program2` is recompiled. *end example*
+> The `Program1` and `Program2` namespaces denote two programs that are compiled separately. Because `Program1.Utils.X` is declared as a `static readonly` field, the value output by the `Console.WriteLine` statement is not known at compile-time, but rather is obtained at run-time. Thus, if the value of `X` is changed and `Program1` is recompiled, the `Console.WriteLine` statement will output the new value even if `Program2` isn’t recompiled. However, had `X` been a constant, the value of `X` would have been obtained at the time `Program2` was compiled, and would remain unaffected by changes in `Program1` until `Program2` is recompiled.
+>
+> *end example*
 
 ### 14.5.4 Volatile fields
 
@@ -1594,7 +1642,9 @@ These restrictions ensure that all threads will observe volatile writes performe
 > result = 143
 > ```
 >
-> In this example, the method `Main` starts a new thread that runs the method `Thread2`. This method stores a value into a non-volatile field called `result`, then stores `true` in the volatile field `finished`. The main thread waits for the field `finished` to be set to `true`, then reads the field `result`. Since `finished` has been declared `volatile`, the main thread shall read the value `143` from the field `result`. If the field `finished` had not been declared `volatile`, then it would be permissible for the store to `result` to be visible to the main thread *after* the store to `finished`, and hence for the main thread to read the value 0 from the field `result`. Declaring `finished` as a `volatile` field prevents any such inconsistency. *end example*
+> In this example, the method `Main` starts a new thread that runs the method `Thread2`. This method stores a value into a non-volatile field called `result`, then stores `true` in the volatile field `finished`. The main thread waits for the field `finished` to be set to `true`, then reads the field `result`. Since `finished` has been declared `volatile`, the main thread shall read the value `143` from the field `result`. If the field `finished` had not been declared `volatile`, then it would be permissible for the store to `result` to be visible to the main thread *after* the store to `finished`, and hence for the main thread to read the value 0 from the field `result`. Declaring `finished` as a `volatile` field prevents any such inconsistency.
+>
+> *end example*
 
 ### 14.5.5 Field initialization
 
@@ -1624,7 +1674,9 @@ The initial value of a field, whether it be a static field or an instance field,
 > b = False, i = 0
 > ```
 >
-> because `b` and `i` are both automatically initialized to default values. *end example*
+> because `b` and `i` are both automatically initialized to default values.
+>
+> *end example*
 
 ### 14.5.6 Variable initializers
 
@@ -1657,7 +1709,9 @@ Field declarations may include *variable_initializer*s. For static fields, varia
 > x = 1.4142135623731, i = 100, s = Hello
 > ```
 >
-> because an assignment to `x` occurs when static field initializers execute and assignments to `i` and `s` occur when the instance field initializers execute. *end example*
+> because an assignment to `x` occurs when static field initializers execute and assignments to `i` and `s` occur when the instance field initializers execute.
+>
+> *end example*
 
 The default value initialization described in [§14.5.5](classes.md#1455-field-initialization) occurs for all fields, including fields that have variable initializers. Thus, when a class is initialized, all static fields in that class are first initialized to their default values, and then the static field initializers are executed in textual order. Likewise, when an instance of a class is created, all instance fields in that instance are first initialized to their default values, and then the instance field initializers are executed in textual order. When there are field declarations in multiple partial type declarations for the same type, the order of the parts is unspecified. However, within each part the field initializers are executed in order.
 
@@ -1686,7 +1740,9 @@ It is possible for static fields with variable initializers to be observed in th
 > a = 1, b = 2
 > ```
 >
-> because the static fields `a` and `b` are initialized to `0` (the default value for `int`) before their initializers are executed. When the initializer for `a` runs, the value of `b` is zero, and so `a` is initialized to `1`. When the initializer for `b` runs, the value of a is already `1`, and so `b` is initialized to `2`. *end example*
+> because the static fields `a` and `b` are initialized to `0` (the default value for `int`) before their initializers are executed. When the initializer for `a` runs, the value of `b` is zero, and so `a` is initialized to `1`. When the initializer for `b` runs, the value of a is already `1`, and so `b` is initialized to `2`.
+>
+> *end example*
 
 #### 14.5.6.2 Static field initialization
 
@@ -1778,7 +1834,9 @@ The static field variable initializers of a class correspond to a sequence of as
 > 1 1
 > ```
 >
-> because the rules for when static constructors execute (as defined in [§14.12](classes.md#1412-static-constructors)) provide that `B`’s static constructor (and hence `B`’s static field initializers) shall run before `A`’s static constructor and field initializers. *end example*
+> because the rules for when static constructors execute (as defined in [§14.12](classes.md#1412-static-constructors)) provide that `B`’s static constructor (and hence `B`’s static field initializers) shall run before `A`’s static constructor and field initializers.
+>
+> *end example*
 
 #### 14.5.6.3 Instance field initialization
 
@@ -1796,7 +1854,9 @@ A variable initializer for an instance field cannot reference the instance being
 > }
 > ```
 >
-> the variable initializer for `y` results in a compile-time error because it references a member of the instance being created. *end example*
+> the variable initializer for `y` results in a compile-time error because it references a member of the instance being created.
+>
+> *end example*
 
 ## 14.6 Methods
 
@@ -1964,7 +2024,9 @@ A *parameter_array* may occur after an optional parameter, but cannot have a def
 > ) { }
 > ```
 >
-> In the *formal_parameter_list* for `M`, `i` is a required `ref` parameter, `d` is a required value parameter, `b`, `s`, `o` and `t` are optional value parameters and `a` is a parameter array. *end example*
+> In the *formal_parameter_list* for `M`, `i` is a required `ref` parameter, `d` is a required value parameter, `b`, `s`, `o` and `t` are optional value parameters and `a` is a parameter array.
+>
+> *end example*
 
 A method declaration creates a separate declaration space ([§7.3](basic-concepts.md#73-declarations)) for parameters and type parameters. Names are introduced into this declaration space by the type parameter list and the formal parameter list of the method. The body of the method, if any, is considered to be nested within this declaration space. It is an error for two members of a method declaration space to have the same name. It is an error for the method declaration space and the local variable declaration space of a nested declaration space to contain elements with the same name.
 
@@ -2026,7 +2088,9 @@ A method declared as an iterator ([§14.14](classes.md#1414-iterators)) may not 
 > i = 2, j = 1
 > ```
 >
-> For the invocation of `Swap` in `Main`, `x` represents `i` and `y` represents `j`. Thus, the invocation has the effect of swapping the values of `i` and `j`. *end example*
+> For the invocation of `Swap` in `Main`, `x` represents `i` and `y` represents `j`. Thus, the invocation has the effect of swapping the values of `i` and `j`.
+>
+> *end example*
 
 In a method that takes reference parameters, it is possible for multiple names to represent the same storage location.
 
@@ -2050,7 +2114,9 @@ In a method that takes reference parameters, it is possible for multiple names t
 > }
 > ```
 >
-> the invocation of `F` in `G` passes a reference to `s` for both `a` and `b`. Thus, for that invocation, the names `s`, `a`, and `b` all refer to the same storage location, and the three assignments all modify the instance field `s`. *end example*
+> the invocation of `F` in `G` passes a reference to `s` for both `a` and `b`. Thus, for that invocation, the names `s`, `a`, and `b` all refer to the same storage location, and the three assignments all modify the instance field `s`.
+>
+> *end example*
 
 #### 14.6.2.4 Output parameters
 
@@ -2105,13 +2171,17 @@ Output parameters are typically used in methods that produce multiple return val
 > hello.txt
 > ```
 >
-> Note that the `dir` and `name` variables can be unassigned before they are passed to `SplitPath`, and that they are considered definitely assigned following the call. *end example*
+> Note that the `dir` and `name` variables can be unassigned before they are passed to `SplitPath`, and that they are considered definitely assigned following the call.
+>
+> *end example*
 
 #### 14.6.2.5 Parameter arrays
 
 A parameter declared with a `params` modifier is a parameter array. If a formal parameter list includes a parameter array, it shall be the last parameter in the list and it shall be of a single-dimensional array type.
 
-> *Example*: The types `string[]` and `string[][]` can be used as the type of a parameter array, but the type `string[,]` can not. *end example*
+> *Example*: The types `string[]` and `string[][]` can be used as the type of a parameter array, but the type `string[,]` can not.
+>
+> *end example*
 
 It is not possible to combine the `params` modifier with the modifiers `ref` and `out`.
 
@@ -2198,7 +2268,9 @@ When performing overload resolution, a method with a parameter array might be ap
 > F(object[]);
 > ```
 >
-> In the example, two of the possible expanded forms of the method with a parameter array are already included in the class as regular methods. These expanded forms are therefore not considered when performing overload resolution, and the first and third method invocations thus select the regular methods. When a class declares a method with a parameter array, it is not uncommon to also include some of the expanded forms as regular methods. By doing so, it is possible to avoid the allocation of an array instance that occurs when an expanded form of a method with a parameter array is invoked. *end example*
+> In the example, two of the possible expanded forms of the method with a parameter array are already included in the class as regular methods. These expanded forms are therefore not considered when performing overload resolution, and the first and third method invocations thus select the regular methods. When a class declares a method with a parameter array, it is not uncommon to also include some of the expanded forms as regular methods. By doing so, it is possible to avoid the allocation of an array instance that occurs when an expanded form of a method with a parameter array is invoked.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -2228,7 +2300,9 @@ When performing overload resolution, a method with a parameter array might be ap
 > False
 > ```
 >
-> The second invocation produces `False` as it is equivalent to `F(new string[] { null })` and passes an array containing a single null reference. *end example*
+> The second invocation produces `False` as it is equivalent to `F(new string[] { null })` and passes an array containing a single null reference.
+>
+> *end example*
 
 When the type of a parameter array is `object[]`, a potential ambiguity arises between the normal form of the method and the expanded form for a single `object` parameter. The reason for the ambiguity is that an `object[]` is itself implicitly convertible to type `object`. The ambiguity presents no problem, however, since it can be resolved by inserting a cast if needed.
 
@@ -2270,7 +2344,9 @@ When the type of a parameter array is `object[]`, a potential ambiguity arises b
 > System.Int32 System.String System.Double
 > ```
 >
-> In the first and last invocations of `F`, the normal form of `F` is applicable because an implicit conversion exists from the argument type to the parameter type (both are of type `object[]`). Thus, overload resolution selects the normal form of `F`, and the argument is passed as a regular value parameter. In the second and third invocations, the normal form of `F` is not applicable because no implicit conversion exists from the argument type to the parameter type (type `object` cannot be implicitly converted to type `object[]`). However, the expanded form of `F` is applicable, so it is selected by overload resolution. As a result, a one-element `object[]` is created by the invocation, and the single element of the array is initialized with the given argument value (which itself is a reference to an `object[]`). *end example*
+> In the first and last invocations of `F`, the normal form of `F` is applicable because an implicit conversion exists from the argument type to the parameter type (both are of type `object[]`). Thus, overload resolution selects the normal form of `F`, and the argument is passed as a regular value parameter. In the second and third invocations, the normal form of `F` is not applicable because no implicit conversion exists from the argument type to the parameter type (type `object` cannot be implicitly converted to type `object[]`). However, the expanded form of `F` is applicable, so it is selected by overload resolution. As a result, a one-element `object[]` is created by the invocation, and the single element of the array is initialized with the given argument value (which itself is a reference to an `object[]`).
+>
+> *end example*
 
 ### 14.6.3 Static and instance methods
 
@@ -2341,7 +2417,9 @@ For every virtual method declared in or inherited by a class, there exists a ***
 > B.G
 > ```
 >
-> Notice that the statement `a.G()` invokes `B.G`, not `A.G`. This is because the run-time type of the instance (which is `B`), not the compile-time type of the instance (which is `A`), determines the actual method implementation to invoke. *end example*
+> Notice that the statement `a.G()` invokes `B.G`, not `A.G`. This is because the run-time type of the instance (which is `B`), not the compile-time type of the instance (which is `A`), determines the actual method implementation to invoke.
+>
+> *end example*
 
 Because methods are allowed to hide inherited methods, it is possible for a class to contain several virtual methods with the same signature. This does not present an ambiguity problem, since all but the most derived method are hidden.
 
@@ -2395,7 +2473,9 @@ Because methods are allowed to hide inherited methods, it is possible for a clas
 > D.F
 > ```
 >
-> Note that it is possible to invoke the hidden virtual method by accessing an instance of `D` through a less derived type in which the method is not hidden. *end example*
+> Note that it is possible to invoke the hidden virtual method by accessing an instance of `D` through a less derived type in which the method is not hidden.
+>
+> *end example*
 
 ### 14.6.5 Override methods
 
@@ -2464,7 +2544,9 @@ An override declaration can access the overridden base method using a *base_acce
 > }
 > ```
 >
-> the `base.PrintFields()` invocation in `B` invokes the PrintFields method declared in `A`. A *base_access* disables the virtual invocation mechanism and simply treats the base method as a non-`virtual` method. Had the invocation in `B` been written `((A)this).PrintFields()`, it would recursively invoke the `PrintFields` method declared in `B`, not the one declared in `A`, since `PrintFields` is virtual and the run-time type of `((A)this)` is `B`. *end example*
+> the `base.PrintFields()` invocation in `B` invokes the PrintFields method declared in `A`. A *base_access* disables the virtual invocation mechanism and simply treats the base method as a non-`virtual` method. Had the invocation in `B` been written `((A)this).PrintFields()`, it would recursively invoke the `PrintFields` method declared in `B`, not the one declared in `A`, since `PrintFields` is virtual and the run-time type of `((A)this)` is `B`.
+>
+> *end example*
 
 Only by including an `override` modifier can a method override another method. In all other cases, a method with the same signature as an inherited method simply hides the inherited method.
 
@@ -2482,7 +2564,9 @@ Only by including an `override` modifier can a method override another method. I
 > }
 > ```
 >
-> the `F` method in `B` does not include an `override` modifier and therefore does not override the `F` method in `A`. Rather, the `F` method in `B` hides the method in `A`, and a warning is reported because the declaration does not include a new modifier. *end example*
+> the `F` method in `B` does not include an `override` modifier and therefore does not override the `F` method in `A`. Rather, the `F` method in `B` hides the method in `A`, and a warning is reported because the declaration does not include a new modifier.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -2505,7 +2589,9 @@ Only by including an `override` modifier can a method override another method. I
 > }
 > ```
 >
-> the `F` method in `B` hides the virtual `F` method inherited from `A`. Since the new `F` in `B` has private access, its scope only includes the class body of `B` and does not extend to `C`. Therefore, the declaration of `F` in `C` is permitted to override the `F` inherited from `A`. *end example*
+> the `F` method in `B` hides the virtual `F` method inherited from `A`. Since the new `F` in `B` has private access, its scope only includes the class body of `B` and does not extend to `C`. Therefore, the declaration of `F` in `C` is permitted to override the `F` inherited from `A`.
+>
+> *end example*
 
 ### 14.6.6 Sealed methods
 
@@ -2534,7 +2620,9 @@ When an instance method declaration includes a `sealed` modifier, that method is
 > }
 > ```
 >
-> the class `B` provides two override methods: an `F` method that has the `sealed` modifier and a `G` method that does not. `B`’s use of the `sealed` modifier prevents `C` from further overriding `F`. *end example*
+> the class `B` provides two override methods: an `F` method that has the `sealed` modifier and a `G` method that does not. `B`’s use of the `sealed` modifier prevents `C` from further overriding `F`.
+>
+> *end example*
 
 ### 14.6.7 Abstract methods
 
@@ -2563,7 +2651,9 @@ Abstract method declarations are only permitted in abstract classes ([§14.2.2.2
 > }
 > ```
 >
-> the `Shape` class defines the abstract notion of a geometrical shape object that can paint itself. The `Paint` method is abstract because there is no meaningful default implementation. The `Ellipse` and `Box` classes are concrete `Shape` implementations. Because these classes are non-abstract, they are required to override the `Paint` method and provide an actual implementation. *end example*
+> the `Shape` class defines the abstract notion of a geometrical shape object that can paint itself. The `Paint` method is abstract because there is no meaningful default implementation. The `Ellipse` and `Box` classes are concrete `Shape` implementations. Because these classes are non-abstract, they are required to override the `Paint` method and provide an actual implementation.
+>
+> *end example*
 
 It is a compile-time error for a *base_access* ([§11.7.13](expressions.md#11713-base-access)) to reference an abstract method.
 
@@ -2582,7 +2672,9 @@ It is a compile-time error for a *base_access* ([§11.7.13](expressions.md#11713
 > }
 > ```
 >
-> a compile-time error is reported for the `base.F()` invocation because it references an abstract method. *end example*
+> a compile-time error is reported for the `base.F()` invocation because it references an abstract method.
+>
+> *end example*
 
 An abstract method declaration is permitted to override a virtual method. This allows an abstract class to force re-implementation of the method in derived classes, and makes the original implementation of the method unavailable.
 
@@ -2606,7 +2698,9 @@ An abstract method declaration is permitted to override a virtual method. This a
 > }
 > ```
 >
-> class `A` declares a virtual method, class `B` overrides this method with an abstract method, and class `C` overrides the abstract method to provide its own implementation. *end example*
+> class `A` declares a virtual method, class `B` overrides this method with an abstract method, and class `C` overrides the abstract method to provide its own implementation.
+>
+> *end example*
 
 ### 14.6.8 External methods
 
@@ -2883,7 +2977,9 @@ When the effective return type of a method is not `void` and the method has an e
 > }
 > ```
 >
-> the value-returning `F` method results in a compile-time error because control can flow off the end of the method body. The `G` and `H` methods are correct because all possible execution paths end in a return statement that specifies a return value. The `I` method is correct, because its body is equivalent to a statement block with just a single return statement in it. *end example*
+> the value-returning `F` method results in a compile-time error because control can flow off the end of the method body. The `G` and `H` methods are correct because all possible execution paths end in a return statement that specifies a return value. The `I` method is correct, because its body is equivalent to a statement block with just a single return statement in it.
+>
+> *end example*
 
 ## 14.7 Properties
 
@@ -3050,7 +3146,9 @@ Based on the presence or absence of the get and set accessors, a property is cla
 > string s = okButton.Caption; // Invokes get accessor
 > ```
 >
-> Here, the set accessor is invoked by assigning a value to the property, and the get accessor is invoked by referencing the property in an expression. *end example*
+> Here, the set accessor is invoked by assigning a value to the property, and the get accessor is invoked by referencing the property in an expression.
+>
+> *end example*
 
 The get and set accessors of a property are not distinct members, and it is not possible to declare the accessors of a property separately.
 
@@ -3075,7 +3173,9 @@ The get and set accessors of a property are not distinct members, and it is not 
 > }
 > ```
 >
-> does not declare a single read-write property. Rather, it declares two properties with the same name, one read-only and one write-only. Since two members declared in the same class cannot have the same name, the example causes a compile-time error to occur. *end example*
+> does not declare a single read-write property. Rather, it declares two properties with the same name, one read-only and one write-only. Since two members declared in the same class cannot have the same name, the example causes a compile-time error to occur.
+>
+> *end example*
 
 When a derived class declares a property by the same name as an inherited property, the derived property hides the inherited property with respect to both reading and writing.
 
@@ -3107,7 +3207,9 @@ When a derived class declares a property by the same name as an inherited proper
 > ((A)b).P = 1;  // Ok, reference to A.P
 > ```
 >
-> the assignment to `b.P` causes a compile-time error to be reported, since the read-only `P` property in `B` hides the write-only `P` property in `A`. Note, however, that a cast can be used to access the hidden `P` property. *end example*
+> the assignment to `b.P` causes a compile-time error to be reported, since the read-only `P` property in `B` hides the write-only `P` property in `A`. Note, however, that a cast can be used to access the hidden `P` property.
+>
+> *end example*
 
 Unlike public fields, properties provide a separation between an object’s internal state and its public interface.
 
@@ -3154,7 +3256,9 @@ Unlike public fields, properties provide a separation between an object’s inte
 > }
 > ```
 >
-> Had `x` and `y` instead been `public readonly` fields, it would have been impossible to make such a change to the `Label` class. *end example*
+> Had `x` and `y` instead been `public readonly` fields, it would have been impossible to make such a change to the `Label` class.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -3175,7 +3279,9 @@ Unlike public fields, properties provide a separation between an object’s inte
 >
 > the value of the `Next` property depends on the number of times the property has previously been accessed. Thus, accessing the property produces an observable side effect, and the property should be implemented as a method instead.
 >
-> The “no side-effects” convention for get accessors doesn’t mean that get accessors should always be written simply to return values stored in fields. Indeed, get accessors often compute the value of a property by accessing multiple fields or invoking methods. However, a properly designed get accessor performs no actions that cause observable changes in the state of the object. *end example*
+> The “no side-effects” convention for get accessors doesn’t mean that get accessors should always be written simply to return values stored in fields. Indeed, get accessors often compute the value of a property by accessing multiple fields or invoking methods. However, a properly designed get accessor performs no actions that cause observable changes in the state of the object.
+>
+> *end example*
 
 Properties can be used to delay initialization of a resource until the moment it is first referenced.
 
@@ -3234,7 +3340,9 @@ Properties can be used to delay initialization of a resource until the moment it
 > Console.Out.WriteLine("hello, world");
 > ```
 >
-> the underlying `TextWriter` for the output device is created. However, if the application makes no reference to the `In` and `Error` properties, then no objects are created for those devices. *end example*
+> the underlying `TextWriter` for the output device is created. However, if the application makes no reference to the `In` and `Error` properties, then no objects are created for those devices.
+>
+> *end example*
 
 ### 14.7.4 Automatically implemented properties
 
@@ -3305,7 +3413,9 @@ An auto-property may optionally have a *property_initializer*, which is applied 
 > }
 > ```
 >
-> The assignments to the read-only field are valid, because they occur within the constructor. *end example*
+> The assignments to the read-only field are valid, because they occur within the constructor.
+>
+> *end example*
 
 ### 14.7.5 Accessibility
 
@@ -3460,7 +3570,9 @@ Except for differences in declaration and invocation syntax, virtual, sealed, ov
 > }
 > ```
 >
-> Here, the declarations of `X`, `Y`, and `Z` are overriding property declarations. Each property declaration exactly matches the accessibility modifiers, type, and name of the corresponding inherited property. The get accessor of `X` and the set accessor of `Y` use the base keyword to access the inherited accessors. The declaration of `Z` overrides both abstract accessors—thus, there are no outstanding `abstract` function members in `B`, and `B` is permitted to be a non-abstract class. *end example*
+> Here, the declarations of `X`, `Y`, and `Z` are overriding property declarations. Each property declaration exactly matches the accessibility modifiers, type, and name of the corresponding inherited property. The get accessor of `X` and the set accessor of `Y` use the base keyword to access the inherited accessors. The declaration of `Z` overrides both abstract accessors—thus, there are no outstanding `abstract` function members in `B`, and `B` is permitted to be a non-abstract class.
+>
+> *end example*
 
 When a property is declared as an override, any overridden accessors shall be accessible to the overriding code. In addition, the declared accessibility of both the property or indexer itself, and of the accessors, shall match that of the overridden member and accessors.
 
@@ -3590,7 +3702,9 @@ In an operation of the form `x += y` or `x –= y`, when `x` is an event the
 > }
 > ```
 >
-> Here, the `LoginDialog` instance constructor creates two `Button` instances and attaches event handlers to the `Click` events. *end example*
+> Here, the `LoginDialog` instance constructor creates two `Button` instances and attaches event handlers to the `Click` events.
+>
+> *end example*
 
 ### 14.8.2 Field-like events
 
@@ -3632,7 +3746,9 @@ Within the program text of the class or struct that contains the declaration of 
 > Click –= new EventHandler(...);
 > ```
 >
-> which removes a delegate from the invocation list of the `Click` event. *end example*
+> which removes a delegate from the invocation list of the `Click` event.
+>
+> *end example*
 
 When compiling a field-like event, the compiler automatically creates storage to hold the delegate, and creates accessors for the event that add or remove event handlers to the delegate field. The addition and removal operations are thread safe, and may (but are not required to) be done while holding the lock ([§9.4.4.19](variables.md#94419-lock-statements)) in the containing object for an instance event, or the type `object` ([§11.7.15.7](expressions.md#117157-anonymous-object-creation-expressions)) for a static event.
 
@@ -3728,7 +3844,9 @@ Since an `event` accessor implicitly has a parameter named `value`, it is a comp
 > }
 > ```
 >
-> the `Control` class implements an internal storage mechanism for events. The `AddEventHandler` method associates a delegate value with a key, the `GetEventHandler` method returns the delegate currently associated with a key, and the `RemoveEventHandler` method removes a delegate as an event handler for the specified event. Presumably, the underlying storage mechanism is designed such that there is no cost for associating a null delegate value with a key, and thus unhandled events consume no storage. *end example*
+> the `Control` class implements an internal storage mechanism for events. The `AddEventHandler` method associates a delegate value with a key, the `GetEventHandler` method returns the delegate currently associated with a key, and the `RemoveEventHandler` method removes a delegate as an event handler for the specified event. Presumably, the underlying storage mechanism is designed such that there is no cost for associating a null delegate value with a key, and thus unhandled events consume no storage.
+>
+> *end example*
 
 ### 14.8.4 Static and instance events
 
@@ -3928,7 +4046,9 @@ When an indexer declaration includes an `extern` modifier, the indexer is said t
 >
 > ```
 >
-> Note that the syntax for accessing elements of the `BitArray` is precisely the same as for a `bool[]`. *end example*
+> Note that the syntax for accessing elements of the `BitArray` is precisely the same as for a `bool[]`.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -4098,7 +4218,9 @@ The `true` and `false` unary operators require pair-wise declaration. A compile-
 > }
 > ```
 >
-> Note how the operator method returns the value produced by adding 1 to the operand, just like the postfix increment and decrement operators ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators)), and the prefix increment and decrement operators ([§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators)). Unlike in C++, this method should not modify the value of its operand directly as this would violate the standard semantics of the postfix increment operator ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators)). *end example*
+> Note how the operator method returns the value produced by adding 1 to the operand, just like the postfix increment and decrement operators ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators)), and the prefix increment and decrement operators ([§11.8.6](expressions.md#1186-prefix-increment-and-decrement-operators)). Unlike in C++, this method should not modify the value of its operand directly as this would violate the standard semantics of the postfix increment operator ([§11.7.14](expressions.md#11714-postfix-increment-and-decrement-operators)).
+>
+> *end example*
 
 ### 14.10.3 Binary operators
 
@@ -4149,11 +4271,15 @@ For the purposes of these rules, any type parameters associated with `S` or `T
 > }
 > ```
 >
-> the first two operator declarations are permitted because `T` and `int` and `string`, respectively are considered unique types with no relationship. However, the third operator is an error because `C<T>` is the base class of `D<T>`. *end example*
+> the first two operator declarations are permitted because `T` and `int` and `string`, respectively are considered unique types with no relationship. However, the third operator is an error because `C<T>` is the base class of `D<T>`.
+>
+> *end example*
 
 From the second rule, it follows that a conversion operator shall convert either to or from the class or struct type in which the operator is declared.
 
-> *Example*: It is possible for a class or struct type `C` to define a conversion from `C` to `int` and from `int` to `C`, but not from `int` to `bool`. *end example*
+> *Example*: It is possible for a class or struct type `C` to define a conversion from `C` to `int` and from `int` to `C`, but not from `int` to `bool`.
+>
+> *end example*
 
 It is not possible to directly redefine a pre-defined conversion. Thus, conversion operators are not allowed to convert from or to `object` because implicit and explicit conversions already exist between `object` and all other types. Likewise, neither the source nor the target types of a conversion can be a base type of the other, since a conversion would then already exist. However, it *is* possible to declare operators on generic types that, for particular type arguments, specify conversions that already exist as pre-defined conversions.
 
@@ -4167,7 +4293,9 @@ It is not possible to directly redefine a pre-defined conversion. Thus, conversi
 > }
 > ```
 >
-> when type `object` is specified as a type argument for `T`, the second operator declares a conversion that already exists (an implicit, and therefore also an explicit, conversion exists from any type to type object). *end example*
+> when type `object` is specified as a type argument for `T`, the second operator declares a conversion that already exists (an implicit, and therefore also an explicit, conversion exists from any type to type object).
+>
+> *end example*
 
 In cases where a pre-defined conversion exists between two types, any user-defined conversions between those types are ignored. Specifically:
 
@@ -4234,7 +4362,9 @@ The signature of a conversion operator consists of the source type and the targe
 > }
 > ```
 >
-> the conversion from `Digit` to `byte` is implicit because it never throws exceptions or loses information, but the conversion from `byte` to `Digit` is explicit since `Digit` can only represent a subset of the possible values of a `byte`. *end example*
+> the conversion from `Digit` to `byte` is implicit because it never throws exceptions or loses information, but the conversion from `byte` to `Digit` is explicit since `Digit` can only represent a subset of the possible values of a `byte`.
+>
+> *end example*
 
 ## 14.11 Instance constructors
 
@@ -4601,7 +4731,9 @@ To initialize a new closed class type, first a new set of static fields ([§14.5
 > B.F
 > ```
 >
-> because the execution of `A`’s static constructor is triggered by the call to `A.F`, and the execution of `B`’s static constructor is triggered by the call to `B.F`. *end example*
+> because the execution of `A`’s static constructor is triggered by the call to `A.F`, and the execution of `B`’s static constructor is triggered by the call to `B.F`.
+>
+> *end example*
 
 It is possible to construct circular dependencies that allow static fields with variable initializers to be observed in their default value state.
 
@@ -4638,7 +4770,9 @@ It is possible to construct circular dependencies that allow static fields with 
 > X = 1, Y = 2
 > ```
 >
-> To execute the `Main` method, the system first runs the initializer for `B.Y`, prior to class `B`’s static constructor. `Y`’s initializer causes `A`’s `static` constructor to be run because the value of `A.X` is referenced. The static constructor of `A` in turn proceeds to compute the value of `X`, and in doing so fetches the default value of `Y`, which is zero. `A.X` is thus initialized to 1. The process of running `A`’s static field initializers and static constructor then completes, returning to the calculation of the initial value of `Y`, the result of which becomes 2. *end example*
+> To execute the `Main` method, the system first runs the initializer for `B.Y`, prior to class `B`’s static constructor. `Y`’s initializer causes `A`’s `static` constructor to be run because the value of `A.X` is referenced. The static constructor of `A` in turn proceeds to compute the value of `X`, and in doing so fetches the default value of `Y`, which is zero. `A.X` is thus initialized to 1. The process of running `A`’s static field initializers and static constructor then completes, returning to the calculation of the initial value of `Y`, the result of which becomes 2.
+>
+> *end example*
 
 Because the static constructor is executed exactly once for each closed constructed class type, it is a convenient place to enforce run-time checks on the type parameter that cannot be checked at compile-time via constraints ([§14.2.5](classes.md#1425-type-parameter-constraints)).
 
@@ -4731,7 +4865,9 @@ Finalizers are invoked automatically, and cannot be invoked explicitly. An insta
 > A's finalizer
 > ```
 >
-> since finalizers in an inheritance chain are called in order, from most derived to least derived. *end example*
+> since finalizers in an inheritance chain are called in order, from most derived to least derived.
+>
+> *end example*
 
 Finalizers are implemented by overriding the virtual method `Finalize` on `System.Object`. C# programs are not permitted to override this method or call it (or overrides of it) directly.
 
@@ -4748,7 +4884,9 @@ Finalizers are implemented by overriding the virtual method `Finalize` on `Syste
 > }
 > ```
 >
-> contains two errors. *end example*
+> contains two errors.
+>
+> *end example*
 
 The compiler behaves as if this method, and overrides of it, do not exist at all.
 
@@ -4761,7 +4899,9 @@ The compiler behaves as if this method, and overrides of it, do not exist at all
 > }
 > ```
 >
-> is valid and the method shown hides `System.Object`’s `Finalize` method. *end example*
+> is valid and the method shown hides `System.Object`’s `Finalize` method.
+>
+> *end example*
 
 For a discussion of the behavior when an exception is thrown from a finalizer, see [§20.4](exceptions.md#204-how-exceptions-are-handled).
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3781,8 +3781,8 @@ When compiling a field-like event, the compiler automatically creates storage to
 >     }
 > }
 > ```
-
-Within the class `X`, references to `Ev` on the left-hand side of the `+=` and `–=` operators cause the add and remove accessors to be invoked. All other references to `Ev` are compiled to reference the hidden field `__Ev` instead ([§11.7.6](expressions.md#1176-member-access)). The name “`__Ev`” is arbitrary; the hidden field could have any name or no name at all.
+>
+> Within the class `X`, references to `Ev` on the left-hand side of the `+=` and `–=` operators cause the add and remove accessors to be invoked. All other references to `Ev` are compiled to reference the hidden field `__Ev` instead ([§11.7.6](expressions.md#1176-member-access)). The name “`__Ev`” is arbitrary; the hidden field could have any name or no name at all.
 >
 > *end note*
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -249,7 +249,9 @@ This implicit conversion seemingly violates the advice in the beginning of [§10
 > int i = d;             // Compiles but fails at run-time – no conversion exists
 > ```
 >
-> The assignments to `s2` and `i` both employ implicit dynamic conversions, where the binding of the operations is suspended until run-time. At run-time, implicit conversions are sought from the run-time type of `d`(`string`) to the target type. A conversion is found to `string` but not to `int`. *end example*
+> The assignments to `s2` and `i` both employ implicit dynamic conversions, where the binding of the operations is suspended until run-time. At run-time, implicit conversions are sought from the run-time type of `d`(`string`) to the target type. A conversion is found to `string` but not to `int`.
+>
+> *end example*
 
 ### 10.2.11 Implicit constant expression conversions
 
@@ -371,7 +373,9 @@ The explicit enumeration conversions are:
 
 An explicit enumeration conversion between two types is processed by treating any participating *enum_type* as the underlying type of that *enum_type*, and then performing an implicit or explicit numeric conversion between the resulting types.
 
-> *Example*: Given an *enum_type* `E` with and underlying type of `int`, a conversion from `E` to `byte` is processed as an explicit numeric conversion ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)) from `int` to `byte`, and a conversion from `byte` to `E` is processed as an implicit numeric conversion ([§10.2.3](conversions.md#1023-implicit-numeric-conversions)) from `byte` to `int`. *end example*
+> *Example*: Given an *enum_type* `E` with and underlying type of `int`, a conversion from `E` to `byte` is processed as an explicit numeric conversion ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)) from `int` to `byte`, and a conversion from `byte` to `E` is processed as an implicit numeric conversion ([§10.2.3](conversions.md#1023-implicit-numeric-conversions)) from `byte` to `int`.
+>
+> *end example*
 
 ### 10.3.4 Explicit nullable conversions
 
@@ -478,7 +482,9 @@ If dynamic binding of the conversion is not desired, the expression can be first
 > var c2 = (C)d; // Compiles and user defined conversion succeeds
 > ```
 >
-> The best conversion of `o` to `C` is found at compile-time to be an explicit reference conversion. This fails at run-time, because `"1"` is not in fact a `C`. The conversion of `d` to `C` however, as an explicit dynamic conversion, is suspended to run-time, where a user defined conversion from the run-time type of `d` (`string`) to `C` is found, and succeeds. *end example*
+> The best conversion of `o` to `C` is found at compile-time to be an explicit reference conversion. This fails at run-time, because `"1"` is not in fact a `C`. The conversion of `d` to `C` however, as an explicit dynamic conversion, is suspended to run-time, where a user defined conversion from the run-time type of `d` (`string`) to `C` is found, and succeeds.
+>
+> *end example*
 
 ### 10.3.8 Explicit conversions involving type parameters
 
@@ -529,7 +535,9 @@ The above rules do not permit a direct explicit conversion from an unconstrained
 > }
 > ```
 >
-> This code will now compile but executing `X<int>.F(7)` would then throw an exception at run-time, since a boxed `int` cannot be converted directly to a `long`. *end example*
+> This code will now compile but executing `X<int>.F(7)` would then throw an exception at run-time, since a boxed `int` cannot be converted directly to a `long`.
+>
+> *end example*
 
 ### 10.3.9 User-defined explicit conversions
 
@@ -774,7 +782,9 @@ Specifically, an anonymous function `F` is compatible with a delegate type `D`
 >
 > However, the third assignment is a compile-time error because, when `x` is given type `double`, the result of `x + 1` (of type `double`) is not implicitly convertible to type `int`.
 >
-> The fourth assignment successfully converts the anonymous async function to the delegate type `Func<int, Task<int>>` because the result of `x + 1` (of type `int`) is implicitly convertible to the effective return type `int` of the async lambda, which has a return type `Task<int>`. *end example*
+> The fourth assignment successfully converts the anonymous async function to the delegate type `Func<int, Task<int>>` because the result of `x + 1` (of type `int`) is implicitly convertible to the effective return type `int` of the async lambda, which has a return type `Task<int>`.
+>
+> *end example*
 
 A lambda expression `F` is compatible with an expression tree type `Expression<D>` if `F` is compatible with the delegate type `D`. This does not apply to anonymous methods, only lambda expressions.
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -229,7 +229,9 @@ Boxing a value of a *nullable_value_type* produces a null reference if it is the
 >
 > will output the value 10 on the console because the implicit boxing operation that occurs in the assignment of `p` to `box` causes the value of `p` to be copied. Had `Point` been declared a `class` instead, the value 20 would be output because `p` and `box` would reference the same instance.
 >
-> The analogy of a boxing class should not be used as more than a helpful tool for picturing how boxing works conceptually. There are numerous subtle differences between the behavior described by this specification and the behavior that would result from boxing being implemented in precisely this manner. *end note*
+> The analogy of a boxing class should not be used as more than a helpful tool for picturing how boxing works conceptually. There are numerous subtle differences between the behavior described by this specification and the behavior that would result from boxing being implemented in precisely this manner.
+>
+> *end note*
 
 ### 10.2.10 Implicit dynamic conversions
 
@@ -824,7 +826,9 @@ Not every lambda expression can be converted to expression tree types. The conve
 > - It has the `async` modifier
 > - It contains an assignment operator
 > - It contains an `out` or `ref` parameter
-> - It contains a dynamically bound expression *end note*
+> - It contains a dynamically bound expression
+>
+> *end note*
 
 ## 10.8 Method group conversions
 

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -130,7 +130,7 @@ This definition of consistency allows covariance in return type and contravarian
 > }
 > ```
 >
-> The method `X.F` is compatible with the delegate type `Predicate<int>` and the method `X.G` is compatible with the delegate type `Predicate<string>`. 
+> The method `X.F` is compatible with the delegate type `Predicate<int>` and the method `X.G` is compatible with the delegate type `Predicate<string>`.
 >
 > *end example*
 <!-- markdownlint-disable MD028 -->

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -149,7 +149,9 @@ This definition of consistency allows covariance in return type and contravarian
 >
 > The `Print` method is compatible with the `Action<string>` delegate type because any invocation of an `Action<string>` delegate would also be a valid invocation of the `Print` method.
 >
-> If the signature of the `Print` method above were changed to `Print(object value, bool prependTimestamp = false)` for example, the `Print` method would no longer be compatible with `Action<string>` by the rules of this clause. *end note*
+> If the signature of the `Print` method above were changed to `Print(object value, bool prependTimestamp = false)` for example, the `Print` method would no longer be compatible with `Action<string>` by the rules of this clause.
+>
+> *end note*
 
 ## 19.5 Delegate instantiation
 

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -62,7 +62,9 @@ Delegate types in C# are name equivalent, not structurally equivalent.
 > delegate int D2(int c, double d);
 > ```
 >
-> The delegate types `D1` and `D2` are two different types, so they are not interchangeable, despite their identical signatures. *end example*
+> The delegate types `D1` and `D2` are two different types, so they are not interchangeable, despite their identical signatures.
+>
+> *end example*
 
 Like other generic type declarations, type arguments shall be given to create a constructed delegate type. The parameter types and return type of a constructed delegate type are created by substituting, for each type parameter in the delegate declaration, the corresponding type argument of the constructed delegate type.
 
@@ -110,7 +112,9 @@ This definition of consistency allows covariance in return type and contravarian
 > }
 > ```
 >
-> The methods `A.M1` and `B.M1` are compatible with both the delegate types `D1` and `D2`, since they have the same return type and parameter list. The methods `B.M2`, `B.M3`, and `B.M4` are incompatible with the delegate types `D1` and `D2`, since they have different return types or parameter lists. The methods `B.M5` and `B.M6` are both compatible with delegate type `D3`. *end example*
+> The methods `A.M1` and `B.M1` are compatible with both the delegate types `D1` and `D2`, since they have the same return type and parameter list. The methods `B.M2`, `B.M3`, and `B.M4` are incompatible with the delegate types `D1` and `D2`, since they have different return types or parameter lists. The methods `B.M5` and `B.M6` are both compatible with delegate type `D3`.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -126,7 +130,9 @@ This definition of consistency allows covariance in return type and contravarian
 > }
 > ```
 >
-> The method `X.F` is compatible with the delegate type `Predicate<int>` and the method `X.G` is compatible with the delegate type `Predicate<string>`.  *end example*
+> The method `X.F` is compatible with the delegate type `Predicate<int>` and the method `X.G` is compatible with the delegate type `Predicate<string>`. 
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -229,7 +235,9 @@ Delegates are combined using the binary `+` ([§11.9.5](expressions.md#1195-add
 > When creating a delegate from another delegate with a *delegate_creation_expression* the result has an invocation list with a different structure from the original, but which results in the same methods being invoked in the same order. When `td3` is created from `cd3` its invocation list has just one member, but that member is a list of the methods `M1` and `M2` and those methods are invoked by `td3` in the same order as they are invoked by `cd3`. Similarly when `td4` is instantiated its invocation list has just two entries but it invokes the three methods `M1`, `M2`, and `M1`, in that order just as `cd4` does.
 >
 > The structure of the invocation list affects delegate subtraction. Delegate `cd6`, created by subtracting `cd2` (which invokes `M2`) from `cd4` (which invokes `M1`, `M2`, and `M1`) invokes `M1` and `M1`. However delegate `td6`, created by subtracting `cd2` (which invokes `M2`) from `td4` (which invokes `M1`, `M2`, and `M1`) still invokes `M1`, `M2` and `M1`, in that order, as `M2` is not a single entry in the list but a member of a nested list.
-> For more examples of combining (as well as removing) delegates, see [§19.6](delegates.md#196-delegate-invocation). *end example*
+> For more examples of combining (as well as removing) delegates, see [§19.6](delegates.md#196-delegate-invocation).
+>
+> *end example*
 
 Once instantiated, a delegate instance always refers to the same invocation list.
 

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -15,7 +15,9 @@ An ***enum type*** is a distinct value type ([§8.3](types.md#83-value-types)) t
 > }
 > ```
 >
-> declares an enum type named `Color` with members `Red`, `Green`, and `Blue`. *end example*
+> declares an enum type named `Color` with members `Red`, `Green`, and `Blue`.
+>
+> *end example*
 
 ## 18.2 Enum declarations
 
@@ -58,7 +60,9 @@ An enum declaration that does not explicitly declare an underlying type has an u
 > }
 > ```
 >
-> declares an enum with an underlying type of `long`. *end example*
+> declares an enum with an underlying type of `long`.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -117,7 +121,9 @@ Each enum member has an associated constant value. The type of this value is the
 > }
 > ```
 >
-> results in a compile-time error because the constant values `-1`, `-2`, and `-3` are not in the range of the underlying integral type `uint`. *end example*
+> results in a compile-time error because the constant values `-1`, `-2`, and `-3` are not in the range of the underlying integral type `uint`.
+>
+> *end example*
 
 Multiple enum members may share the same associated value.
 
@@ -133,7 +139,9 @@ Multiple enum members may share the same associated value.
 > }
 > ```
 >
-> shows an enum in which two enum members—`Blue` and `Max`—have the same associated value. *end example*
+> shows an enum in which two enum members—`Blue` and `Max`—have the same associated value.
+>
+> *end example*
 
 The associated value of an enum member is assigned either implicitly or explicitly. If the declaration of the enum member has a *constant_expression* initializer, the value of that constant expression, implicitly converted to the underlying type of the enum, is the associated value of the enum member. If the declaration of the enum member has no initializer, its associated value is set implicitly, as follows:
 
@@ -189,7 +197,9 @@ The associated value of an enum member is assigned either implicitly or explicit
 >
 > - the enum member `Red` is automatically assigned the value zero (since it has no initializer and is the first enum member);
 > - the enum member `Green` is explicitly given the value `10`;
-> - and the enum member `Blue` is automatically assigned the value one greater than the member that textually precedes it. *end example*
+> - and the enum member `Blue` is automatically assigned the value one greater than the member that textually precedes it.
+>
+> *end example*
 
 The associated value of an enum member may not, directly or indirectly, use the value of its own associated enum member. Other than this circularity restriction, enum member initializers may freely refer to other enum member initializers, regardless of their textual position. Within an enum member initializer, values of other enum members are always treated as having the type of their underlying type, so that casts are not necessary when referring to other enum members.
 
@@ -203,7 +213,9 @@ The associated value of an enum member may not, directly or indirectly, use the 
 > }
 > ```
 >
-> results in a compile-time error because the declarations of `A` and `B` are circular. `A` depends on `B` explicitly, and `B` depends on `A` implicitly. *end example*
+> results in a compile-time error because the declarations of `A` and `B` are circular. `A` depends on `B` explicitly, and `B` depends on `A` implicitly.
+>
+> *end example*
 
 Enum members are named and scoped in a manner exactly analogous to fields within classes. The scope of an enum member is the body of its containing enum type. Within that scope, enum members can be referred to by their simple name. From all other code, the name of an enum member shall be qualified with the name of its enum type. Enum members do not have any declared accessibility—an enum member is accessible if its containing enum type is accessible.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -79,7 +79,9 @@ Static binding takes place at compile-time, whereas dynamic binding takes place 
 >
 > The first two calls are statically bound: the overload of `Console.WriteLine` is picked based on the compile-time type of their argument. Thus, the binding-time is *compile-time*.
 >
-> The third call is dynamically bound: the overload of `Console.WriteLine` is picked based on the run-time type of its argument. This happens because the argument is a dynamic expression – its compile-time type is dynamic. Thus, the binding-time for the third call is *run-time*. *end example*
+> The third call is dynamically bound: the overload of `Console.WriteLine` is picked based on the run-time type of its argument. This happens because the argument is a dynamic expression – its compile-time type is dynamic. Thus, the binding-time for the third call is *run-time*.
+>
+> *end example*
 
 ### 11.3.3 Dynamic binding
 
@@ -637,7 +639,9 @@ The array co-variance rules ([§16.6](arrays.md#166-array-covariance)) permit a 
 > }
 > ```
 >
-> the second invocation of `F` causes a `System.ArrayTypeMismatchException` to be thrown because the actual element type of `b` is `string` and not `object`. *end example*
+> the second invocation of `F` causes a `System.ArrayTypeMismatchException` to be thrown because the actual element type of `b` is `string` and not `object`.
+>
+> *end example*
 
 When a function member with a parameter array is invoked in its expanded form with at least one expanded argument, the invocation is processed as if an array creation expression with an array initializer ([§11.7.15.5](expressions.md#117155-array-creation-expressions)) was inserted around the expanded arguments. An empty array is passed when there are no arguments for the parameter array; it is unspecified whether the reference passed is to a newly allocated or existing empty array.
 
@@ -691,7 +695,9 @@ When a generic method is called without specifying type arguments, a ***type inf
 > string s = Chooser.Choose("apple", "banana"); // Calls Choose<string>
 > ```
 >
-> Through type inference, the type arguments `int` and `string` are determined from the arguments to the method. *end example*
+> Through type inference, the type arguments `int` and `string` are determined from the arguments to the method.
+>
+> *end example*
 
 Type inference occurs as part of the binding-time processing of a method invocation ([§11.7.8.2](expressions.md#11782-method-invocations)) and takes place before the overload resolution step of the invocation. When a particular method group is specified in a method invocation, and no type arguments are specified as part of the method invocation, type inference is applied to each generic method in the method group. If type inference succeeds, then the inferred type arguments are used to determine the types of arguments for subsequent overload resolution. If overload resolution chooses a generic method as the one to invoke, then the inferred type arguments are used as the type arguments for the invocation. If type inference for a particular method fails, that method does not participate in overload resolution. The failure of type inference, in and of itself, does not cause a binding-time error. However, it often leads to a binding-time error when overload resolution then fails to find any applicable methods.
 
@@ -893,7 +899,9 @@ The ***inferred return type*** is determined as follows:
 > double seconds = F("1:15:30", s => TimeSpan.Parse(s), t => t.TotalSeconds);
 > ```
 >
-> proceeds as follows: First, the argument “1:15:30” is related to the value parameter, inferring `X` to be string. Then, the parameter of the first anonymous function, `s`, is given the inferred type `string`, and the expression `TimeSpan.Parse(s)` is related to the return type of `f1`, inferring `Y` to be `System.TimeSpan`. Finally, the parameter of the second anonymous function, `t`, is given the inferred type `System.TimeSpan`, and the expression `t.TotalSeconds` is related to the return type of `f2`, inferring `Z` to be `double`. Thus, the result of the invocation is of type `double`. *end example*
+> proceeds as follows: First, the argument “1:15:30” is related to the value parameter, inferring `X` to be string. Then, the parameter of the first anonymous function, `s`, is given the inferred type `string`, and the expression `TimeSpan.Parse(s)` is related to the return type of `f1`, inferring `Y` to be `System.TimeSpan`. Finally, the parameter of the second anonymous function, `t`, is given the inferred type `System.TimeSpan`, and the expression `t.TotalSeconds` is related to the return type of `f2`, inferring `Z` to be `double`. Thus, the result of the invocation is of type `double`.
+>
+> *end example*
 
 #### 11.6.3.14 Type inference for conversion of method groups
 
@@ -1525,7 +1533,9 @@ In a member access of the form `E.I`, if `E` is a single identifier, and if the 
 > }
 > ```
 >
-> Within the `A` class, those occurrences of the Color identifier that reference the Color type are delimited by `**`, and those that reference the Color field are not. *end example*
+> Within the `A` class, those occurrences of the Color identifier that reference the Color type are delimited by `**`, and those that reference the Color field are not.
+>
+> *end example*
 
 ### 11.7.7 Null Conditional Member Access
 
@@ -1762,7 +1772,9 @@ The preceding rules mean that instance methods take precedence over extension me
 > C.H(3)
 > ```
 >
-> `D.G` takes precendece over `C.G`, and `E.F` takes precedence over both `D.F` and `C.F`. *end example*
+> `D.G` takes precendece over `C.G`, and `E.F` takes precedence over both `D.F` and `C.F`.
+>
+> *end example*
 
 #### 11.7.8.4 Delegate invocations
 
@@ -2283,7 +2295,9 @@ The collection object to which a collection initializer is applied shall be of a
 > var contacts = __clist;
 > ```
 >
-> where `__clist`, `__c1` and `__c2` are temporary variables that are otherwise invisible and inaccessible. *end example*
+> where `__clist`, `__c1` and `__c2` are temporary variables that are otherwise invisible and inaccessible.
+>
+> *end example*
 
 #### 11.7.15.5 Array creation expressions
 
@@ -2299,7 +2313,9 @@ array_creation_expression
 
 An array creation expression of the first form allocates an array instance of the type that results from deleting each of the individual expressions from the expression list.
 
-> *Example*: The array creation expression `new int[10,20]` produces an array instance of type `int[,]`, and the array creation expression new `int[10][,]` produces an array instance of type `int[][,]`. *end example*
+> *Example*: The array creation expression `new int[10,20]` produces an array instance of type `int[,]`, and the array creation expression new `int[10][,]` produces an array instance of type `int[][,]`.
+>
+> *end example*
 
 Each expression in the expression list shall be of type `int`, `uint`, `long`, or `ulong`, or implicitly convertible to one or more of these types. The value of each expression determines the length of the corresponding dimension in the newly allocated array instance. Since the length of an array dimension shall be nonnegative, it is a compile-time error to have a constant expression with a negative value, in the expression list.
 
@@ -2380,7 +2396,9 @@ An array creation expression permits instantiation of an array with elements of 
 > var d = new[] { 1, "one", 2, "two" };                   // Error
 > ```
 >
-> The last expression causes a compile-time error because neither `int` nor `string` is implicitly convertible to the other, and so there is no best common type. An explicitly typed array creation expression must be used in this case, for example specifying the type to be `object[]`. Alternatively, one of the elements can be cast to a common base type, which would then become the inferred element type. *end example*
+> The last expression causes a compile-time error because neither `int` nor `string` is implicitly convertible to the other, and so there is no best common type. An explicitly typed array creation expression must be used in this case, for example specifying the type to be `object[]`. Alternatively, one of the elements can be cast to a common base type, which would then become the inferred element type.
+>
+> *end example*
 
 Implicitly typed array creation expressions can be combined with anonymous object initializers ([§11.7.15.7](expressions.md#117157-anonymous-object-creation-expressions)) to create anonymously typed data structures.
 
@@ -2455,7 +2473,9 @@ It is not possible to create a delegate that refers to a property, indexer, user
 > }
 > ```
 >
-> the `A.f` field is initialized with a delegate that refers to the second `Square` method because that method exactly matches the formal parameter list and return type of `DoubleFunc`. Had the second `Square` method not been present, a compile-time error would have occurred. *end example*
+> the `A.f` field is initialized with a delegate that refers to the second `Square` method because that method exactly matches the formal parameter list and return type of `DoubleFunc`. Had the second `Square` method not been present, a compile-time error would have occurred.
+>
+> *end example*
 
 #### 11.7.15.7 Anonymous object creation expressions
 
@@ -2529,7 +2549,9 @@ Within the same program, two anonymous object initializers that specify a sequen
 > p1 = p2;
 > ```
 >
-> the assignment on the last line is permitted because `p1` and `p2` are of the same anonymous type. *end example*
+> the assignment on the last line is permitted because `p1` and `p2` are of the same anonymous type.
+>
+> *end example*
 
 The `Equals` and `GetHashcode` methods on anonymous types override the methods inherited from `object`, and are defined in terms of the `Equals` and `GetHashcode` of the properties, so that two instances of the same anonymous type are equal if and only if all their properties are equal.
 
@@ -2641,7 +2663,9 @@ The `typeof` operator can be used on a type parameter. The result is the `System
 > ```
 >
 > Note that `int` and `System.Int32` are the same type.
-> The result of `typeof(X<>)` does not depend on the type argument but the result of `typeof(X<T>)` does. *end example*
+> The result of `typeof(X<>)` does not depend on the type argument but the result of `typeof(X<T>)` does.
+>
+> *end example*
 
 ### 11.7.17 The sizeof operator
 
@@ -2723,7 +2747,9 @@ The body of an anonymous function is not affected by `checked` or `unchecked` co
 > }
 > ```
 >
-> no compile-time errors are reported since neither of the expressions can be evaluated at compile-time. At run-time, the `F` method throws a `System.OverflowException`, and the `G` method returns –727379968 (the lower 32 bits of the out-of-range result). The behavior of the `H` method depends on the default overflow-checking context for the compilation, but it is either the same as `F` or the same as `G`. *end example*
+> no compile-time errors are reported since neither of the expressions can be evaluated at compile-time. At run-time, the `F` method throws a `System.OverflowException`, and the `G` method returns –727379968 (the lower 32 bits of the out-of-range result). The behavior of the `H` method depends on the default overflow-checking context for the compilation, but it is either the same as `F` or the same as `G`.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -2741,7 +2767,9 @@ The body of an anonymous function is not affected by `checked` or `unchecked` co
 > }
 > ```
 >
-> the overflows that occur when evaluating the constant expressions in `F` and `H` cause compile-time errors to be reported because the expressions are evaluated in a `checked` context. An overflow also occurs when evaluating the constant expression in `G`, but since the evaluation takes place in an `unchecked` context, the overflow is not reported. *end example*
+> the overflows that occur when evaluating the constant expressions in `F` and `H` cause compile-time errors to be reported because the expressions are evaluated in a `checked` context. An overflow also occurs when evaluating the constant expression in `G`, but since the evaluation takes place in an `unchecked` context, the overflow is not reported.
+>
+> *end example*
 
 The `checked` and `unchecked` operators only affect the overflow checking context for those operations that are textually contained within the “`(`” and “`)`” tokens. The operators have no effect on function members that are invoked as a result of evaluating the contained expression.
 
@@ -2756,7 +2784,9 @@ The `checked` and `unchecked` operators only affect the overflow checking contex
 > }
 > ```
 >
-> the use of `checked` in F does not affect the evaluation of `x * y` in `Multiply`, so `x * y` is evaluated in the default overflow checking context. *end example*
+> the use of `checked` in F does not affect the evaluation of `x * y` in `Multiply`, so `x * y` is evaluated in the default overflow checking context.
+>
+> *end example*
 
 The `unchecked` operator is convenient when writing constants of the signed integral types in hexadecimal notation.
 
@@ -2770,7 +2800,9 @@ The `unchecked` operator is convenient when writing constants of the signed inte
 > }
 > ```
 >
-> Both of the hexadecimal constants above are of type `uint`. Because the constants are outside the `int` range, without the `unchecked` operator, the casts to `int` would produce compile-time errors. *end example*
+> Both of the hexadecimal constants above are of type `uint`. Because the constants are outside the `int` range, without the `unchecked` operator, the casts to `int` would produce compile-time errors.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -3047,7 +3079,9 @@ A *cast_expression* of the form `(T)E`, where `T` is a type and `E` is a *unary_
 
 The grammar for a *cast_expression* leads to certain syntactic ambiguities.
 
-> *Example*: The expression `(x)–y` could either be interpreted as a *cast_expression* (a cast of `–y` to type `x`) or as an *additive_expression* combined with a *parenthesized_expression* (which computes the value `x – y`). *end example*
+> *Example*: The expression `(x)–y` could either be interpreted as a *cast_expression* (a cast of `–y` to type `x`) or as an *additive_expression* combined with a *parenthesized_expression* (which computes the value `x – y`).
+>
+> *end example*
 
 To resolve *cast_expression* ambiguities, the following rule exists: A sequence of one or more tokens ([§6.4](lexical-structure.md#64-tokens)) enclosed in parentheses is considered the start of a *cast_expression* only if at least one of the following are true:
 
@@ -3056,7 +3090,9 @@ To resolve *cast_expression* ambiguities, the following rule exists: A sequence 
 
 The term “correct grammar” above means only that the sequence of tokens shall conform to the particular grammatical production. It specifically does not consider the actual meaning of any constituent identifiers.
 
-> *Example*: If `x` and `y` are identifiers, then `x.y` is correct grammar for a type, even if `x.y` doesn’t actually denote a type. *end example*
+> *Example*: If `x` and `y` are identifiers, then `x.y` is correct grammar for a type, even if `x.y` doesn’t actually denote a type.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -3691,7 +3727,9 @@ The predefined addition operators are listed below. For numeric and enumeration 
   > }
   > ```
   >
-  > The output shown in the comments is the typical result on a US-English system. The precise output might depend on the regional settings of the execution environment. The string-concatenation operator itself behaves the same way in each case, but the `ToString` methods implicitly called during execution might be affected by regional settings. *end example*
+  > The output shown in the comments is the typical result on a US-English system. The precise output might depend on the regional settings of the execution environment. The string-concatenation operator itself behaves the same way in each case, but the `ToString` methods implicitly called during execution might be affected by regional settings.
+>
+> *end example*
 
   The result of the string concatenation operator is a `string` that consists of the characters of the left operand followed by the characters of the right operand. The string concatenation operator never returns a `null` value. A `System.OutOfMemoryException` may be thrown if there is not enough memory available to allocate the resulting string.
 - Delegate combination. Every delegate type implicitly provides the following predefined operator, where `D` is the delegate type:
@@ -3940,7 +3978,9 @@ Shift operations never cause overflows and produce the same results in checked a
 
 When the left operand of the `>>` operator is of a signed integral type, the operator performs an *arithmetic* shift right wherein the value of the most significant bit (the sign bit) of the operand is propagated to the high-order empty bit positions. When the left operand of the `>>` operator is of an unsigned integral type, the operator performs a *logical* shift right wherein high-order empty bit positions are always set to zero. To perform the opposite operation of that inferred from the operand type, explicit casts can be used.
 
-> *Example*: If `x` is a variable of type `int`, the operation `unchecked ((int)((uint)x >> y))` performs a logical shift right of `x`. *end example*
+> *Example*: If `x` is a variable of type `int`, the operation `unchecked ((int)((uint)x >> y))` performs a logical shift right of `x`.
+>
+> *end example*
 
 Lifted ([§11.4.8](expressions.md#1148-lifted-operators)) forms of the unlifted predefined shift operators defined above are also predefined.
 
@@ -4055,7 +4095,9 @@ The operators compare the operands according to the rules of the IEC 60559 stand
 
 If either operand is NaN, the result is `false` for all operators except `!=`, for which the result is `true`. For any two operands, `x != y` always produces the same result as `!(x == y)`. However, when one or both operands are NaN, the `<`, `>`, `<=`, and `>=` operators do *not* produce the same results as the logical negation of the opposite operator.
 
-> *Example*: If either of `x` and `y` is NaN, then `x` < `y` is `false`, but `!(x >= y)` is `true`. *end example*
+> *Example*: If either of `x` and `y` is NaN, then `x` < `y` is `false`, but `!(x >= y)` is `true`.
+>
+> *end example*
 
 When neither operand is NaN, the operators compare the values of the two floating-point operands with respect to the ordering
 
@@ -4172,7 +4214,9 @@ Unless one of these conditions is true, a binding-time error occurs.
 > }
 > ```
 >
-> The `x == null` construct is permitted even though `T` could represent a non-nullable value type, and the result is simply defined to be `false` when `T` is a non-nullable value type. *end example*
+> The `x == null` construct is permitted even though `T` could represent a non-nullable value type, and the result is simply defined to be `false` when `T` is a non-nullable value type.
+>
+> *end example*
 
 For an operation of the form `x == y` or `x != y`, if any applicable `operator ==` or `operator !=` exists, the operator overload resolution ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) rules will select that operator instead of the predefined reference type equality operator.
 
@@ -4223,7 +4267,9 @@ For an operation of the form `x == y` or `x != y`, if any applicable `operat
 > }
 > ```
 >
-> outputs `False` because the casts create references to two separate instances of boxed `int` values. *end example*
+> outputs `False` because the casts create references to two separate instances of boxed `int` values.
+>
+> *end example*
 
 ### 11.11.8 String equality operators
 
@@ -4369,7 +4415,9 @@ Note that some conversions, such as user defined conversions, are not possible w
 > }
 > ```
 >
-> the type parameter `T` of `G` is known to be a reference type, because it has the class constraint. The type parameter `U` of `H` is not however; hence the use of the `as` operator in `H` is disallowed. *end example*
+> the type parameter `T` of `G` is known to be a reference type, because it has the class constraint. The type parameter `U` of `H` is not however; hence the use of the `as` operator in `H` is disallowed.
+>
+> *end example*
 
 ## 11.12 Logical operators
 
@@ -4553,7 +4601,9 @@ In a null coalescing expression of the form `a ?? b`, if `a` is non-`null`, th
 
 The null coalescing operator is right-associative, meaning that operations are grouped from right to left.
 
-> *Example*: An expression of the form `a ?? b ?? c` is evaluated as a `?? (b ?? c)`. In general terms, an expression of the form `E1 ?? E2 ?? ... ?? EN` returns the first of the operands that is non-`null`, or `null` if all operands are `null`. *end example*
+> *Example*: An expression of the form `a ?? b ?? c` is evaluated as a `?? (b ?? c)`. In general terms, an expression of the form `E1 ?? E2 ?? ... ?? EN` returns the first of the operands that is non-`null`, or `null` if all operands are `null`.
+>
+> *end example*
 
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
@@ -4581,7 +4631,9 @@ A conditional expression of the form `b ? x : y` first evaluates the conditi
 
 The conditional operator is right-associative, meaning that operations are grouped from right to left.
 
-> *Example*: An expression of the form `a ? b : c ? d : e` is evaluated as `a ? b : (c ? d : e)`. *end example*
+> *Example*: An expression of the form `a ? b : c ? d : e` is evaluated as `a ? b : (c ? d : e)`.
+>
+> *end example*
 
 The first operand of the `?:` operator shall be an expression that can be implicitly converted to `bool`, or an expression of a type that implements `operator true`. If neither of these requirements is satisfied, a compile-time error occurs.
 
@@ -4790,7 +4842,9 @@ Anonymous functions in an argument list participate in type inference and overlo
 >
 > In the first invocation of `orderDetails.Sum`, both `Sum` methods are applicable because the anonymous function `d => d.UnitCount` is compatible with both `Func<Detail,int>` and `Func<Detail,double>`. However, overload resolution picks the first `Sum` method because the conversion to `Func<Detail,int>` is better than the conversion to `Func<Detail,double>`.
 >
-> In the second invocation of `orderDetails.Sum`, only the second `Sum` method is applicable because the anonymous function `d => d.UnitPrice * d.UnitCount` produces a value of type `double`. Thus, overload resolution picks the second `Sum` method for that invocation. *end example*
+> In the second invocation of `orderDetails.Sum`, only the second `Sum` method is applicable because the anonymous function `d => d.UnitPrice * d.UnitCount` produces a value of type `double`. Thus, overload resolution picks the second `Sum` method for that invocation.
+>
+> *end example*
 
 ### 11.16.5 Anonymous functions and dynamic binding
 
@@ -4941,7 +4995,9 @@ When not captured, there is no way to observe exactly how often a local variable
 > 5
 > ```
 >
-> Note that the compiler is permitted (but not required) to optimize the three instantiations into a single delegate instance ([§10.7.2](conversions.md#1072-evaluation-of-anonymous-function-conversions-to-delegate-types)). *end example*
+> Note that the compiler is permitted (but not required) to optimize the three instantiations into a single delegate instance ([§10.7.2](conversions.md#1072-evaluation-of-anonymous-function-conversions-to-delegate-types)).
+>
+> *end example*
 
 If a for-loop declares an iteration variable, that variable itself is considered to be declared outside of the loop.
 
@@ -5525,7 +5581,9 @@ Q
 > Select(x => new { x.c.Name, x.o.OrderID, x.o.Total })
 > ```
 >
-> where `x` is a compiler generated identifier that is otherwise invisible and inaccessible. *end example*
+> where `x` is a compiler generated identifier that is otherwise invisible and inaccessible.
+>
+> *end example*
 
 A `let` expression along with its preceding `from` clause:
 
@@ -5568,7 +5626,9 @@ from * in ( «e» ) . Select ( «x» => new { «x» , «y» = «f» } )
 >     .Select(x => new { x.o.OrderID, Total = x.t })
 > ```
 >
-> where `x` is a compiler generated identifier that is otherwise invisible and inaccessible. *end example*
+> where `x` is a compiler generated identifier that is otherwise invisible and inaccessible.
+>
+> *end example*
 
 A `where` expression along with its preceding `from` clause:
 
@@ -5701,7 +5761,9 @@ from * in ( «e1» ) . GroupJoin(
 >     .Select(y => new { y.x.c.Name, OrderCount = y.n })
 > ```
 >
-> where `x` and `y` are compiler generated identifiers that are otherwise invisible and inaccessible. *end example*
+> where `x` and `y` are compiler generated identifiers that are otherwise invisible and inaccessible.
+>
+> *end example*
 
 An `orderby` clause and its preceding `from` clause:
 
@@ -5993,7 +6055,9 @@ The `+=` and `-=` operators with an event access expression as the left operand
 
 The assignment operators are right-associative, meaning that operations are grouped from right to left.
 
-> *Example*: An expression of the form `a = b = c` is evaluated as `a = (b = c)`. *end example*
+> *Example*: An expression of the form `a = b = c` is evaluated as `a = (b = c)`.
+>
+> *end example*
 
 ### 11.18.2 Simple assignment
 
@@ -6113,7 +6177,9 @@ When a property or indexer declared in a *struct_type* is the target of an assig
 > r.B.Y = 100;
 > ```
 >
-> the assignments are all invalid, since `r.A` and `r.B` are not variables. *end example*
+> the assignments are all invalid, since `r.A` and `r.B` are not variables.
+>
+> *end example*
 
 ### 11.18.3 Compound assignment
 
@@ -6127,7 +6193,9 @@ An operation of the form `x «op»= y` is processed by applying binary operato
 
 The term “evaluated only once” means that in the evaluation of `x «op» y`, the results of any constituent expressions of `x` are temporarily saved and then reused when performing the assignment to `x`.
 
-> *Example*: In the assignment `A()[B()] += C()`, where `A` is a method returning `int[]`, and `B` and `C` are methods returning `int`, the methods are invoked only once, in the order `A`, `B`, `C`. *end example*
+> *Example*: In the assignment `A()[B()] += C()`, where `A` is a method returning `int[]`, and `B` and `C` are methods returning `int`, the methods are invoked only once, in the order `A`, `B`, `C`.
+>
+> *end example*
 
 When the left operand of a compound assignment is a property access or indexer access, the property or indexer shall have both a get accessor and a set accessor. If this is not the case, a binding-time error occurs.
 
@@ -6149,7 +6217,9 @@ The intuitive effect of the rule for predefined operators is simply that `x «op
 > ch += (char)1;    // OK
 > ```
 >
-> the intuitive reason for each error is that a corresponding simple assignment would also have been an error. *end example*
+> the intuitive reason for each error is that a corresponding simple assignment would also have been an error.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -6232,7 +6302,9 @@ The following conversions are permitted in constant expressions:
 > }
 > ```
 >
-> the initialization of `i` is an error because a boxing conversion is required. The initialization of `str` is an error because an implicit reference conversion from a non-`null` value is required. *end example*
+> the initialization of `i` is an error because a boxing conversion is required. The initialization of `str` is an error because an implicit reference conversion from a non-`null` value is required.
+>
+> *end example*
 
 Whenever an expression fulfills the requirements listed above, the expression is evaluated at compile-time. This is true even if the expression is a subexpression of a larger expression that contains non-constant constructs.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3728,8 +3728,8 @@ The predefined addition operators are listed below. For numeric and enumeration 
   > ```
   >
   > The output shown in the comments is the typical result on a US-English system. The precise output might depend on the regional settings of the execution environment. The string-concatenation operator itself behaves the same way in each case, but the `ToString` methods implicitly called during execution might be affected by regional settings.
->
-> *end example*
+  >
+  > *end example*
 
   The result of the string concatenation operator is a `string` that consists of the characters of the left operand followed by the characters of the right operand. The string concatenation operator never returns a `null` value. A `System.OutOfMemoryException` may be thrown if there is not enough memory available to allocate the resulting string.
 - Delegate combination. Every delegate type implicitly provides the following predefined operator, where `D` is the delegate type:

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -922,9 +922,7 @@ The best common type for a set of expressions `E₁...Eᵥ` is determined as fol
 - `X` is *fixed* ([§11.6.3.12](expressions.md#116312-fixing)), if possible, and the resulting type is the best common type.
 - Otherwise inference fails.
 
-> *Note*: Intuitively this inference is equivalent to calling a method
-> `void M<X>(X x₁ ... X xᵥ)`
-> with the `Eᵢ` as arguments and inferring `X`. *end note*
+> *Note*: Intuitively this inference is equivalent to calling a method `void M<X>(X x₁ ... X xᵥ)` with the `Eᵢ` as arguments and inferring `X`. *end note*
 
 ### 11.6.4 Overload resolution
 
@@ -1575,7 +1573,9 @@ A  *null_conditional_member_access* expression `E` is of the form `P?.A`. Let `T
 > P?.A₀?.A₁
 > ```
 >
-> then if `P` evaluates to `null` neither `A₀` or `A₁` are evaluated. The same is true if an expression is a sequence of *null_conditional_member_access* or *null_conditional_element_access* [§11.7.11](expressions.md#11711-null-conditional-element-access) operations. *end note*
+> then if `P` evaluates to `null` neither `A₀` or `A₁` are evaluated. The same is true if an expression is a sequence of *null_conditional_member_access* or *null_conditional_element_access* [§11.7.11](expressions.md#11711-null-conditional-element-access) operations.
+>
+> *end note*
 
 A *null_conditional_projection_initializer* is a restriction of *null_conditional_member_access* and has the same semantics. It only occurs as a projection initializer in an anonymous object creation expression ([§11.7.15.7](expressions.md#117157-anonymous-object-creation-expressions)).
 
@@ -1909,7 +1909,9 @@ A *null_conditional_element_access* expression `E` is of the form `P?[A]B`; wher
 > P?[A₀]?[A₁]
 > ```
 >
-> if `P` evaluates to `null` neither `A₀` or `A₁` are evaluated. The same is true if an expression is a sequence of *null_conditional_element_access* or *null_conditional_member_access* [§11.7.7](expressions.md#1177-null-conditional-member-access) operations. *end note*
+> if `P` evaluates to `null` neither `A₀` or `A₁` are evaluated. The same is true if an expression is a sequence of *null_conditional_element_access* or *null_conditional_member_access* [§11.7.7](expressions.md#1177-null-conditional-member-access) operations.
+>
+> *end note*
 
 ### 11.7.12 This access
 
@@ -2363,7 +2365,9 @@ An array creation expression permits instantiation of an array with elements of 
 > int[,] = new int[100, 5];
 > ```
 >
-> creates only a single object, a two-dimensional array, and accomplishes the allocation in a single statement. *end note*
+> creates only a single object, a two-dimensional array, and accomplishes the allocation in a single statement.
+>
+> *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -4146,7 +4150,9 @@ Unless one of these conditions is true, a binding-time error occurs.
 > - The predefined reference type equality operators do not permit value type operands to be compared (except when type parameters are compared to `null`, which is handled specially).
 > - Operands of predefined reference type equality operators are never boxed. It would be meaningless to perform such boxing operations, since references to the newly allocated boxed instances would necessarily differ from all other references.
 >
-> For an operation of the form `x == y` or `x != y`, if any applicable user-defined `operator ==` or `operator !=` exists, the operator overload resolution rules ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) will select that operator instead of the predefined reference type equality operator. It is always possible to select the predefined reference type equality operator by explicitly casting one or both of the operands to type `object`. *end note*
+> For an operation of the form `x == y` or `x != y`, if any applicable user-defined `operator ==` or `operator !=` exists, the operator overload resolution rules ([§11.4.5](expressions.md#1145-binary-operator-overload-resolution)) will select that operator instead of the predefined reference type equality operator. It is always possible to select the predefined reference type equality operator by explicitly casting one or both of the operands to type `object`.
+>
+> *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -4310,7 +4316,9 @@ User defined conversions are not considered by the `is` operator.
 >   - Otherwise, the result of the operation is equivalent to evaluating `E != null`.
 > - Otherwise, if an explicit reference conversion ([§10.3.5](conversions.md#1035-explicit-reference-conversions)) or unboxing conversion ([§10.3.6](conversions.md#1036-unboxing-conversions)) exists from `C` to `T`, or if `C` or `T` is an open type ([§8.4.3](types.md#843-open-and-closed-types)), then runtime checks as above must be peformed.
 > - Otherwise, no reference, boxing, wrapping, or unwrapping conversion of `E` to type `T` is possible, and the result of the operation is `false`.
-> A compiler may implement optimisations based on the compile-time type. *end note*
+> A compiler may implement optimisations based on the compile-time type.
+>
+> *end note*
 
 ### 11.11.12 The as operator
 
@@ -6025,7 +6033,9 @@ The run-time processing of a simple assignment of the form `x` = `y` consists 
 > oa[2] = new ArrayList();   // ArrayTypeMismatchException
 > ```
 >
-> the last assignment causes a `System.ArrayTypeMismatchException` to be thrown because a reference to an `ArrayList` cannot be stored in an element of a `string[]`. *end note*
+> the last assignment causes a `System.ArrayTypeMismatchException` to be thrown because a reference to an `ArrayList` cannot be stored in an element of a `string[]`.
+>
+> *end note*
 
 When a property or indexer declared in a *struct_type* is the target of an assignment, the instance expression associated with the property or indexer access shall be classified as a variable. If the instance expression is classified as a value, a binding-time error occurs.
 

--- a/standard/general-description.md
+++ b/standard/general-description.md
@@ -14,6 +14,6 @@ Informative text is indicated in the following ways:
 
 1. Whole or partial clauses or annexes delimited by “**This clause/text is informative**” and “**End of informative text**”.
 1. *Example*: The following example … code fragment, possibly with some narrative … *end example*
-1. *Note*: narrative … *end note*
+1. *Note*: narrative … *end note*  The *Note*: and *end note* are in the same paragraph for single paragraph notes. If a note spans multiple paragraphs, the *end note* marker should be its own paragraph.
 
 All text not marked as being informative is normative.

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -87,7 +87,9 @@ If the variance annotation is `out`, the type parameter is said to be ***covaria
 > }
 > ```
 >
-> `X` is covariant, `Y` is contravariant and `Z` is invariant. *end example*
+> `X` is covariant, `Y` is contravariant and `Z` is invariant.
+>
+> *end example*
 
 If a generic interface is declared in multiple parts ([§14.2.3](classes.md#1423-type-parameters)), each partial declaration shall specify the same variance for each type parameter.
 
@@ -168,7 +170,9 @@ The ***base interfaces*** of an interface are the explicit base interfaces and t
 > interface IComboBox: ITextBox, IListBox {}
 > ```
 >
-> the base interfaces of `IComboBox` are `IControl`, `ITextBox`, and `IListBox`. In other words, the `IComboBox` interface above inherits members `SetText` and `SetItems` as well as `Paint`. *end example*
+> the base interfaces of `IComboBox` are `IControl`, `ITextBox`, and `IListBox`. In other words, the `IComboBox` interface above inherits members `SetText` and `SetItems` as well as `Paint`.
+>
+> *end example*
 
 Members inherited from a constructed generic type are inherited after type substitution. That is, any constituent types in the member have the base class declaration’s type parameters replaced with the corresponding type arguments used in the *class_base* specification.
 
@@ -186,7 +190,9 @@ Members inherited from a constructed generic type are inherited after type subst
 > }
 > ```
 >
-> the interface IDerived inherits the Combine method after the type parameter `T` is replaced with `string[,]`. *end example*
+> the interface IDerived inherits the Combine method after the type parameter `T` is replaced with `string[,]`.
+>
+> *end example*
 
 A class or struct that implements an interface also implicitly implements all of the interface’s base interfaces.
 
@@ -289,7 +295,9 @@ These rules ensure that any covariant or contravariant usage of the interface re
 > b.M<E>();
 > ```
 >
-> This is actually a call to `C.M<E>`. But that call requires that `E` derive from `D`, so type safety would be violated here. *end example*
+> This is actually a call to `C.M<E>`. But that call requires that `E` derive from `D`, so type safety would be violated here.
+>
+> *end example*
 
 ### 17.4.3 Interface properties
 
@@ -383,7 +391,9 @@ For interfaces that are strictly single-inheritance (each interface in the inher
 > }
 > ```
 >
-> the first two statements cause compile-time errors because the member lookup ([§11.5](expressions.md#115-member-lookup)) of `Count` in `IListCounter` is ambiguous. As illustrated by the example, the ambiguity is resolved by casting `x` to the appropriate base interface type. Such casts have no run-time costs—they merely consist of viewing the instance as a less derived type at compile-time. *end example*
+> the first two statements cause compile-time errors because the member lookup ([§11.5](expressions.md#115-member-lookup)) of `Count` in `IListCounter` is ambiguous. As illustrated by the example, the ambiguity is resolved by casting `x` to the appropriate base interface type. Such casts have no run-time costs—they merely consist of viewing the instance as a less derived type at compile-time.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -414,7 +424,9 @@ For interfaces that are strictly single-inheritance (each interface in the inher
 > }
 > ```
 >
-> the invocation `n.Add(1)` selects `IInteger.Add` by applying overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). Similarly, the invocation `n.Add(1.0)` selects `IDouble.Add`. When explicit casts are inserted, there is only one candidate method, and thus no ambiguity. *end example*
+> the invocation `n.Add(1)` selects `IInteger.Add` by applying overload resolution rules of [§11.6.4](expressions.md#1164-overload-resolution). Similarly, the invocation `n.Add(1.0)` selects `IDouble.Add`. When explicit casts are inserted, there is only one candidate method, and thus no ambiguity.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -452,7 +464,9 @@ For interfaces that are strictly single-inheritance (each interface in the inher
 >
 > the `IBase.F` member is hidden by the `ILeft.F` member. The invocation `d.F(1)` thus selects `ILeft.F`, even though `IBase.F` appears to not be hidden in the access path that leads through `IRight`.
 >
-> The intuitive rule for hiding in multiple-inheritance interfaces is simply this: If a member is hidden in any access path, it is hidden in all access paths. Because the access path from `IDerived` to `ILeft` to `IBase` hides `IBase.F`, the member is also hidden in the access path from `IDerived` to `IRight` to `IBase`. *end example*
+> The intuitive rule for hiding in multiple-inheritance interfaces is simply this: If a member is hidden in any access path, it is hidden in all access paths. Because the access path from `IDerived` to `ILeft` to `IBase` hides `IBase.F`, the member is also hidden in the access path from `IDerived` to `IRight` to `IBase`.
+>
+> *end example*
 
 ## 17.5 Qualified interface member names
 
@@ -472,7 +486,9 @@ An interface member is sometimes referred to by its ***qualified interface membe
 > }
 > ```
 >
-> the qualified name of `Paint` is `IControl.Paint` and the qualified name of SetText is `ITextBox.SetText`. In the example above, it is not possible to refer to `Paint` as `ITextBox.Paint`. *end example*
+> the qualified name of `Paint` is `IControl.Paint` and the qualified name of SetText is `ITextBox.SetText`. In the example above, it is not possible to refer to `Paint` as `ITextBox.Paint`.
+>
+> *end example*
 
 When an interface is part of a namespace, a qualified interface member name can include the namespace name.
 
@@ -488,7 +504,9 @@ When an interface is part of a namespace, a qualified interface member name can 
 > }
 > ```
 >
-> Within the `System` namespace, both `ICloneable.Clone` and `System.ICloneable.Clone` are qualified interface member names for the `Clone` method. *end example*
+> Within the `System` namespace, both `ICloneable.Clone` and `System.ICloneable.Clone` are qualified interface member names for the `Clone` method.
+>
+> *end example*
 
 ## 17.6 Interface implementations
 
@@ -540,7 +558,9 @@ A class or struct that directly implements an interface also implicitly implemen
 > }
 > ```
 >
-> Here, class `TextBox` implements both `IControl` and `ITextBox`. *end example*
+> Here, class `TextBox` implements both `IControl` and `ITextBox`.
+>
+> *end example*
 
 When a class `C` directly implements an interface, all classes derived from `C` also implement the interface implicitly.
 
@@ -585,7 +605,9 @@ For purposes of implementing interfaces, a class or struct may declare ***explic
 > }
 > ```
 >
-> Here `IDictionary<int,T>.this` and `IDictionary<int,T>.Add` are explicit interface member implementations. *end example*
+> Here `IDictionary<int,T>.this` and `IDictionary<int,T>.Add` are explicit interface member implementations.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -651,7 +673,9 @@ For an explicit interface member implementation to be valid, the class or struct
 > }
 > ```
 >
-> the declaration of `ICloneable.Clone` in `Ellipse` results in a compile-time error because `ICloneable` is not explicitly listed in the base class list of `Ellipse`. *end example*
+> the declaration of `ICloneable.Clone` in `Ellipse` results in a compile-time error because `ICloneable` is not explicitly listed in the base class list of `Ellipse`.
+>
+> *end example*
 
 The qualified interface member name of an explicit interface member implementation shall reference the interface in which the member was declared.
 
@@ -675,7 +699,9 @@ The qualified interface member name of an explicit interface member implementati
 > }
 > ```
 >
-> the explicit interface member implementation of Paint must be written as `IControl.Paint`, not `ITextBox.Paint`. *end example*
+> the explicit interface member implementation of Paint must be written as `IControl.Paint`, not `ITextBox.Paint`.
+>
+> *end example*
 
 ### 17.6.3 Uniqueness of implemented interfaces
 
@@ -846,7 +872,9 @@ Notable implications of the interface-mapping algorithm are:
 > }
 > ```
 >
-> the `ICloneable.Clone` member of `C` becomes the implementation of `Clone` in ‘ICloneable’ because explicit interface member implementations take precedence over other members. *end example*
+> the `ICloneable.Clone` member of `C` becomes the implementation of `Clone` in ‘ICloneable’ because explicit interface member implementations take precedence over other members.
+>
+> *end example*
 
 If a class or struct implements two or more interfaces containing a member with the same name, type, and parameter types, it is possible to map each of those interface members onto a single class or struct member.
 
@@ -869,7 +897,9 @@ If a class or struct implements two or more interfaces containing a member with 
 > }
 > ```
 >
-> Here, the `Paint` methods of both `IControl` and `IForm` are mapped onto the `Paint` method in `Page`. It is of course also possible to have separate explicit interface member implementations for the two methods. *end example*
+> Here, the `Paint` methods of both `IControl` and `IForm` are mapped onto the `Paint` method in `Page`. It is of course also possible to have separate explicit interface member implementations for the two methods.
+>
+> *end example*
 
 If a class or struct implements an interface that contains hidden members, then some members may need to be implemented through explicit interface member implementations.
 
@@ -937,7 +967,9 @@ When a class implements multiple interfaces that have the same base interface, t
 > }
 > ```
 >
-> it is not possible to have separate implementations for the `IControl` named in the base class list, the `IControl` inherited by `ITextBox`, and the `IControl` inherited by `IListBox`. Indeed, there is no notion of a separate identity for these interfaces. Rather, the implementations of `ITextBox`and `IListBox` share the same implementation of `IControl`, and `ComboBox` is simply considered to implement three interfaces, `IControl`, `ITextBox`, and `IListBox`. *end example*
+> it is not possible to have separate implementations for the `IControl` named in the base class list, the `IControl` inherited by `ITextBox`, and the `IControl` inherited by `IListBox`. Indeed, there is no notion of a separate identity for these interfaces. Rather, the implementations of `ITextBox`and `IListBox` share the same implementation of `IControl`, and `ComboBox` is simply considered to implement three interfaces, `IControl`, `ITextBox`, and `IListBox`.
+>
+> *end example*
 
 The members of a base class participate in interface mapping.
 
@@ -961,7 +993,9 @@ The members of a base class participate in interface mapping.
 > }
 > ```
 >
-> the method `F` in `Class1` is used in `Class2's` implementation of `Interface1`. *end example*
+> the method `F` in `Class1` is used in `Class2's` implementation of `Interface1`.
+>
+> *end example*
 
 ### 17.6.6 Interface implementation inheritance
 
@@ -1061,7 +1095,9 @@ Since explicit interface member implementations cannot be declared virtual, it i
 > }
 > ```
 
-Here, classes derived from `Control` can specialize the implementation of `IControl.Paint` by overriding the `PaintControl` method. *end example*
+Here, classes derived from `Control` can specialize the implementation of `IControl.Paint` by overriding the `PaintControl` method.
+>
+> *end example*
 
 ### 17.6.7 Interface re-implementation
 
@@ -1088,7 +1124,9 @@ A re-implementation of an interface follows exactly the same interface mapping r
 > }
 > ```
 >
-> the fact that `Control` maps `IControl.Paint` onto `Control.IControl.Paint` doesn’t affect the re-implementation in `MyControl`, which maps `IControl.Paint` onto `MyControl.Paint`. *end example*
+> the fact that `Control` maps `IControl.Paint` onto `Control.IControl.Paint` doesn’t affect the re-implementation in `MyControl`, which maps `IControl.Paint` onto `MyControl.Paint`.
+>
+> *end example*
 
 Inherited public member declarations and inherited explicit interface member declarations participate in the interface mapping process for re-implemented interfaces.
 
@@ -1118,7 +1156,9 @@ Inherited public member declarations and inherited explicit interface member dec
 > }
 > ```
 >
-> Here, the implementation of `IMethods` in `Derived` maps the interface methods onto `Derived.F`, `Base.IMethods.G`, `Derived.IMethods.H`, and `Base.I`. *end example*
+> Here, the implementation of `IMethods` in `Derived` maps the interface methods onto `Derived.F`, `Base.IMethods.G`, `Derived.IMethods.H`, and `Base.I`.
+>
+> *end example*
 
 When a class implements an interface, it implicitly also implements all that interface’s base interfaces. Likewise, a re-implementation of an interface is also implicitly a re-implementation of all of the interface’s base interfaces.
 
@@ -1148,7 +1188,9 @@ When a class implements an interface, it implicitly also implements all that int
 > }
 > ```
 >
-> Here, the re-implementation of `IDerived` also re-implements `IBase`, mapping `IBase.F` onto `D.F`. *end example*
+> Here, the re-implementation of `IDerived` also re-implements `IBase`, mapping `IBase.F` onto `D.F`.
+>
+> *end example*
 
 ### 17.6.8 Abstract classes and interfaces
 
@@ -1170,7 +1212,9 @@ Like a non-abstract class, an abstract class shall provide implementations of al
 >     }
 > ```
 >
-> Here, the implementation of `IMethods` maps `F` and `G` onto abstract methods, which shall be overridden in non-abstract classes that derive from `C`. *end example*
+> Here, the implementation of `IMethods` maps `F` and `G` onto abstract methods, which shall be overridden in non-abstract classes that derive from `C`.
+>
+> *end example*
 
 Explicit interface member implementations cannot be abstract, but explicit interface member implementations are of course permitted to call abstract methods.
 
@@ -1192,4 +1236,6 @@ Explicit interface member implementations cannot be abstract, but explicit inter
 > }
 > ```
 >
-> Here, non-abstract classes that derive from `C` would be required to override `FF` and `GG`, thus providing the actual implementation of `IMethods`. *end example*
+> Here, non-abstract classes that derive from `C` would be required to override `FF` and `GG`, thus providing the actual implementation of `IMethods`.
+>
+> *end example*

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -1094,8 +1094,8 @@ Since explicit interface member implementations cannot be declared virtual, it i
 >     protected override void PaintControl() {...}
 > }
 > ```
-
-Here, classes derived from `Control` can specialize the implementation of `IControl.Paint` by overriding the `PaintControl` method.
+>
+> Here, classes derived from `Control` can specialize the implementation of `IControl.Paint` by overriding the `PaintControl` method.
 >
 > *end example*
 

--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -621,7 +621,9 @@ It is a compile-time error for an explicit interface method implementation to in
 > Explicit interface member implementations serve two primary purposes:
 >
 > - Because explicit interface member implementations are not accessible through class or struct instances, they allow interface implementations to be excluded from the public interface of a class or struct. This is particularly useful when a class or struct implements an internal interface that is of no interest to a consumer of that class or struct.
-> - Explicit interface member implementations allow disambiguation of interface members with the same signature. Without explicit interface member implementations it would be impossible for a class or struct to have different implementations of interface members with the same signature and return type, as would it be impossible for a class or struct to have any implementation at all of interface members with the same signature but with different return types. *end note*
+> - Explicit interface member implementations allow disambiguation of interface members with the same signature. Without explicit interface member implementations it would be impossible for a class or struct to have different implementations of interface members with the same signature and return type, as would it be impossible for a class or struct to have any implementation at all of interface members with the same signature but with different return types.
+>
+> *end note*
 
 For an explicit interface member implementation to be valid, the class or struct shall name an interface in its base class list that contains a member whose qualified interface member name, type, number of type parameters, and parameter types exactly match those of the explicit interface member implementation. If an interface function member has a parameter array, the corresponding parameter of an associated explicit interface member implementation is allowed, but not required, to have the `params` modifier. If the interface function member does not have a parameter array then an associated explicit interface member implementation shall not have a parameter array.
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -462,7 +462,9 @@ fragment Formatting_Character
 >   - ANTLR considers these implicit rules before the explicit lexical rules in the grammar.
 >   - Therefore fragment *Available_Identifier* will not match keywords or contextual keywords as the lexical rules for those precede it.
 > - Fragment *Escaped_Identifier* includes escaped keywords and contextual keywords as they are part of the longer token starting with an `@` and lexical processing always forms the longest possible lexical element ([§6.3.1](lexical-structure.md#631-general)).
-> - How an implementation enforces the restrictions on the allowable *Unicode_Escape_Sequence* values is an implementation issue. *end note*
+> - How an implementation enforces the restrictions on the allowable *Unicode_Escape_Sequence* values is an implementation issue.
+>
+> *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -730,7 +732,9 @@ fragment Hexadecimal_Escape_Sequence
 > string bad = "x9Bad text";
 > ```
 >
-> it might appear at first that the leading character is the same (`U+0009`, a tab character) in both strings. In fact the second string starts with `U+9BAD` as all three letters in the word “Bad” are valid hexadecimal digits. As a matter of style, it is recommended that `\x` is avoided in favour of either specific escape sequences (`\t` in this example) or the fixed-length `\u` escape sequence. *end note*
+> it might appear at first that the leading character is the same (`U+0009`, a tab character) in both strings. In fact the second string starts with `U+9BAD` as all three letters in the word “Bad” are valid hexadecimal digits. As a matter of style, it is recommended that `\x` is avoided in favour of either specific escape sequences (`\t` in this example) or the fixed-length `\u` escape sequence.
+>
+> *end note*
 
 A hexadecimal escape sequence represents a single Unicode UTF-16 code unit, with the value formed by the hexadecimal number following “`\x`”.
 
@@ -939,7 +943,9 @@ fragment PP_New_Line
 > *Note*:
 >
 > - The pre-processor grammar defines a single lexical token `PP_Directive` used for all pre-processing directives. The semantics of each of the pre-processing directives are defined in this language specification but not how to implement them.
-> - The `PP_Start` fragment must only be recognised at the start of a line, the `getCharPositionInLine() == 0` ANTLR lexical predicate above suggests one way in which this may be achieved and is informative *only*, an implementation may use a different strategy. *end note*
+> - The `PP_Start` fragment must only be recognised at the start of a line, the `getCharPositionInLine() == 0` ANTLR lexical predicate above suggests one way in which this may be achieved and is informative *only*, an implementation may use a different strategy.
+>
+> *end note*
 
 The following pre-processing directives are available:
 
@@ -1380,7 +1386,9 @@ The `#pragma` preprocessing directive is used to specify contextual information 
 >
 > - Enable or disable particular warning messages when compiling subsequent code.
 > - Specify which optimizations to apply to subsequent code.
-> - Specify information to be used by a debugger. *end note*
+> - Specify information to be used by a debugger.
+>
+> *end note*
 
 ```ANTLR
 fragment PP_Pragma

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -60,7 +60,9 @@ The productions for *simple_name* ([§11.7.4](expressions.md#1174-simple-names))
 > F(G<A, B>(7));
 > ```
 >
-> could be interpreted as a call to `F` with two arguments, `G < A` and `B > (7)`. Alternatively, it could be interpreted as a call to `F` with one argument, which is a call to a generic method `G` with two type arguments and one regular argument. *end example*
+> could be interpreted as a call to `F` with two arguments, `G < A` and `B > (7)`. Alternatively, it could be interpreted as a call to `F` with one argument, which is a call to a generic method `G` with two type arguments and one regular argument.
+>
+> *end example*
 
 If a sequence of tokens can be parsed (in context) as a *simple_name* ([§11.7.4](expressions.md#1174-simple-names)), *member_access* ([§11.7.6](expressions.md#1176-member-access)), or *pointer_member_access* ([§22.6.3](unsafe-code.md#2263-pointer-member-access)) ending with a *type_argument_list* ([§8.4.2](types.md#842-type-arguments)), the token immediately following the closing `>` token is examined. If it is one of
 
@@ -99,7 +101,9 @@ then the *type_argument_list* is retained as part of the *simple_name*, *member_
 > x = y is C<T> && z;
 > ```
 >
-> the tokens `C<T>` are interpreted as a *namespace_or_type_name* with a *type_argument_list* due to being on the right-hand side of the `is` operator ([§11.11.1](expressions.md#11111-general)). Because `C<T>` parses as a *namespace_or_type_name*, not a *simple_name*, *member_access*, or *pointer_member_access*, the above rule does not apply, and it is considered to have a *type_argument_list* regardless of the token that follows. *end example*
+> the tokens `C<T>` are interpreted as a *namespace_or_type_name* with a *type_argument_list* due to being on the right-hand side of the `is` operator ([§11.11.1](expressions.md#11111-general)). Because `C<T>` parses as a *namespace_or_type_name*, not a *simple_name*, *member_access*, or *pointer_member_access*, the above rule does not apply, and it is considered to have a *type_argument_list* regardless of the token that follows.
+>
+> *end example*
 
 ## 6.3 Lexical analysis
 
@@ -151,7 +155,9 @@ The lexical processing of a C# compilation unit consists of reducing the file i
 
 When several lexical grammar productions match a sequence of characters in a compilation unit, the lexical processing always forms the longest possible lexical element.
 
-> *Example*: The character sequence `//` is processed as the beginning of a single-line comment because that lexical element is longer than a single `/` token. *end example*
+> *Example*: The character sequence `//` is processed as the beginning of a single-line comment because that lexical element is longer than a single `/` token.
+>
+> *end example*
 
 Some tokens are defined by a set of lexical rules; a main rule and one or more sub-rules. The latter are marked in the grammar by `fragment` to indicate the rule defines part of another token. Fragment rules are not considered in the top-to-bottom ordering of lexical rules.
 
@@ -196,7 +202,9 @@ A ***delimited comment*** begins with the characters `/*` and ends with the cha
 > }
 > ```
 >
-> includes a delimited comment. *end example*
+> includes a delimited comment.
+>
+> *end example*
 
 A ***single-line comment*** begins with the characters `//` and extends to the end of the line.
 
@@ -215,7 +223,9 @@ A ***single-line comment*** begins with the characters `//` and extends to the 
 > }
 > ```
 >
-> shows several single-line comments. *end example*
+> shows several single-line comments.
+>
+> *end example*
 
 ```ANTLR
 Comment
@@ -505,7 +515,9 @@ The prefix “`@`” enables the use of keywords as identifiers, which is usefu
 > }
 > ```
 >
-> defines a class named “`class`” with a static method named “`static`” that takes a parameter named “`bool`”. Note that since Unicode escapes are not permitted in keywords, the token “`cl\u0061ss`” is an identifier, and is the same identifier as “`@class`”. *end example*
+> defines a class named “`class`” with a static method named “`static`” that takes a parameter named “`bool`”. Note that since Unicode escapes are not permitted in keywords, the token “`cl\u0061ss`” is an identifier, and is the same identifier as “`@class`”.
+>
+> *end example*
 
 Two identifiers are considered the same if they are identical after the following transformations are applied, in order:
 
@@ -826,7 +838,9 @@ fragment Quote_Escape_Sequence
 > three";
 > ```
 >
-> shows a variety of string literals. The last string literal, `j`, is a verbatim string literal that spans multiple lines. The characters between the quotation marks, including white space such as new line characters, are preserved verbatim, and each pair of double-quote characters is replaced by one such character. *end example*
+> shows a variety of string literals. The last string literal, `j`, is a verbatim string literal that spans multiple lines. The characters between the quotation marks, including white space such as new line characters, are preserved verbatim, and each pair of double-quote characters is replaced by one such character.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -854,7 +868,9 @@ Each string literal does not necessarily result in a new string instance. When t
 > }
 > ```
 >
-> is `True` because the two literals refer to the same string instance. *end example*
+> is `True` because the two literals refer to the same string instance.
+>
+> *end example*
 
 #### 6.4.5.7 The null literal
 
@@ -992,7 +1008,9 @@ Pre-processing directives are not part of the syntactic grammar of C#. However,
 > }
 > ```
 >
-> Thus, whereas lexically, the two programs are quite different, syntactically, they are identical. *end example*
+> Thus, whereas lexically, the two programs are quite different, syntactically, they are identical.
+>
+> *end example*
 
 ### 6.5.2 Conditional compilation symbols
 
@@ -1085,7 +1103,9 @@ Any `#define` and `#undef` directives in a compilation unit shall occur before t
 > }
 > ```
 >
-> is valid because the `#define` directives precede the first token (the `namespace` keyword) in the compilation unit. *end example*
+> is valid because the `#define` directives precede the first token (the `namespace` keyword) in the compilation unit.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -1113,7 +1133,9 @@ A `#define` may define a conditional compilation symbol that is already defined,
 > #define A
 > ```
 >
-> For compilers that allow conditional compilation symbols to be defined as compilation options, an alternative way for such redefinition to occur is to define the symbol as a compiler option as well as in the source. *end example*
+> For compilers that allow conditional compilation symbols to be defined as compilation options, an alternative way for such redefinition to occur is to define the symbol as a compiler option as well as in the source.
+>
+> *end example*
 
 A `#undef` may “undefine” a conditional compilation symbol that is not defined.
 
@@ -1275,7 +1297,9 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 > #endif
 > ```
 >
-> always produces the same token stream (`class` `Q` `{` `}`), regardless of whether or not `X` is defined. If `X` is defined, the only processed directives are `#if` and `#endif`, due to the multi-line comment. If `X` is undefined, then three directives (`#if`, `#else`, `#endif`) are part of the directive set. *end example*
+> always produces the same token stream (`class` `Q` `{` `}`), regardless of whether or not `X` is defined. If `X` is defined, the only processed directives are `#if` and `#endif`, due to the multi-line comment. If `X` is undefined, then three directives (`#if`, `#else`, `#endif`) are part of the directive set.
+>
+> *end example*
 
 ### 6.5.6 Diagnostic directives
 
@@ -1301,7 +1325,9 @@ fragment PP_Message
 > class Test {...}
 > ```
 >
-> produces a compile-time error (“A build can’t be both debug and retail”) if the conditional compilation symbols `Debug` and `Retail` are both defined. Note that a *PP_Message* can contain arbitrary text; specifically, it need not contain well-formed tokens, as shown by the single quote in the word `can't`. *end example*
+> produces a compile-time error (“A build can’t be both debug and retail”) if the conditional compilation symbols `Debug` and `Retail` are both defined. Note that a *PP_Message* can contain arbitrary text; specifically, it need not contain well-formed tokens, as shown by the single quote in the word `can't`.
+>
+> *end example*
 
 ### 6.5.7 Region directives
 

--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -816,7 +816,9 @@ Using this notation, the meaning of a *qualified_alias_member* is determined as 
 > }
 > ```
 >
-> `global.A` resolves to `MyGlobalTypes.A` and `global::A` resolves to class `A` in the global namespace. *end note*
+> `global.A` resolves to `MyGlobalTypes.A` and `global::A` resolves to class `A` in the global namespace.
+>
+> *end note*
 
 ### 13.8.2 Uniqueness of aliases
 

--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -35,7 +35,9 @@ The *namespace_member_declaration*s of each compilation unit of a program contri
 >     class B {}
 > ```
 >
-> The two compilation units contribute to the single global namespace, in this case declaring two classes with the fully qualified names `A` and `B`. Because the two compilation units contribute to the same declaration space, it would have been an error if each contained a declaration of a member with the same name. *end example*
+> The two compilation units contribute to the single global namespace, in this case declaring two classes with the fully qualified names `A` and `B`. Because the two compilation units contribute to the same declaration space, it would have been an error if each contained a declaration of a member with the same name.
+>
+> *end example*
 
 ## 13.3 Namespace declarations
 
@@ -104,7 +106,9 @@ Namespaces are open-ended, and two namespace declarations with the same fully qu
 > }
 > ```
 >
-> the two namespace declarations above contribute to the same declaration space, in this case declaring two classes with the fully qualified names `N1.N2.A` and `N1.N2.B`. Because the two declarations contribute to the same declaration space, it would have been an error if each contained a declaration of a member with the same name. *end example*
+> the two namespace declarations above contribute to the same declaration space, in this case declaring two classes with the fully qualified names `N1.N2.A` and `N1.N2.B`. Because the two declarations contribute to the same declaration space, it would have been an error if each contained a declaration of a member with the same name.
+>
+> *end example*
 
 ## 13.4 Extern alias directives
 
@@ -313,7 +317,9 @@ Each *extern_alias_directive* or *using_alias_directive* in a *compilation_unit*
 > }
 > ```
 >
-> In the second namespace body for `N3`, unqualified use of `B` results in an error, since `N3` contains a member named `B` and the namespace body that also declares an alias with name `B`; likewise for `A`. The class `N3.B` can be referenced as `N3.B` or `global::N3.B`. The alias `A` can be used in a *qualified-alias-member* ([§13.8](namespaces.md#138-qualified-alias-member)), such as `A::B`. The alias `B` is essentially useless. It cannot be used in a *qualified_alias_member* since only namespace aliases can be used in a *qualified_alias_member* and `B` aliases a type. *end example*
+> In the second namespace body for `N3`, unqualified use of `B` results in an error, since `N3` contains a member named `B` and the namespace body that also declares an alias with name `B`; likewise for `A`. The class `N3.B` can be referenced as `N3.B` or `global::N3.B`. The alias `A` can be used in a *qualified-alias-member* ([§13.8](namespaces.md#138-qualified-alias-member)), such as `A::B`. The alias `B` is essentially useless. It cannot be used in a *qualified_alias_member* since only namespace aliases can be used in a *qualified_alias_member* and `B` aliases a type.
+>
+> *end example*
 
 Just like regular members, names introduced by *alias_directives* are hidden by similarly named members in nested scopes.
 
@@ -329,7 +335,9 @@ Just like regular members, names introduced by *alias_directives* are hidden by 
 > }
 > ```
 >
-> the reference to `R.A` in the declaration of `B` causes a compile-time error because `R` refers to `N3.R`, not `N1.N2`. *end example*
+> the reference to `R.A` in the declaration of `B` causes a compile-time error because `R` refers to `N3.R`, not `N1.N2`.
+>
+> *end example*
 
 The order in which *extern_alias_directive*s are written has no significance. Likewise, the order in which *using_alias_directive*s are written has no significance, but all *using_alias_directives* must come after all *extern_alias_directive*s in the same compilation unit or namespace body. Resolution of the *namespace_or_type_name* referenced by a *using_alias_directive* is not affected by the *using_alias_directive* itself or by other *using_directive*s in the immediately containing compilation unit or namespace body, but may be affected by *extern_alias_directive*s in the immediately containing compilation unit or namespace body. In other words, the *namespace_or_type_name* of a *using_alias_directive* is resolved as if the immediately containing compilation unit or namespace body had no *using_directive*s but has the correct set of *extern_alias_directive*s.
 
@@ -349,7 +357,9 @@ The order in which *extern_alias_directive*s are written has no significance. Li
 > }
 > ```
 >
-> the last *using_alias_directive* results in a compile-time error because it is not affected by the previous *using_alias_directive*. The first *using_alias_directive* does not result in an error since the scope of the extern alias E includes the *using_alias_directive*. *end example*
+> the last *using_alias_directive* results in a compile-time error because it is not affected by the previous *using_alias_directive*. The first *using_alias_directive* does not result in an error since the scope of the extern alias E includes the *using_alias_directive*.
+>
+> *end example*
 
 A *using_alias_directive* can create an alias for any namespace or type, including the namespace within which it appears and any namespace or type nested within that namespace.
 
@@ -377,7 +387,9 @@ Accessing a namespace or type through an alias yields exactly the same result as
 > }
 > ```
 >
-> the names `N1.N2.A`, `R1.N2.A`, and `R2.A` are equivalent and all refer to the class declaration whose fully qualified name is `N1.N2.A`. *end example*
+> the names `N1.N2.A`, `R1.N2.A`, and `R2.A` are equivalent and all refer to the class declaration whose fully qualified name is `N1.N2.A`.
+>
+> *end example*
 
 Although each part of a partial type ([§14.2.7](classes.md#1427-partial-declarations)) is declared within the same namespace, the parts are typically written within different namespace declarations. Thus, different *extern_alias_directive*s and *using_directive*s can be present for each part. When interpreting simple names ([§11.7.4](expressions.md#1174-simple-names)) within one part, only the *extern_alias_directive*s and *using_directive*s of the namespace bodies and compilation unit enclosing that part are considered. This may result in the same identifier having different meanings in different parts.
 
@@ -459,7 +471,9 @@ Within member declarations in a compilation unit or namespace body that contains
 > }
 > ```
 >
-> Above, within member declarations in the `N3` namespace, the type members of `N1.N2` are directly available, and thus class `N3.B` derives from class `N1.N2.A`. *end example*
+> Above, within member declarations in the `N3` namespace, the type members of `N1.N2` are directly available, and thus class `N3.B` derives from class `N1.N2.A`.
+>
+> *end example*
 
 A *using_namespace_directive* imports the types contained in the given namespace, but specifically does not import nested namespaces.
 
@@ -478,7 +492,9 @@ A *using_namespace_directive* imports the types contained in the given namespace
 > }
 > ```
 >
-> the *using_namespace_directive* imports the types contained in `N1`, but not the namespaces nested in `N1`. Thus, the reference to `N2.A` in the declaration of `B` results in a compile-time error because no members named `N2` are in scope. *end example*
+> the *using_namespace_directive* imports the types contained in `N1`, but not the namespaces nested in `N1`. Thus, the reference to `N2.A` in the declaration of `B` results in a compile-time error because no members named `N2` are in scope.
+>
+> *end example*
 
 Unlike a *using_alias_directive*, a *using_namespace_directive* may import types whose identifiers are already defined within the enclosing compilation unit or namespace body. In effect, names imported by a *using_namespace_directive* are hidden by similarly named members in the enclosing compilation unit or namespace body.
 
@@ -498,7 +514,9 @@ Unlike a *using_alias_directive*, a *using_namespace_directive* may import types
 > }
 > ```
 >
-> Here, within member declarations in the `N3` namespace, `A` refers to `N3.A` rather than `N1.N2.A`. *end example*
+> Here, within member declarations in the `N3` namespace, `A` refers to `N3.A` rather than `N1.N2.A`.
+>
+> *end example*
 
 Because names may be ambiguous when more than one imported namespace introduces the same type name, a *using_alias_directive* is useful to disambiguate the reference.
 
@@ -570,7 +588,9 @@ Furthermore, when more than one namespace or type imported by *using_namespace_d
 > }
 > ```
 >
-> `N1` contains a type member `A`, and `C` contains a static field `A`, and because `N2` imports both, referencing `A` as a *simple_name* is ambiguous and a compile-time error. *end example*
+> `N1` contains a type member `A`, and `C` contains a static field `A`, and because `N2` imports both, referencing `A` as a *simple_name* is ambiguous and a compile-time error.
+>
+> *end example*
 
 Like a *using_alias_directive*, a *using_namespace_directive* does not contribute any new members to the underlying declaration space of the compilation unit or namespace, but, rather, affects only the compilation unit or namespace body in which it appears.
 
@@ -614,7 +634,9 @@ Within member declarations in a compilation unit or namespace body that contains
 > }
 > ```
 >
-> In the preceding code, within member declarations in the `N2` namespace, the static members and nested types of `N1.A` are directly available, and thus the method `N` is able to reference both the `B` and `M` members of `N1.A`. *end example*
+> In the preceding code, within member declarations in the `N2` namespace, the static members and nested types of `N1.A` are directly available, and thus the method `N` is able to reference both the `B` and `M` members of `N1.A`.
+>
+> *end example*
 
 A *using_static_directive* specifically does not import extension methods directly as static methods, but makes them available for extension method invocation ([§11.7.8.3](expressions.md#11783-extension-method-invocations)).
 
@@ -645,7 +667,9 @@ A *using_static_directive* specifically does not import extension methods direct
 > }
 > ```
 >
-> the *using_static_directive* imports the extension method `M` contained in `N1.A`, but only as an extension method. Thus, the first reference to `M` in the body of `B.N` results in a compile-time error because no members named `M` are in scope. *end example*
+> the *using_static_directive* imports the extension method `M` contained in `N1.A`, but only as an extension method. Thus, the first reference to `M` in the body of `B.N` results in a compile-time error because no members named `M` are in scope.
+>
+> *end example*
 
 A *using_static_directive* only imports members and types declared directly in the given type, not members and types declared in base classes.
 
@@ -680,7 +704,9 @@ A *using_static_directive* only imports members and types declared directly in t
 > }
 > ```
 >
-> the *using_static_directive* imports the method `M2` contained in `N1.B`, but does not import the method `M` contained in `N1.A`. Thus, the reference to `M` in the body of `C.N` results in a compile-time error because no members named `M` are in scope. Developers must add a second `using static` directive to specify that the methods in `N1.A` should also be imported. *end example*
+> the *using_static_directive* imports the method `M2` contained in `N1.B`, but does not import the method `M` contained in `N1.A`. Thus, the reference to `M` in the body of `C.N` results in a compile-time error because no members named `M` are in scope. Developers must add a second `using static` directive to specify that the methods in `N1.A` should also be imported.
+>
+> *end example*
 
 Ambiguities between multiple *using_namespace_directives* and *using_static_directives* are discussed in [§13.5.3](namespaces.md#1353-using-namespace-directives).
 
@@ -784,7 +810,9 @@ Using this notation, the meaning of a *qualified_alias_member* is determined as 
 > }
 > ```
 >
-> the class `A` is referenced with `global::A` and the type `System.Net.Sockets.Socket` is referenced with `S::Socket`. Using `A.x` and `S.Socket` instead would have caused compile-time errors because `A` and `S` would have resolved to the parameters. *end example*
+> the class `A` is referenced with `global::A` and the type `System.Net.Sockets.Socket` is referenced with `S::Socket`. Using `A.x` and `S.Socket` instead would have caused compile-time errors because `A` and `S` would have resolved to the parameters.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -845,4 +873,6 @@ Each compilation unit and namespace body has a separate declaration space for ex
 > }
 > ```
 >
-> the name `A` has two possible meanings in the second namespace body because both the class `A` and the using alias `A` are in scope. For this reason, use of `A` in the qualified name `A.Stream` is ambiguous and causes a compile-time error to occur. However, use of `A` with the `::` qualifier is not an error because `A` is looked up only as a namespace alias. *end example*
+> the name `A` has two possible meanings in the second namespace body because both the class `A` and the using alias `A` are in scope. For this reason, use of `A` in the qualified name `A.Stream` is ambiguous and causes a compile-time error to occur. However, use of `A` with the `::` qualifier is not an error because `A` is looked up only as a namespace alias.
+>
+> *end example*

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -96,7 +96,9 @@ A warning is reported if a statement other than *throw_statement*, *block*, or *
 > }
 > ```
 >
-> the `Console.WriteLine` invocation is considered reachable, even though, in reality, it will never be executed. *end note*
+> the `Console.WriteLine` invocation is considered reachable, even though, in reality, it will never be executed.
+>
+> *end note*
 
 The *block* of a function member or an anonymous function is always considered reachable. By successively evaluating the reachability rules of each statement in a block, the reachability of any given statement can be determined.
 
@@ -1155,7 +1157,9 @@ The target of a `goto` *identifier* statement is the labeled statement with the 
 > }
 > ```
 >
-> a `goto` statement is used to transfer control out of a nested scope. *end note*
+> a `goto` statement is used to transfer control out of a nested scope.
+>
+> *end note*
 
 The target of a `goto case` statement is the statement list in the immediately enclosing `switch` statement ([§12.8.3](statements.md#1283-the-switch-statement)) which contains a`case` label with the given constant value. If the `goto case` statement is not enclosed by a `switch` statement, if the *constant_expression* is not implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the governing type of the nearest enclosing `switch` statement, or if the nearest enclosing `switch` statement does not contain a `case` label with the given constant value, a compile-time error occurs.
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -45,7 +45,9 @@ The *embedded_statement* nonterminal is used for statements that appear within o
 > }
 > ```
 >
-> results in a compile-time error because an `if` statement requires an *embedded_statement* rather than a *statement* for its `if` branch. If this code were permitted, then the variable `i` would be declared, but it could never be used. Note, however, that by placing `i`’s declaration in a block, the example is valid. *end example*
+> results in a compile-time error because an `if` statement requires an *embedded_statement* rather than a *statement* for its `if` branch. If this code were permitted, then the variable `i` would be declared, but it could never be used. Note, however, that by placing `i`’s declaration in a block, the example is valid.
+>
+> *end example*
 
 ## 12.2 End points and reachability
 
@@ -68,7 +70,9 @@ If a statement can possibly be reached by execution, the statement is said to be
 > }
 > ```
 >
-> the second invocation of Console.WriteLine is unreachable because there is no possibility that the statement will be executed. *end example*
+> the second invocation of Console.WriteLine is unreachable because there is no possibility that the statement will be executed.
+>
+> *end example*
 
 A warning is reported if a statement other than *throw_statement*, *block*, or *empty_statement* is unreachable. It is specifically not an error for a statement to be unreachable.
 
@@ -118,7 +122,9 @@ The *block* of a function member or an anonymous function is always considered r
 > - The first `Console.WriteLine` expression statement is reachable because the block of the `F` method is reachable ([§12.3](statements.md#123-blocks)).
 > - The end point of the first `Console.WriteLine` expression statement is reachable because that statement is reachable ([§12.7](statements.md#127-expression-statements) and [§12.3](statements.md#123-blocks)).
 > - The `if` statement is reachable because the end point of the first `Console.WriteLine` expression statement is reachable ([§12.7](statements.md#127-expression-statements) and [§12.3](statements.md#123-blocks)).
-> - The second `Console.WriteLine` expression statement is reachable because the Boolean expression of the `if` statement does not have the constant value `false`. *end example*
+> - The second `Console.WriteLine` expression statement is reachable because the Boolean expression of the `if` statement does not have the constant value `false`.
+>
+> *end example*
 
 There are two situations in which it is a compile-time error for the end point of a statement to be reachable:
 
@@ -252,7 +258,9 @@ Labels have their own declaration space and do not interfere with other identifi
 > }
 > ```
 >
-> is valid and uses the name x as both a parameter and a label. *end example*
+> is valid and uses the name x as both a parameter and a label.
+>
+> *end example*
 
 Execution of a labeled statement corresponds exactly to execution of the statement following the label.
 
@@ -611,7 +619,9 @@ Multiple labels are permitted in a *switch_section*.
 > }
 > ```
 >
-> is valid. The example does not violate the “no fall through” rule because the labels `case 2:` and `default:` are part of the same *switch_section*. *end example*
+> is valid. The example does not violate the “no fall through” rule because the labels `case 2:` and `default:` are part of the same *switch_section*.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -899,7 +909,9 @@ The placement of `v` inside the `while` loop is important for how it is captured
 > f();
 > ```
 >
-> If `v` in the expanded form were declared outside of the `while` loop, it would be shared among all iterations, and its value after the `for` loop would be the final value, `13`, which is what the invocation of `f` would print. Instead, because each iteration has its own variable `v`, the one captured by `f` in the first iteration will continue to hold the value `7`, which is what will be printed. (Note that earlier versions of C# declared `v` outside of the `while` loop.) *end example*
+> If `v` in the expanded form were declared outside of the `while` loop, it would be shared among all iterations, and its value after the `for` loop would be the final value, `13`, which is what the invocation of `f` would print. Instead, because each iteration has its own variable `v`, the one captured by `f` in the first iteration will continue to hold the value `7`, which is what will be printed. (Note that earlier versions of C# declared `v` outside of the `while` loop.)
+>
+> *end example*
 
 The body of the `finally` block is constructed according to the following steps:
 
@@ -1612,7 +1624,9 @@ using (ResourceType rN = eN)
 > }
 > ```
 >
-> Since the `TextWriter` and `TextReader` classes implement the `IDisposable` interface, the example can use `using` statements to ensure that the underlying file is properly closed following the write or read operations. *end example*
+> Since the `TextWriter` and `TextReader` classes implement the `IDisposable` interface, the example can use `using` statements to ensure that the underlying file is properly closed following the write or read operations.
+>
+> *end example*
 
 ## 12.15 The yield statement
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -231,7 +231,9 @@ The default value of a struct corresponds to the value returned by the default c
 > }
 > ```
 >
-> the user-defined instance constructor protects against `null` values only where it is explicitly called. In cases where a `KeyValuePair` variable is subject to default value initialization, the `key` and `value` fields will be `null`, and the struct should be prepared to handle this state. *end note*
+> the user-defined instance constructor protects against `null` values only where it is explicitly called. In cases where a `KeyValuePair` variable is subject to default value initialization, the `key` and `value` fields will be `null`, and the struct should be prepared to handle this state.
+>
+> *end note*
 
 ### 15.4.6 Boxing and unboxing
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -175,7 +175,9 @@ With classes, it is possible for two variables to reference the same object, and
 > System.Console.WriteLine(b.x);
 > ```
 >
-> outputs the value `10`. The assignment of `a` to `b` creates a copy of the value, and `b` is thus unaffected by the assignment to `a.x`. Had `Point` instead been declared as a class, the output would be `100` because `a` and `b` would reference the same object. *end example*
+> outputs the value `10`. The assignment of `a` to `b` creates a copy of the value, and `b` is thus unaffected by the assignment to `a.x`. Had `Point` instead been declared as a class, the output would be `100` because `a` and `b` would reference the same object.
+>
+> *end example*
 
 ### 15.4.3 Inheritance
 
@@ -205,7 +207,9 @@ As described in [§9.3](variables.md#93-default-values), several kinds of variab
 > Point[] a = new Point[100];
 > ```
 >
-> initializes each `Point` in the array to the value produced by setting the `x` and `y` fields to zero. *end example*
+> initializes each `Point` in the array to the value produced by setting the `x` and `y` fields to zero.
+>
+> *end example*
 
 The default value of a struct corresponds to the value returned by the default constructor of the struct ([§8.3.3](types.md#833-default-constructors)). Unlike a class, a struct is not permitted to declare a parameterless instance constructor. Instead, every struct implicitly has a parameterless instance constructor, which always returns the value that results from setting all fields to their default values.
 
@@ -285,7 +289,9 @@ The meaning of `this` in a struct differs from the meaning of `this` in a class,
 > 3
 > ```
 >
-> Although it is bad style for `ToString` to have side effects, the example demonstrates that no boxing occurred for the three invocations of `x.ToString()`. *end example*
+> Although it is bad style for `ToString` to have side effects, the example demonstrates that no boxing occurred for the three invocations of `x.ToString()`.
+>
+> *end example*
 
 Similarly, boxing never implicitly occurs when accessing a member on a constrained type parameter when the member is implemented within the value type. For example, suppose an interface `ICounter` contains a method `Increment`, which can be used to modify a value. If `ICounter` is used as a constraint, the implementation of the `Increment` method is called with a reference to the variable that `Increment` was called on, never a boxed copy.
 
@@ -348,7 +354,9 @@ As described in [§15.4.5](structs.md#1545-default-values), the default value of
 > }
 > ```
 >
-> is in error because the instance field declarations include variable initializers. *end example*
+> is in error because the instance field declarations include variable initializers.
+>
+> *end example*
 
 ### 15.4.9 Constructors
 
@@ -376,7 +384,9 @@ Unlike a class, a struct is not permitted to declare a parameterless instance co
 > Point p2 = new Point(0, 0);
 > ```
 >
-> both create a `Point` with `x` and `y` initialized to zero. *end example*
+> both create a `Point` with `x` and `y` initialized to zero.
+>
+> *end example*
 
 A struct instance constructor is not permitted to include a constructor initializer of the form `base(`*argument_list*`)`, where *argument_list* is optional.
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -281,7 +281,9 @@ Because a simple type aliases a struct type, every simple type has members.
 <!-- markdownlint-enable MD028 -->
 > *Note*: The simple types differ from other struct types in that they permit certain additional operations:
 >
-> - Most simple types permit values to be created by writing *literals* ([§6.4.5](lexical-structure.md#645-literals)), although C# makes no provision for literals of struct types in general. *Example*: `123` is a literal of type `int` and `'a'` is a literal of type `char`. *end example*
+> - Most simple types permit values to be created by writing *literals* ([§6.4.5](lexical-structure.md#645-literals)), although C# makes no provision for literals of struct types in general. *Example*: `123` is a literal of type `int` and `'a'` is a literal of type `char`.
+>
+> *end example*
 > - When the operands of an expression are all simple type constants, it is possible for the compiler to evaluate the expression at compile-time. Such an expression is known as a *constant_expression* ([§11.20](expressions.md#1120-constant-expressions)). Expressions involving operators defined by other struct types are not considered to be constant expressions.
 > - Through `const` declarations, it is possible to declare constants of the simple types ([§14.4](classes.md#144-constants)). It is not possible to have constants of other struct types, but a similar effect is provided by static readonly fields.
 > - Conversions involving simple types can participate in evaluation of conversion operators defined by other struct types, but a user-defined conversion operator can never participate in evaluation of another user-defined conversion operator ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)).
@@ -577,7 +579,9 @@ If a conversion exists from a lambda expression to a delegate type `D`, a conver
 > Expression<Func<int,int>> exp = x => x + 1; // Data
 > ```
 >
-> Following these assignments, the delegate `del` references a method that returns `x + 1`, and the expression tree exp references a data structure that describes the expression `x => x + 1`. *end example*
+> Following these assignments, the delegate `del` references a method that returns `x + 1`, and the expression tree exp references a data structure that describes the expression `x => x + 1`.
+>
+> *end example*
 
 `Expression<TDelegate>` provides an instance method `Compile` which produces a delegate of type `TDelegate`:
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -281,10 +281,8 @@ Because a simple type aliases a struct type, every simple type has members.
 <!-- markdownlint-enable MD028 -->
 > *Note*: The simple types differ from other struct types in that they permit certain additional operations:
 >
-> - Most simple types permit values to be created by writing *literals* ([§6.4.5](lexical-structure.md#645-literals)), although C# makes no provision for literals of struct types in general. *Example*: `123` is a literal of type `int` and `'a'` is a literal of type `char`.
->
-> *end example*
-> - When the operands of an expression are all simple type constants, it is possible for the compiler to evaluate the expression at compile-time. Such an expression is known as a *constant_expression* ([§11.20](expressions.md#1120-constant-expressions)). Expressions involving operators defined by other struct types are not considered to be constant expressions.
+> - Most simple types permit values to be created by writing *literals* ([§6.4.5](lexical-structure.md#645-literals)), although C# makes no provision for literals of struct types in general. *Example*: `123` is a literal of type `int` and `'a'` is a literal of type `char`. *end example*
+> - When the operands of an expression are all simple type constants, it is possible for the compiler to evaluate the expression at compile-time. Such an expression is known as a *constant_expression* ([§11.20](expressions.md#1120-constant-expressions)). Expressions involving operators defined by other struct types are not considered to be constant expressions
 > - Through `const` declarations, it is possible to declare constants of the simple types ([§14.4](classes.md#144-constants)). It is not possible to have constants of other struct types, but a similar effect is provided by static readonly fields.
 > - Conversions involving simple types can participate in evaluation of conversion operators defined by other struct types, but a user-defined conversion operator can never participate in evaluation of another user-defined conversion operator ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)).
 >

--- a/standard/types.md
+++ b/standard/types.md
@@ -284,7 +284,9 @@ Because a simple type aliases a struct type, every simple type has members.
 > - Most simple types permit values to be created by writing *literals* ([§6.4.5](lexical-structure.md#645-literals)), although C# makes no provision for literals of struct types in general. *Example*: `123` is a literal of type `int` and `'a'` is a literal of type `char`. *end example*
 > - When the operands of an expression are all simple type constants, it is possible for the compiler to evaluate the expression at compile-time. Such an expression is known as a *constant_expression* ([§11.20](expressions.md#1120-constant-expressions)). Expressions involving operators defined by other struct types are not considered to be constant expressions.
 > - Through `const` declarations, it is possible to declare constants of the simple types ([§14.4](classes.md#144-constants)). It is not possible to have constants of other struct types, but a similar effect is provided by static readonly fields.
-> - Conversions involving simple types can participate in evaluation of conversion operators defined by other struct types, but a user-defined conversion operator can never participate in evaluation of another user-defined conversion operator ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)). *end note*.
+> - Conversions involving simple types can participate in evaluation of conversion operators defined by other struct types, but a user-defined conversion operator can never participate in evaluation of another user-defined conversion operator ([§10.5.3](conversions.md#1053-evaluation-of-user-defined-conversions)).
+>
+> *end note*.
 
 ### 8.3.6 Integral types
 
@@ -556,7 +558,9 @@ Since a type parameter can be instantiated with many different type arguments, t
 > - A `new` expression ([§11.7.15.2](expressions.md#117152-object-creation-expressions)) can only be used with a type parameter if the type parameter is constrained by a *constructor_constraint* or the value type constraint ([§14.2.5](classes.md#1425-type-parameter-constraints)).
 > - A type parameter cannot be used anywhere within an attribute.
 > - A type parameter cannot be used in a member access ([§11.7.6](expressions.md#1176-member-access)) or type name ([§7.8](basic-concepts.md#78-namespace-and-type-names)) to identify a static member or a nested type.
-> - A type parameter cannot be used as an *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)). *end note*
+> - A type parameter cannot be used as an *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)).
+>
+> *end note*
 
 As a type, type parameters are purely a compile-time construct. At run-time, each type parameter is bound to a run-time type that was specified by supplying a type argument to the generic type declaration. Thus, the type of a variable declared with a type parameter will, at run-time, be a closed constructed type [§8.4.3](types.md#843-open-and-closed-types). The run-time execution of all statements and expressions involving type parameters uses the type that was supplied as the type argument for that parameter.
 

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -12,7 +12,9 @@ An implementation that does not support unsafe code is required to diagnose any 
 >
 > In unsafe code, it is possible to declare and operate on pointers, to perform conversions between pointers and integral types, to take the address of variables, and so forth. In a sense, writing unsafe code is much like writing C code within a C# program.
 >
-> Unsafe code is in fact a “safe” feature from the perspective of both developers and users. Unsafe code shall be clearly marked with the modifier `unsafe`, so developers can’t possibly use unsafe features accidentally, and the execution engine works to ensure that unsafe code cannot be executed in an untrusted environment. *end note*
+> Unsafe code is in fact a “safe” feature from the perspective of both developers and users. Unsafe code shall be clearly marked with the modifier `unsafe`, so developers can’t possibly use unsafe features accidentally, and the execution engine works to ensure that unsafe code cannot be executed in an untrusted environment.
+>
+> *end note*
 
 ## 22.2 Unsafe contexts
 

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -59,7 +59,9 @@ unsafe_statement
 > }
 > ```
 >
-> Here, the `unsafe` modifiers in the field declarations cause those declarations to be considered unsafe contexts. *end example*
+> Here, the `unsafe` modifiers in the field declarations cause those declarations to be considered unsafe contexts.
+>
+> *end example*
 
 Other than establishing an unsafe context, thus permitting the use of pointer types, the `unsafe` modifier has no effect on a type or a member.
 
@@ -101,7 +103,9 @@ Other than establishing an unsafe context, thus permitting the use of pointer ty
 > }
 > ```
 >
-> Here, because `F`’s signature includes a pointer type, it can only be written in an unsafe context. However, the unsafe context can be introduced by either making the entire class unsafe, as is the case in `A`, or by including an `unsafe` modifier in the method declaration, as is the case in `B`. *end example*
+> Here, because `F`’s signature includes a pointer type, it can only be written in an unsafe context. However, the unsafe context can be introduced by either making the entire class unsafe, as is the case in `A`, or by including an `unsafe` modifier in the method declaration, as is the case in `B`.
+>
+> *end example*
 
 When the `unsafe` modifier is used on a partial type declaration ([§14.2.7](classes.md#1427-partial-declarations)), only that particular part is considered an unsafe context.
 
@@ -313,7 +317,9 @@ When a pointer type is converted to a pointer to `byte`, the result points to th
 > }
 > ```
 >
-> Of course, the output produced depends on endianness. *end example*
+> Of course, the output produced depends on endianness.
+>
+> *end example*
 
 Mappings between pointers and integers are implementation-defined.
 
@@ -540,7 +546,9 @@ The `&` operator does not require its argument to be definitely assigned, but fo
 > }
 > ```
 >
-> `i` is considered definitely assigned following the `&i` operation used to initialize `p`. The assignment to `*p` in effect initializes `i`, but the inclusion of this initialization is the responsibility of the programmer, and no compile-time error would occur if the assignment was removed. *end example*
+> `i` is considered definitely assigned following the `&i` operation used to initialize `p`. The assignment to `*p` in effect initializes `i`, but the inclusion of this initialization is the responsibility of the programmer, and no compile-time error would occur if the assignment was removed.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -715,7 +723,9 @@ Fixed objects can cause fragmentation of the heap (because they can’t be moved
 >
 > demonstrates several uses of the `fixed` statement. The first statement fixes and obtains the address of a static field, the second statement fixes and obtains the address of an instance field, and the third statement fixes and obtains the address of an array element. In each case, it would have been an error to use the regular `&` operator since the variables are all classified as moveable variables.
 >
-> The third and fourth `fixed` statements in the example above produce identical results. In general, for an array instance `a`, specifying `a[0]` in a `fixed` statement is the same as simply specifying `a`. *end example*
+> The third and fourth `fixed` statements in the example above produce identical results. In general, for an array instance `a`, specifying `a[0]` in a `fixed` statement is the same as simply specifying `a`.
+>
+> *end example*
 
 In an unsafe context, array elements of single-dimensional arrays are stored in increasing index order, starting with index `0` and ending with index `Length – 1`. For multi-dimensional arrays, array elements are stored such that the indices of the rightmost dimension are increased first, then the next left dimension, and so on to the left.
 
@@ -796,7 +806,9 @@ Within a `fixed` statement that obtains a pointer `p` to an array instance `a`, 
 > }
 > ```
 >
-> a `fixed` statement is used to fix an array so its address can be passed to a method that takes a pointer. *end example*
+> a `fixed` statement is used to fix an array so its address can be passed to a method that takes a pointer.
+>
+> *end example*
 
 A `char*` value produced by fixing a string instance always points to a null-terminated string. Within a fixed statement that obtains a pointer `p` to a string instance `s`, the pointer values ranging from `p` to `p + s.Length ‑ 1` represent addresses of the characters in the string, and the pointer value `p + s.Length` always points to a null character (the character with value ‘\0’).
 
@@ -1033,7 +1045,9 @@ All stack-allocated memory blocks created during the execution of a function mem
 > }
 > ```
 >
-> a `stackalloc` initializer is used in the `IntToString` method to allocate a buffer of 16 characters on the stack. The buffer is automatically discarded when the method returns. *end example*
+> a `stackalloc` initializer is used in the `IntToString` method to allocate a buffer of 16 characters on the stack. The buffer is automatically discarded when the method returns.
+>
+> *end example*
 
 Except for the `stackalloc` operator, C# provides no predefined constructs for managing non-garbage collected memory. Such services are typically provided by supporting class libraries or imported directly from the underlying operating system.
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -126,7 +126,9 @@ The lifetime of a local variable is the portion of program execution during whic
 <!-- markdownlint-enable MD028 -->
 > *Note*: The actual lifetime of a local variable is implementation-dependent. For example, a compiler might statically determine that a local variable in a block is only used for a small portion of that block. Using this analysis, the compiler could generate code that results in the variable’s storage having a shorter lifetime than its containing block.
 >
-> The storage referred to by a local reference variable is reclaimed independently of the lifetime of that local reference variable ([§7.9](basic-concepts.md#79-automatic-memory-management)). *end note*
+> The storage referred to by a local reference variable is reclaimed independently of the lifetime of that local reference variable ([§7.9](basic-concepts.md#79-automatic-memory-management)).
+>
+> *end note*
 
 A local variable introduced by a *local_variable_declaration* is not automatically initialized and thus has no default value. Such a local variable is considered initially unassigned.
 
@@ -140,7 +142,9 @@ A local variable introduced by a *local_variable_declaration* is not automatical
 > L: x += 1; // error: x not definitely assigned
 > ```
 >
-> Within the scope of a local variable, it is a compile-time error to refer to that local variable in a textual position that precedes its *local_variable_declarator*. *end note*
+> Within the scope of a local variable, it is a compile-time error to refer to that local variable in a textual position that precedes its *local_variable_declarator*.
+>
+> *end note*
 
 ## 9.3 Default values
 
@@ -171,7 +175,9 @@ At a given location in the executable code of a function member or an anonymous 
 >   - An invocation expression ([§11.7.8](expressions.md#1178-invocation-expressions)) or object creation expression ([§11.7.15.2](expressions.md#117152-object-creation-expressions) that passes the variable as an output parameter.
 >   - For a local variable, a local variable declaration for the variable ([§12.6.2](statements.md#1262-local-variable-declarations)) that includes a variable initializer.
 >
-> The formal specification underlying the above informal rules is described in [§9.4.2](variables.md#942-initially-assigned-variables), [§9.4.3](variables.md#943-initially-unassigned-variables), and [§9.4.4](variables.md#944-precise-rules-for-determining-definite-assignment). *end note*
+> The formal specification underlying the above informal rules is described in [§9.4.2](variables.md#942-initially-assigned-variables), [§9.4.3](variables.md#943-initially-unassigned-variables), and [§9.4.4](variables.md#944-precise-rules-for-determining-definite-assignment).
+>
+> *end note*
 
 The definite assignment states of instance variables of a *struct_type* variable are tracked individually as well as collectively. In additional to the rules above, the following rules apply to *struct_type* variables and their instance variables:
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -30,7 +30,9 @@ C# defines seven categories of variables: static variables, instance variables, 
 > }
 > ```
 >
-> `x` is a static variable, `y` is an instance variable, `v[0]` is an array element, `a` is a value parameter, `b` is a reference parameter, `c` is an output parameter, and `i` is a local variable. *end example*
+> `x` is a static variable, `y` is an instance variable, `v[0]` is an array element, `a` is a value parameter, `b` is a reference parameter, `c` is an output parameter, and `i` is a local variable.
+>
+> *end example*
 
 ### 9.2.2 Static variables
 
@@ -539,7 +541,9 @@ The following rules apply to these kinds of expressions: parenthesized expressio
 
 Each of these expressions has one or more subexpressions that are unconditionally evaluated in a fixed order.
 
-> *Example*: The binary `%` operator evaluates the left hand side of the operator, then the right hand side. An indexing operation evaluates the indexed expression, and then evaluates each of the index expressions, in order from left to right. *end example*
+> *Example*: The binary `%` operator evaluates the left hand side of the operator, then the right hand side. An indexing operation evaluates the indexed expression, and then evaluates each of the index expressions, in order from left to right.
+>
+> *end example*
 
 For an expression *expr*, which has subexpressions *expr₁*, *expr₂*, …, *exprₓ*, evaluated in that order:
 
@@ -590,7 +594,9 @@ For an expression *expr* of the form:
 > }
 > ```
 >
-> the variable `x` is considered definitely assigned after `arr[x = 1]` is evaluated as the left hand side of the second simple assignment. *end example*
+> the variable `x` is considered definitely assigned after `arr[x = 1]` is evaluated as the left hand side of the second simple assignment.
+>
+> *end example*
 
 #### 9.4.4.26 && expressions
 
@@ -628,7 +634,9 @@ For an expression *expr* of the form:
 > }
 > ```
 >
-> the variable `i` is considered definitely assigned in one of the embedded statements of an `if` statement but not in the other. In the `if` statement in method `F`, the variable `i` is definitely assigned in the first embedded statement because execution of the expression `(i = y)` always precedes execution of this embedded statement. In contrast, the variable `i` is not definitely assigned in the second embedded statement, since `x >= 0` might have tested false, resulting in the variable `i`’s being unassigned. *end example*
+> the variable `i` is considered definitely assigned in one of the embedded statements of an `if` statement but not in the other. In the `if` statement in method `F`, the variable `i` is definitely assigned in the first embedded statement because execution of the expression `(i = y)` always precedes execution of this embedded statement. In contrast, the variable `i` is not definitely assigned in the second embedded statement, since `x >= 0` might have tested false, resulting in the variable `i`’s being unassigned.
+>
+> *end example*
 
 #### 9.4.4.27 || expressions
 
@@ -666,7 +674,9 @@ For an expression *expr* of the form:
 > }
 > ```
 >
-> the variable `i` is considered definitely assigned in one of the embedded statements of an `if` statement but not in the other. In the `if` statement in method `G`, the variable `i` is definitely assigned in the second embedded statement because execution of the expression `(i = y)` always precedes execution of this embedded statement. In contrast, the variable `i` is not definitely assigned in the first embedded statement, since `x >= 0` might have tested true, resulting in the variable `i`’s being unassigned. *end example*
+> the variable `i` is considered definitely assigned in one of the embedded statements of an `if` statement but not in the other. In the `if` statement in method `G`, the variable `i` is definitely assigned in the second embedded statement because execution of the expression `(i = y)` always precedes execution of this embedded statement. In contrast, the variable `i` is not definitely assigned in the first embedded statement, since `x >= 0` might have tested true, resulting in the variable `i`’s being unassigned.
+>
+> *end example*
 
 #### 9.4.4.28 ! expressions
 
@@ -730,7 +740,9 @@ For a *lambda_expression* or *anonymous_method_expression* *expr* with a body (e
 > }
 > ```
 >
-> generates a compile-time error since max is not definitely assigned where the anonymous function is declared. *end example*
+> generates a compile-time error since max is not definitely assigned where the anonymous function is declared.
+>
+> *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -748,7 +760,9 @@ For a *lambda_expression* or *anonymous_method_expression* *expr* with a body (e
 > }
 > ```
 >
-> also generates a compile-time error since the assignment to `n` in the anonymous function has no affect on the definite assignment state of `n` outside the anonymous function. *end example*
+> also generates a compile-time error since the assignment to `n` in the anonymous function has no affect on the definite assignment state of `n` outside the anonymous function.
+>
+> *end example*
 
 ## 9.5 Variable references
 

--- a/tools/MarkdownConverter/Spec/MarkdownSpec.cs
+++ b/tools/MarkdownConverter/Spec/MarkdownSpec.cs
@@ -247,6 +247,9 @@ namespace MarkdownConverter.Spec
         /// them as separate spans. We remove this later on when converting Markdown to Word. Note that this
         /// only works at the top level at the moment.
         /// </summary>
+        /// <remarks>
+        /// This may no longer be necessary now that we're using Markdown Lint to avoid this condition.
+        /// </remarks>
         private static string SeparateNotesAndExamples(string text) => text
             .Replace("*end note*\r\n\r\n> *", $"*end note*\r\n\r\n{NoteAndExampleFakeSeparator}\r\n\r\n> *")
             .Replace("*end example*\r\n\r\n> *", $"*end example*\r\n\r\n{NoteAndExampleFakeSeparator}\r\n\r\n> *");

--- a/tools/MarkdownConverter/Spec/MarkdownSpec.cs
+++ b/tools/MarkdownConverter/Spec/MarkdownSpec.cs
@@ -249,6 +249,8 @@ namespace MarkdownConverter.Spec
         /// </summary>
         /// <remarks>
         /// This may no longer be necessary now that we're using Markdown Lint to avoid this condition.
+        /// See https://github.com/dotnet/csharpstandard/pull/534#discussion_r837375272 for 
+        /// discussion and a possible remaining use case.
         /// </remarks>
         private static string SeparateNotesAndExamples(string text) => text
             .Replace("*end note*\r\n\r\n> *", $"*end note*\r\n\r\n{NoteAndExampleFakeSeparator}\r\n\r\n> *")


### PR DESCRIPTION
The *end note* and *end example* marker for a note should be at the end of a single paragraph note. If a note spans multiple paragraphs (including notes that contain examples or lists), the *end note* or *end example* marker should be its own paragraph.

I searched for both *end note* (first commit) and *end example* (second commit) and made the updates to those that didn't follow the format we agreed on.
