### PR TITLE
C# V7: integer and float literal additions

### DIFF
--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -762,7 +762,6 @@ The value of a real literal of type `float` or `double` is determined by using t
 > 15D            // double
 > 19.73M         // decimal
 > 1.F            // parsed as a member access of F due to non-digit after .
-> _1.2F          // invalid; _1 is an identifier due to leading _
 > 1_.2F          // invalid; no trailing _ allowed in integer part
 > 1._234         // parsed as a member access of _234 due to non-digit after .
 > 1.234_         // invalid; no trailing _ allowed in fraction

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -714,7 +714,7 @@ To permit the smallest possible `int` and `long` values to be written as integer
 - When an *Integer_Literal* representing the value `9223372036854775808` (2⁶³) and no *Integer_Type_Suffix* or the *Integer_Type_Suffix* `L` or `l` appears as the token immediately following a unary minus operator token ([§11.8.3](expressions.md#1183-unary-minus-operator)), the result (of both tokens) is a constant of type `long` with the value `−9223372036854775808` (−2⁶³). In all other situations, such an *Integer_Literal* is of type `ulong`.
 
 > *Example*:
-> 
+>
 > ```csharp
 > 123                  // decimal, int
 > 10_543_765Lu         // decimal, ulong
@@ -731,7 +731,7 @@ To permit the smallest possible `int` and `long` values to be written as integer
 > 0b1111_1111_0000UL   // binary, ulong
 > 0B__111              // binary, int
 > ```
-> 
+>
 > *end example*
 
 #### 6.4.5.4 Real literals
@@ -777,9 +777,9 @@ If the magnitude of the specified literal is too large to be represented in the 
 The value of a real literal of type `float` or `double` is determined by using the IEC 60559 “round to nearest” mode with ties broken to “even” (a value with the least-significant-bit zero), and all digits considered significant.
 
 > *Note*: In a real literal, decimal digits are always required after the decimal point. For example, `1.3F` is a real literal but `1.F` is not. *end note*
-
+>
 > *Example*:
-> 
+>
 > ```csharp
 > 1.234_567              // double
 > .3e5f                  // float
@@ -790,7 +790,7 @@ The value of a real literal of type `float` or `double` is determined by using t
 > 1.234_                 // invalid; no trailing _ allowed in fraction
 > .3e5_F                 // invalid; no trailing _ allowed in exponent
 > ```
-> 
+>
 > *end example*
 
 #### 6.4.5.5 Character literals

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -688,21 +688,21 @@ To permit the smallest possible `int` and `long` values to be written as integer
 > 123                  // decimal, int
 > 10_543_765Lu         // decimal, ulong
 > 1_2__3___4____5      // decimal, int
-> _123                 // invalid; no leading _ allowed
+> _123                 // not a numeric literal; identifier due to leading _
 > 123_                 // invalid; no trailing _allowed
 > 
 > 0xFf                 // hex, int
 > 0X1b_a0_44_fEL       // hex, long
 > 0x1ade_3FE1_29AaUL   // hex, ulong
 > 0x_abc               // hex, int
-> _0x123               // invalid; no leading _ allowed
+> _0x123               // not a numeric literal; identifier due to leading _
 > 0xabc_               // invalid; no trailing _ allowed
 > 
 > 0b101                // binary, int
 > 0B1001_1010u         // binary, uint
 > 0b1111_1111_0000UL   // binary, ulong
 > 0B__111              // binary, int
-> __0B111              // invalid; no leading _ allowed
+> __0B111              // not a numeric literal; identifier due to leading _
 > 0B111__              // invalid; no trailing _ allowed
 > ```
 >
@@ -756,18 +756,18 @@ The value of a real literal of type `float` or `double` is determined by using t
 > *Example*:
 >
 > ```csharp
-> 1.234_567              // double
-> .3e5f                  // float
-> 2_345E-2_0             // double
-> 15D                    // double
-> 19.73M                 // decimal
-> 1.F                    // invalid; ill-formed (parsed as "1." and "F")
-> _1.2F                  // invalid; no leading _ allowed
-> 1_.2F                  // invalid; no trailing _ allowed in integer part
-> 1._234                 // invalid; no leading _ allowed in fraction
-> 1.234_                 // invalid; no trailing _ allowed in fraction
-> .3e_5F                 // invalid; no leading _ allowed in exponent
-> .3e5_F                 // invalid; no trailing _ allowed in exponent
+> 1.234_567      // double
+> .3e5f          // float
+> 2_345E-2_0     // double
+> 15D            // double
+> 19.73M         // decimal
+> 1.F            // parsed as a member access of F due to non-digit after .
+> _1.2F          // invalid; _1 is an identifier due to leading _
+> 1_.2F          // invalid; no trailing _ allowed in integer part
+> 1._234         // parsed as a member access of _234 due to non-digit after .
+> 1.234_         // invalid; no trailing _ allowed in fraction
+> .3e_5F         // invalid; no leading _ allowed in exponent
+> .3e5_F         // invalid; no trailing _ allowed in exponent
 > ```
 >
 > *end example*

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -615,20 +615,35 @@ The type of a *boolean_literal* is `bool`.
 
 #### 6.4.5.3 Integer literals
 
-Integer literals are used to write values of types `int`, `uint`, `long`, and `ulong`. Integer literals have two possible forms: decimal and hexadecimal.
+Integer literals are used to write values of types `int`, `uint`, `long`, and `ulong`. Integer literals have three possible forms: decimal and, hexadecimal, and binary.
 
 ```ANTLR
 Integer_Literal
     : Decimal_Integer_Literal
     | Hexadecimal_Integer_Literal
+    | Binary_Integer_Literal
     ;
 
 fragment Decimal_Integer_Literal
-    : Decimal_Digit+ Integer_Type_Suffix?
+    : Decimal_Digits Integer_Type_Suffix?
+    ;
+
+fragment Decimal_Digits
+    : Decimal_Digit
+    | Decimal_Digit Decimal_Digits_And_Underscores? Decimal_Digit
     ;
     
 fragment Decimal_Digit
     : '0'..'9'
+    ;
+    
+fragment Decimal_Digits_And_Underscores
+    : Decimal_Digits_And_Underscore+
+    ;
+
+fragment Decimal_Digits_And_Underscore
+    : Decimal_Digit
+    | '_'
     ;
     
 fragment Integer_Type_Suffix
@@ -636,11 +651,49 @@ fragment Integer_Type_Suffix
     ;
     
 fragment Hexadecimal_Integer_Literal
-    : ('0x' | '0X') Hex_Digit+ Integer_Type_Suffix?
+    : ('0x' | '0X') Hex_Digits Integer_Type_Suffix?
+    ;
+
+fragment Hex_Digits
+    : '_'* Hex_Digit
+    | '_'* Hex_Digit Hex_Digits_And_Underscores? Hex_Digit
     ;
 
 fragment Hex_Digit
     : '0'..'9' | 'A'..'F' | 'a'..'f'
+    ;
+
+fragment Hex_Digits_And_Underscores
+    : Hex_Digits_And_Underscore+
+    ;
+
+fragment Hex_Digits_And_Underscore
+    : Hex_Digit
+    | '_'
+    ;
+
+fragment Binary_Integer_Literal
+    : '0b' Binary_Digits Integer_Type_Suffix?
+    | '0B' Binary_Digits Integer_Type_Suffix?
+    ;
+
+fragment Binary_Digits
+    : '_'* Binary_Digit
+    | '_'* Binary_Digit Binary_Digits_And_Underscores? Binary_Digit
+    ;
+
+fragment Binary_Digit
+    : '0'
+    | '1'
+    ;
+
+fragment Binary_Digits_And_Underscores
+    : Binary_Digits_And_Underscore+
+    ;
+
+fragment Binary_Digits_And_Underscore
+    : Binary_Digit
+    | '_'
     ;
 ```
 
@@ -660,20 +713,41 @@ To permit the smallest possible `int` and `long` values to be written as integer
 - When an *Integer_Literal* representing the value `2147483648` (2³¹) and no *Integer_Type_Suffix* appears as the token immediately following a unary minus operator token ([§11.8.3](expressions.md#1183-unary-minus-operator)), the result (of both tokens) is a constant of type int with the value `−2147483648` (−2³¹). In all other situations, such an *Integer_Literal* is of type `uint`.
 - When an *Integer_Literal* representing the value `9223372036854775808` (2⁶³) and no *Integer_Type_Suffix* or the *Integer_Type_Suffix* `L` or `l` appears as the token immediately following a unary minus operator token ([§11.8.3](expressions.md#1183-unary-minus-operator)), the result (of both tokens) is a constant of type `long` with the value `−9223372036854775808` (−2⁶³). In all other situations, such an *Integer_Literal* is of type `ulong`.
 
+> *Example*:
+> 
+> ```csharp
+> 123                  // decimal, int
+> 10_543_765Lu         // decimal, ulong
+> 1_2__3___4____5      // decimal, int
+> 
+> 0xFf                 // hex, int
+> 0X1b_a0_44_fEL       // hex, long
+> 0x1ade_3FE1_29AaUL   // hex, ulong
+> 0x_abc               // hex, int
+> 0xabc_               // invalid; no trailing _ allowed
+> 
+> 0b101                // binary, int
+> 0B1001_1010u         // binary, uint
+> 0b1111_1111_0000UL   // binary, ulong
+> 0B__111              // binary, int
+> ```
+> 
+> *end example*
+
 #### 6.4.5.4 Real literals
 
 Real literals are used to write values of types `float`, `double`, and `decimal`.
 
 ```ANTLR
 Real_Literal
-    : Decimal_Digit+ '.' Decimal_Digit+ Exponent_Part? Real_Type_Suffix?
-    | '.' Decimal_Digit+ Exponent_Part? Real_Type_Suffix?
-    | Decimal_Digit+ Exponent_Part Real_Type_Suffix?
-    | Decimal_Digit+ Real_Type_Suffix
+    : Decimal_Digits '.' Decimal_Digits Exponent_Part? Real_Type_Suffix?
+    | '.' Decimal_Digits Exponent_Part? Real_Type_Suffix?
+    | Decimal_Digits Exponent_Part Real_Type_Suffix?
+    | Decimal_Digits Real_Type_Suffix
     ;
 
 fragment Exponent_Part
-    : ('e' | 'E') Sign? Decimal_Digit+
+    : ('e' | 'E') Sign? Decimal_Digits
     ;
 
 fragment Sign
@@ -703,6 +777,21 @@ If the magnitude of the specified literal is too large to be represented in the 
 The value of a real literal of type `float` or `double` is determined by using the IEC 60559 “round to nearest” mode with ties broken to “even” (a value with the least-significant-bit zero), and all digits considered significant.
 
 > *Note*: In a real literal, decimal digits are always required after the decimal point. For example, `1.3F` is a real literal but `1.F` is not. *end note*
+
+> *Example*:
+> 
+> ```csharp
+> 1.234_567              // double
+> .3e5f                  // float
+> 2_345E-2_0             // double
+> 15D                    // double
+> 19.73M                 // decimal
+> 1.F                    // invalid; ill-formed (parsed as "1." and "F")
+> 1.234_                 // invalid; no trailing _ allowed in fraction
+> .3e5_F                 // invalid; no trailing _ allowed in exponent
+> ```
+> 
+> *end example*
 
 #### 6.4.5.5 Character literals
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -625,75 +625,44 @@ Integer_Literal
     ;
 
 fragment Decimal_Integer_Literal
-    : Decimal_Digits Integer_Type_Suffix?
+    : Decimal_Digit Decorated_Decimal_Digit* Integer_Type_Suffix?
     ;
 
-fragment Decimal_Digits
-    : Decimal_Digit
-    | Decimal_Digit Decimal_Digits_And_Underscores? Decimal_Digit
+fragment Decorated_Decimal_Digit
+    : '_'* Decimal_Digit
     ;
-    
+       
 fragment Decimal_Digit
     : '0'..'9'
     ;
     
-fragment Decimal_Digits_And_Underscores
-    : Decimal_Digits_And_Underscore+
-    ;
-
-fragment Decimal_Digits_And_Underscore
-    : Decimal_Digit
-    | '_'
-    ;
-    
 fragment Integer_Type_Suffix
-    : 'U' | 'u' | 'L' | 'l' | 'UL' | 'Ul' | 'uL' | 'ul' | 'LU' | 'Lu' | 'lU' | 'lu'
+    : 'U' | 'u' | 'L' | 'l' |
+      'UL' | 'Ul' | 'uL' | 'ul' | 'LU' | 'Lu' | 'lU' | 'lu'
     ;
     
 fragment Hexadecimal_Integer_Literal
-    : ('0x' | '0X') Hex_Digits Integer_Type_Suffix?
+    : ('0x' | '0X') Decorated_Hex_Digit+ Integer_Type_Suffix?
     ;
 
-fragment Hex_Digits
+fragment Decorated_Hex_Digit
     : '_'* Hex_Digit
-    | '_'* Hex_Digit Hex_Digits_And_Underscores? Hex_Digit
     ;
-
+       
 fragment Hex_Digit
     : '0'..'9' | 'A'..'F' | 'a'..'f'
     ;
-
-fragment Hex_Digits_And_Underscores
-    : Hex_Digits_And_Underscore+
-    ;
-
-fragment Hex_Digits_And_Underscore
-    : Hex_Digit
-    | '_'
-    ;
-
+   
 fragment Binary_Integer_Literal
-    : '0b' Binary_Digits Integer_Type_Suffix?
-    | '0B' Binary_Digits Integer_Type_Suffix?
+    : ('0b' | '0B') Decorated_Binary_Digit+ Integer_Type_Suffix?
     ;
 
-fragment Binary_Digits
+fragment Decorated_Binary_Digit
     : '_'* Binary_Digit
-    | '_'* Binary_Digit Binary_Digits_And_Underscores? Binary_Digit
     ;
-
+       
 fragment Binary_Digit
-    : '0'
-    | '1'
-    ;
-
-fragment Binary_Digits_And_Underscores
-    : Binary_Digits_And_Underscore+
-    ;
-
-fragment Binary_Digits_And_Underscore
-    : Binary_Digit
-    | '_'
+    : '0' | '1'
     ;
 ```
 
@@ -719,17 +688,22 @@ To permit the smallest possible `int` and `long` values to be written as integer
 > 123                  // decimal, int
 > 10_543_765Lu         // decimal, ulong
 > 1_2__3___4____5      // decimal, int
+> _123                 // invalid; no leading _ allowed
+> 123_                 // invalid; no trailing _allowed
 > 
 > 0xFf                 // hex, int
 > 0X1b_a0_44_fEL       // hex, long
 > 0x1ade_3FE1_29AaUL   // hex, ulong
 > 0x_abc               // hex, int
+> _0x123               // invalid; no leading _ allowed
 > 0xabc_               // invalid; no trailing _ allowed
 > 
 > 0b101                // binary, int
 > 0B1001_1010u         // binary, uint
 > 0b1111_1111_0000UL   // binary, ulong
 > 0B__111              // binary, int
+> __0B111              // invalid; no leading _ allowed
+> 0B111__              // invalid; no trailing _ allowed
 > ```
 >
 > *end example*
@@ -740,14 +714,15 @@ Real literals are used to write values of types `float`, `double`, and `decimal`
 
 ```ANTLR
 Real_Literal
-    : Decimal_Digits '.' Decimal_Digits Exponent_Part? Real_Type_Suffix?
-    | '.' Decimal_Digits Exponent_Part? Real_Type_Suffix?
-    | Decimal_Digits Exponent_Part Real_Type_Suffix?
-    | Decimal_Digits Real_Type_Suffix
+    : Decimal_Digit Decorated_Decimal_Digit* '.'
+      Decimal_Digit Decorated_Decimal_Digit* Exponent_Part? Real_Type_Suffix?
+    | '.' Decimal_Digit Decorated_Decimal_Digit* Exponent_Part? Real_Type_Suffix?
+    | Decimal_Digit Decorated_Decimal_Digit* Exponent_Part Real_Type_Suffix?
+    | Decimal_Digit Decorated_Decimal_Digit* Real_Type_Suffix
     ;
 
 fragment Exponent_Part
-    : ('e' | 'E') Sign? Decimal_Digits
+    : ('e' | 'E') Sign? Decimal_Digit Decorated_Decimal_Digit*
     ;
 
 fragment Sign
@@ -787,7 +762,11 @@ The value of a real literal of type `float` or `double` is determined by using t
 > 15D                    // double
 > 19.73M                 // decimal
 > 1.F                    // invalid; ill-formed (parsed as "1." and "F")
+> _1.2F                  // invalid; no leading _ allowed
+> 1_.2F                  // invalid; no trailing _ allowed in integer part
+> 1._234                 // invalid; no leading _ allowed in fraction
 > 1.234_                 // invalid; no trailing _ allowed in fraction
+> .3e_5F                 // invalid; no leading _ allowed in exponent
 > .3e5_F                 // invalid; no trailing _ allowed in exponent
 > ```
 >

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -615,7 +615,7 @@ The type of a *boolean_literal* is `bool`.
 
 #### 6.4.5.3 Integer literals
 
-Integer literals are used to write values of types `int`, `uint`, `long`, and `ulong`. Integer literals have three possible forms: decimal and, hexadecimal, and binary.
+Integer literals are used to write values of types `int`, `uint`, `long`, and `ulong`. Integer literals have three possible forms: decimal, hexadecimal, and binary.
 
 ```ANTLR
 Integer_Literal


### PR DESCRIPTION
This PR contains the text to implement three related features:

* 7.0 binary literals
* 7.0 digit separators 
* 7.2 leading digit separators

It replaces PR #45 and PR #449.