### PR TITLE
Various Pre-v6 tweaks

### DIFF
--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -970,15 +970,15 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 > creates an instance of class `A` and an instance of class `B`. These objects become eligible for garbage collection when the variable `b` is assigned the value `null`, since after this time it is impossible for any user-written code to access them. The output could be either
 >
 > ```console
-> Finalize instance of `A`
-> Finalize instance of `B`
+> Finalize instance of A
+> Finalize instance of B
 > ```
 >
 > or
 >
 > ```console
-> Finalize instance of `B`
-> Finalize instance of `A`
+> Finalize instance of B
+> Finalize instance of A
 > ```
 >
 > because the language imposes no constraints on the order in which objects are garbage collected.

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1430,9 +1430,7 @@ Constants are permitted to depend on other constants within the same program as 
 
 Constant declarations may depend on constants from other programs, but such dependencies are only possible in one direction.
 
-> *Example*: Referring to the example above, if `A` and `B` were declared in separate programs, it would be possible for `A.X` to depend on `B.Z`, but `B.Z` could then not simultaneously depend on `A.Y`.
->
-> *end example*
+> *Example*: Referring to the example above, if `A` and `B` were declared in separate programs, it would be possible for `A.X` to depend on `B.Z`, but `B.Z` could then not simultaneously depend on `A.Y`. *end example*
 
 ## 14.5 Fields
 
@@ -2179,9 +2177,7 @@ Output parameters are typically used in methods that produce multiple return val
 
 A parameter declared with a `params` modifier is a parameter array. If a formal parameter list includes a parameter array, it shall be the last parameter in the list and it shall be of a single-dimensional array type.
 
-> *Example*: The types `string[]` and `string[][]` can be used as the type of a parameter array, but the type `string[,]` can not.
->
-> *end example*
+> *Example*: The types `string[]` and `string[][]` can be used as the type of a parameter array, but the type `string[,]` can not. *end example*
 
 It is not possible to combine the `params` modifier with the modifiers `ref` and `out`.
 
@@ -4277,9 +4273,7 @@ For the purposes of these rules, any type parameters associated with `S` or `T
 
 From the second rule, it follows that a conversion operator shall convert either to or from the class or struct type in which the operator is declared.
 
-> *Example*: It is possible for a class or struct type `C` to define a conversion from `C` to `int` and from `int` to `C`, but not from `int` to `bool`.
->
-> *end example*
+> *Example*: It is possible for a class or struct type `C` to define a conversion from `C` to `int` and from `int` to `C`, but not from `int` to `bool`. *end example*
 
 It is not possible to directly redefine a pre-defined conversion. Thus, conversion operators are not allowed to convert from or to `object` because implicit and explicit conversions already exist between `object` and all other types. Likewise, neither the source nor the target types of a conversion can be a base type of the other, since a conversion would then already exist. However, it *is* possible to declare operators on generic types that, for particular type arguments, specify conversions that already exist as pre-defined conversions.
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -885,7 +885,7 @@ The compile-time application of the conversion from a method group `E` to a del
 > The assignment to `d4` shows how the method must be applicable in its normal form.
 >
 > The assignment to `d5` shows how parameter and return types of the delegate and method are allowed to differ only for reference types.
-> 
+>
 > *end example*
 
 As with all other implicit and explicit conversions, the cast operator can be used to explicitly perform a particular conversion.
@@ -895,7 +895,7 @@ As with all other implicit and explicit conversions, the cast operator can be us
 > ```csharp
 > object obj = new EventHandler(myDialog.OkClick);
 > ```
-> 
+>
 > could instead be written
 >
 > ```csharp

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -895,7 +895,7 @@ As with all other implicit and explicit conversions, the cast operator can be us
 > ```csharp
 > object obj = new EventHandler(myDialog.OkClick);
 > ```
->
+> 
 > could instead be written
 >
 > ```csharp

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -373,9 +373,7 @@ The explicit enumeration conversions are:
 
 An explicit enumeration conversion between two types is processed by treating any participating *enum_type* as the underlying type of that *enum_type*, and then performing an implicit or explicit numeric conversion between the resulting types.
 
-> *Example*: Given an *enum_type* `E` with and underlying type of `int`, a conversion from `E` to `byte` is processed as an explicit numeric conversion ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)) from `int` to `byte`, and a conversion from `byte` to `E` is processed as an implicit numeric conversion ([§10.2.3](conversions.md#1023-implicit-numeric-conversions)) from `byte` to `int`.
->
-> *end example*
+> *Example*: Given an *enum_type* `E` with and underlying type of `int`, a conversion from `E` to `byte` is processed as an explicit numeric conversion ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)) from `int` to `byte`, and a conversion from `byte` to `E` is processed as an implicit numeric conversion ([§10.2.3](conversions.md#1023-implicit-numeric-conversions)) from `byte` to `int`. *end example*
 
 ### 10.3.4 Explicit nullable conversions
 
@@ -887,6 +885,7 @@ The compile-time application of the conversion from a method group `E` to a del
 > The assignment to `d4` shows how the method must be applicable in its normal form.
 >
 > The assignment to `d5` shows how parameter and return types of the delegate and method are allowed to differ only for reference types.
+> 
 > *end example*
 
 As with all other implicit and explicit conversions, the cast operator can be used to explicitly perform a particular conversion.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -2313,9 +2313,7 @@ array_creation_expression
 
 An array creation expression of the first form allocates an array instance of the type that results from deleting each of the individual expressions from the expression list.
 
-> *Example*: The array creation expression `new int[10,20]` produces an array instance of type `int[,]`, and the array creation expression new `int[10][,]` produces an array instance of type `int[][,]`.
->
-> *end example*
+> *Example*: The array creation expression `new int[10,20]` produces an array instance of type `int[,]`, and the array creation expression new `int[10][,]` produces an array instance of type `int[][,]`. *end example*
 
 Each expression in the expression list shall be of type `int`, `uint`, `long`, or `ulong`, or implicitly convertible to one or more of these types. The value of each expression determines the length of the corresponding dimension in the newly allocated array instance. Since the length of an array dimension shall be nonnegative, it is a compile-time error to have a constant expression with a negative value, in the expression list.
 
@@ -3079,9 +3077,7 @@ A *cast_expression* of the form `(T)E`, where `T` is a type and `E` is a *unary_
 
 The grammar for a *cast_expression* leads to certain syntactic ambiguities.
 
-> *Example*: The expression `(x)–y` could either be interpreted as a *cast_expression* (a cast of `–y` to type `x`) or as an *additive_expression* combined with a *parenthesized_expression* (which computes the value `x – y`).
->
-> *end example*
+> *Example*: The expression `(x)–y` could either be interpreted as a *cast_expression* (a cast of `–y` to type `x`) or as an *additive_expression* combined with a *parenthesized_expression* (which computes the value `x – y`). *end example*
 
 To resolve *cast_expression* ambiguities, the following rule exists: A sequence of one or more tokens ([§6.4](lexical-structure.md#64-tokens)) enclosed in parentheses is considered the start of a *cast_expression* only if at least one of the following are true:
 
@@ -3090,9 +3086,7 @@ To resolve *cast_expression* ambiguities, the following rule exists: A sequence 
 
 The term “correct grammar” above means only that the sequence of tokens shall conform to the particular grammatical production. It specifically does not consider the actual meaning of any constituent identifiers.
 
-> *Example*: If `x` and `y` are identifiers, then `x.y` is correct grammar for a type, even if `x.y` doesn’t actually denote a type.
->
-> *end example*
+> *Example*: If `x` and `y` are identifiers, then `x.y` is correct grammar for a type, even if `x.y` doesn’t actually denote a type. *end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -3978,9 +3972,7 @@ Shift operations never cause overflows and produce the same results in checked a
 
 When the left operand of the `>>` operator is of a signed integral type, the operator performs an *arithmetic* shift right wherein the value of the most significant bit (the sign bit) of the operand is propagated to the high-order empty bit positions. When the left operand of the `>>` operator is of an unsigned integral type, the operator performs a *logical* shift right wherein high-order empty bit positions are always set to zero. To perform the opposite operation of that inferred from the operand type, explicit casts can be used.
 
-> *Example*: If `x` is a variable of type `int`, the operation `unchecked ((int)((uint)x >> y))` performs a logical shift right of `x`.
->
-> *end example*
+> *Example*: If `x` is a variable of type `int`, the operation `unchecked ((int)((uint)x >> y))` performs a logical shift right of `x`. *end example*
 
 Lifted ([§11.4.8](expressions.md#1148-lifted-operators)) forms of the unlifted predefined shift operators defined above are also predefined.
 
@@ -4095,9 +4087,7 @@ The operators compare the operands according to the rules of the IEC 60559 stand
 
 If either operand is NaN, the result is `false` for all operators except `!=`, for which the result is `true`. For any two operands, `x != y` always produces the same result as `!(x == y)`. However, when one or both operands are NaN, the `<`, `>`, `<=`, and `>=` operators do *not* produce the same results as the logical negation of the opposite operator.
 
-> *Example*: If either of `x` and `y` is NaN, then `x` < `y` is `false`, but `!(x >= y)` is `true`.
->
-> *end example*
+> *Example*: If either of `x` and `y` is NaN, then `x` < `y` is `false`, but `!(x >= y)` is `true`. *end example*
 
 When neither operand is NaN, the operators compare the values of the two floating-point operands with respect to the ordering
 
@@ -4601,9 +4591,7 @@ In a null coalescing expression of the form `a ?? b`, if `a` is non-`null`, th
 
 The null coalescing operator is right-associative, meaning that operations are grouped from right to left.
 
-> *Example*: An expression of the form `a ?? b ?? c` is evaluated as a `?? (b ?? c)`. In general terms, an expression of the form `E1 ?? E2 ?? ... ?? EN` returns the first of the operands that is non-`null`, or `null` if all operands are `null`.
->
-> *end example*
+> *Example*: An expression of the form `a ?? b ?? c` is evaluated as a `?? (b ?? c)`. In general terms, an expression of the form `E1 ?? E2 ?? ... ?? EN` returns the first of the operands that is non-`null`, or `null` if all operands are `null`. *end example*
 
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
@@ -4631,9 +4619,7 @@ A conditional expression of the form `b ? x : y` first evaluates the conditi
 
 The conditional operator is right-associative, meaning that operations are grouped from right to left.
 
-> *Example*: An expression of the form `a ? b : c ? d : e` is evaluated as `a ? b : (c ? d : e)`.
->
-> *end example*
+> *Example*: An expression of the form `a ? b : c ? d : e` is evaluated as `a ? b : (c ? d : e)`. *end example*
 
 The first operand of the `?:` operator shall be an expression that can be implicitly converted to `bool`, or an expression of a type that implements `operator true`. If neither of these requirements is satisfied, a compile-time error occurs.
 
@@ -6055,9 +6041,7 @@ The `+=` and `-=` operators with an event access expression as the left operand
 
 The assignment operators are right-associative, meaning that operations are grouped from right to left.
 
-> *Example*: An expression of the form `a = b = c` is evaluated as `a = (b = c)`.
->
-> *end example*
+> *Example*: An expression of the form `a = b = c` is evaluated as `a = (b = c)`. *end example*
 
 ### 11.18.2 Simple assignment
 
@@ -6193,9 +6177,7 @@ An operation of the form `x «op»= y` is processed by applying binary operato
 
 The term “evaluated only once” means that in the evaluation of `x «op» y`, the results of any constituent expressions of `x` are temporarily saved and then reused when performing the assignment to `x`.
 
-> *Example*: In the assignment `A()[B()] += C()`, where `A` is a method returning `int[]`, and `B` and `C` are methods returning `int`, the methods are invoked only once, in the order `A`, `B`, `C`.
->
-> *end example*
+> *Example*: In the assignment `A()[B()] += C()`, where `A` is a method returning `int[]`, and `B` and `C` are methods returning `int`, the methods are invoked only once, in the order `A`, `B`, `C`. *end example*
 
 When the left operand of a compound assignment is a property access or indexer access, the property or indexer shall have both a get accessor and a set accessor. If this is not the case, a binding-time error occurs.
 

--- a/standard/general-description.md
+++ b/standard/general-description.md
@@ -13,7 +13,7 @@ Examples are provided to illustrate possible forms of the constructions describe
 Informative text is indicated in the following ways:
 
 1. Whole or partial clauses or annexes delimited by “**This clause/text is informative**” and “**End of informative text**”.
-1. *Example*: The following example … code fragment, possibly with some narrative … *end example*
-1. *Note*: narrative … *end note*  The *Note*: and *end note* are in the same paragraph for single paragraph notes. If a note spans multiple paragraphs, the *end note* marker should be its own paragraph.
+1. *Example*: The following example … code fragment, possibly with some narrative … *end example*  The *Example:* and *end example* markers are in the same paragraph for single paragraph examples. If an example spans multiple paragraphs, the end example marker should be its own paragraph.
+1. *Note*: narrative … *end note*  The *Note*: and *end note* markers are in the same paragraph for single paragraph notes. If a note spans multiple paragraphs, the *end note* marker should be its own paragraph.
 
 All text not marked as being informative is normative.

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1047,11 +1047,13 @@ fragment PP_Or_Expression
     ;
     
 fragment PP_And_Expression
-    : PP_Equality_Expression (PP_Whitespace? '&&' PP_Whitespace? PP_Equality_Expression)*
+    : PP_Equality_Expression (PP_Whitespace? '&&' PP_Whitespace?
+      PP_Equality_Expression)*
     ;
 
 fragment PP_Equality_Expression
-    : PP_Unary_Expression (PP_Whitespace? ('==' | '!=') PP_Whitespace? PP_Unary_Expression)*
+    : PP_Unary_Expression (PP_Whitespace? ('==' | '!=') PP_Whitespace?
+      PP_Unary_Expression)*
     ;
     
 fragment PP_Unary_Expression

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -155,9 +155,7 @@ The lexical processing of a C# compilation unit consists of reducing the file i
 
 When several lexical grammar productions match a sequence of characters in a compilation unit, the lexical processing always forms the longest possible lexical element.
 
-> *Example*: The character sequence `//` is processed as the beginning of a single-line comment because that lexical element is longer than a single `/` token.
->
-> *end example*
+> *Example*: The character sequence `//` is processed as the beginning of a single-line comment because that lexical element is longer than a single `/` token. *end example*
 
 Some tokens are defined by a set of lexical rules; a main rule and one or more sub-rules. The latter are marked in the grammar by `fragment` to indicate the rule defines part of another token. Fragment rules are not considered in the top-to-bottom ordering of lexical rules.
 
@@ -914,7 +912,7 @@ right_shift_assignment
 
 *right_shift* is made up of the two tokens `>` and `>`. Similarly, *right_shift_assignment* is made up of the two tokens `>` and `>=`. Unlike other productions in the syntactic grammar, no characters of any kind (not even whitespace) are allowed between the two tokens in each of these productions. These productions are treated specially in order to enable the correct handling of *type_parameter_lists* ([§14.2.3](classes.md#1423-type-parameters)).
 
-> *Note*: Prior to the addition of generics to C#, `>>` and `>>=` were both single tokens. However, the syntax for generics uses the `<` and `>` characters to delimit type parameters and type arguments. It is often desirable to use nested constructed types, such as `List<Dictionary<string, int>>`. Rather than requiring the programmer to separate the `>` and `>` by a space, the definition of the two *operator_or_punctuator*s was changed.
+> *Note*: Prior to the addition of generics to C#, `>>` and `>>=` were both single tokens. However, the syntax for generics uses the `<` and `>` characters to delimit type parameters and type arguments. It is often desirable to use nested constructed types, such as `List<Dictionary<string, int>>`. Rather than requiring the programmer to separate the `>` and `>` by a space, the definition of the two *operator_or_punctuator*s was changed. *end note*
 
 ## 6.5 Pre-processing directives
 

--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -12,7 +12,8 @@ A *compilation_unit* consists of zero or more *extern_alias_directive*s followed
 
 ```ANTLR
 compilation_unit
-    : extern_alias_directive* using_directive* global_attributes? namespace_member_declaration*
+    : extern_alias_directive* using_directive* global_attributes?
+      namespace_member_declaration*
     ;
 ```
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -1005,6 +1005,7 @@ The order in which `foreach` traverses the elements of an array, is as follows: 
 > ```
 >
 > the type of `n` is inferred to be `int`, the iteration type of `numbers`.
+>  
 > *end example*
 
 ## 12.10 Jump statements

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -141,9 +141,9 @@ A variable of a struct type directly contains the data of the struct, whereas a 
 > struct B { C c; }
 > struct C { A a; }
 > ```
-> 
+>
 > is an error because each of the types `A`, `B`, and `C` depend on each other.
-> 
+>
 > *end example*
 
 With classes, it is possible for two variables to reference the same object, and thus possible for operations on one variable to affect the object referenced by the other variable. With structs, the variables each have their own copy of the data (except in the case of `ref` and `out` parameter variables), and it is not possible for operations on one to affect the other. Furthermore, except when explicitly nullable ([§8.3.11](types.md#8311-nullable-value-types)), it is not possible for values of a struct type to be `null`.

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -143,7 +143,8 @@ A variable of a struct type directly contains the data of the struct, whereas a 
 > ```
 >
 > is an error because each of the types `A`, `B`, and `C` depend on each other.
-*end example*
+> 
+> *end example*
 
 With classes, it is possible for two variables to reference the same object, and thus possible for operations on one variable to affect the object referenced by the other variable. With structs, the variables each have their own copy of the data (except in the case of `ref` and `out` parameter variables), and it is not possible for operations on one to affect the other. Furthermore, except when explicitly nullable ([§8.3.11](types.md#8311-nullable-value-types)), it is not possible for values of a struct type to be `null`.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -141,7 +141,7 @@ A variable of a struct type directly contains the data of the struct, whereas a 
 > struct B { C c; }
 > struct C { A a; }
 > ```
->
+> 
 > is an error because each of the types `A`, `B`, and `C` depend on each other.
 > 
 > *end example*

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -541,9 +541,7 @@ The following rules apply to these kinds of expressions: parenthesized expressio
 
 Each of these expressions has one or more subexpressions that are unconditionally evaluated in a fixed order.
 
-> *Example*: The binary `%` operator evaluates the left hand side of the operator, then the right hand side. An indexing operation evaluates the indexed expression, and then evaluates each of the index expressions, in order from left to right.
->
-> *end example*
+> *Example*: The binary `%` operator evaluates the left hand side of the operator, then the right hand side. An indexing operation evaluates the indexed expression, and then evaluates each of the index expressions, in order from left to right. *end example*
 
 For an expression *expr*, which has subexpressions *expr₁*, *expr₂*, …, *exprₓ*, evaluated in that order:
 


### PR DESCRIPTION
This mostly fixes putting *end example* at the end of a single-para example, or putting it on its own line with a multi-para example. Plus other formatting fixes found when proofing V6 Word.

I've made all these changes in the Word version.