### PR TITLE
Clarified note about strings in comments

### DIFF
--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -274,9 +274,9 @@ Comments are not processed within character and string literals.
 >
 > is not actually a single-line comment, since `//` has no special meaning within a delimited comment, and so `*/` does have its usual special meaning in that line.
 >
-> Likewise, the delimited comment starting before `D` ends before `E`. The reason is that `"D */ "` is not actually a string literal, since it appears inside a delimited comment.
+> Likewise, the delimited comment starting before `D` ends before `E`. The reason is that `"D */ "` is not actually a string literal, since the initial double quote character appears inside a delimited comment.
 >
-> A useful consequence of `/*` and `*/` having no special meaning within a single-line comment is that a block of source code lines can be commented out by putting `//` at the beginning of each line. In general it does not work to put `/*` before those lines and `*/` after them, as this does not properly encapsulate delimited comments in the block, and in general may completely change the structure of such delimited comments.
+> A useful consequence of `/*` and `*/` having no special meaning within a single-line comment is that a block of source code lines can be commented out by putting `//` at the beginning of each line. In general, it does not work to put `/*` before those lines and `*/` after them, as this does not properly encapsulate delimited comments in the block, and in general may completely change the structure of such delimited comments.
 >
 > Example code:
 >


### PR DESCRIPTION
The potential string literal `"D */ "` is not wholly contained inside a comment in the example code, so I think it's confusing to say it "appears" there. Making it explicit that it's the opening `"` character that is relevant should make this note clearer.

Also, made a tiny grammar edit in the following paragraph.