### PR TITLE
Fixes to documentation comments

### DIFF
--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -221,7 +221,7 @@ and the external file “docs.xml” had the following contents:
     </class>
     <class name="StringList">
         <summary>
-            Contains a list of integers.
+            Contains a list of strings.
         </summary>
     </class>
 </extradoc>
@@ -230,7 +230,7 @@ and the external file “docs.xml” had the following contents:
 then the same documentation is output as if the source code contained:
 
 ```xml
-// <summary>
+/// <summary>
 /// Contains a list of integers.
 /// </summary>
 public class IntList { ... }


### PR DESCRIPTION
One based on #566, but also a typo in the included XML. I originally
thought we should delete StringList, but I assume the intention is
actually to indicate that the relevant piece of XML is included and
other pieces are ignored.

(Once this is merged, I'll make the same XML change in draft-v7.)

Rex: please update Word doc with these changes. (We need to work out when to stop doing this, of course.)