### PR TITLE
Enable smarten again

### DIFF
--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -37,12 +37,12 @@ jobs:
       with:
         java-version: 15.0
 
-#    - name: Smarten quotes
-#      id: smarten-quote
-#      run: | 
-#        cd tools
-#        ./run-smarten.sh
-#      shell: bash
+    - name: Smarten quotes
+      id: smarten-quote
+      run: | 
+        cd tools
+        ./run-smarten.sh
+      shell: bash
 
     - name: Renumber sections
       id: renumber-sections

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3212,7 +3212,6 @@ The predefined multiplication operators are listed below. The operators all comp
 
   The product is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are positive finite values. `z` is the result of `x * y`, rounded to the nearest representable value. If the magnitude of the result is too large for the destination type, `z` is infinity. Because of rounding, `z` may be zero even though neither `x` nor `y` is zero.
   
-  <!-- Custom Word conversion: multiplication -->
   |       | `+y`  | `-y`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
   | :---- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
   | `+x`  | `+z`  | `-z`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
@@ -3264,7 +3263,6 @@ The predefined division operators are listed below. The operators all compute th
 
   The quotient is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are positive finite values. `z` is the result of `x / y`, rounded to the nearest representable value.
 
-  <!-- Custom Word conversion: division -->
   |       | `+y`  | `-y`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
   | :---- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
   | `+x`  | `+z`  | `-z`  | `+∞`  | `-∞`  | `+0`  | `-0`  | `NaN` |
@@ -3314,7 +3312,6 @@ The predefined remainder operators are listed below. The operators all compute t
   
   The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are positive finite values. `z` is the result of `x % y` and is computed as `x – n * y`, where n is the largest possible integer that is less than or equal to `x / y`. This method of computing the remainder is analogous to that used for integer operands, but differs from the IEC 60559 definition (in which `n` is the integer closest to `x / y`).
 
-  <!-- Custom Word conversion: remainder -->
   |       | `+y`  | `-y`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
   | :---- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
   | `+x`  | `+z`  | `+z`  | `NaN` | `NaN` | `+x`  | `+x`  | `NaN` |
@@ -3364,7 +3361,6 @@ The predefined addition operators are listed below. For numeric and enumeration 
 
   The sum is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are nonzero finite values, and `z` is the result of `x + y`,. If `x` and `y` have the same magnitude but opposite signs, `z` is positive zero. If `x + y` is too large to represent in the destination type, `z` is an infinity with the same sign as `x + y`.
 
-  <!-- Custom Word conversion: addition -->
   |       | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
   | :---- | :---: | :---: | :---: | :---: | :---: | :---: |
   | `x`   | `z`   | `x`   | `x`   | `+∞`  | `-∞`  | `NaN` |
@@ -3466,7 +3462,6 @@ The predefined subtraction operators are listed below. The operators all subtrac
 
   The difference is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are nonzero finite values, and `z` is the result of `x – y`. If `x` and `y` are equal, `z` is positive zero. If `x – y` is too large to represent in the destination type, `z` is an infinity with the same sign as `x – y`.
 
-  <!-- Custom Word conversion: subtraction -->
   |       | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
   | :---- | :---: | :---: | :---: | :---: | :---: | :---: |
   | `x`   | `z`   | `x`   | `x`   | `-∞`  | `+∞`  | `NaN` |

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3213,96 +3213,15 @@ The predefined multiplication operators are listed below. The operators all comp
   The product is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are positive finite values. `z` is the result of `x * y`, rounded to the nearest representable value. If the magnitude of the result is too large for the destination type, `z` is infinity. Because of rounding, `z` may be zero even though neither `x` nor `y` is zero.
   
   <!-- Custom Word conversion: multiplication -->
-  <table>
-  <!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-     <td><b><code>+y</code></b></td>
-      <td><b><code>-y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>-∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `+x`  | `+z`  | `-z`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>+x</code></td>
-      <td><code>+z</code></td>
-      <td><code>-z</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-x`  | `-z`  | `+z`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>-x</code></td>
-      <td><code>-z</code></td>
-      <td><code>+z</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:   `+0`  | `+0`  | `-0`  | `+0`  | `-0`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-0`  | `+0`  | `-0`  | `+0`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+  |       | `+y`  | `-y`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
+  | :---- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+  | `+x`  | `+z`  | `-z`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
+  | `-x`  | `-z`  | `+z`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` |
+  | `+0`  | `+0`  | `-0`  | `+0`  | `-0`  | `NaN` | `NaN` | `NaN` |
+  | `-0`  | `-0`  | `+0`  | `-0`  | `+0`  | `NaN` | `NaN` | `NaN` |
+  | `+∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `+∞`  | `-∞`  | `NaN` |
+  | `-∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `-∞`  | `+∞`  | `NaN` |
+  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` |
 
   (Except were otherwise noted, in the floating-point tables in [§11.9.2](expressions.md#1192-multiplication-operator)–[§11.9.6](expressions.md#1196-subtraction-operator) the use of “`+`” means the value is positive; the use of “`-`” means the value is negative; and the lack of a sign means the value may be positive or negative or has no sign (NaN).)
 - Decimal multiplication:
@@ -3346,96 +3265,15 @@ The predefined division operators are listed below. The operators all compute th
   The quotient is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are positive finite values. `z` is the result of `x / y`, rounded to the nearest representable value.
 
   <!-- Custom Word conversion: division -->
-  <table>
-  <!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-      <td><b><code>+y</code></b></td>
-      <td><b><code>-y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>-∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent:   `+x`  | `+z`  | `-z`  | `+∞`  | `-∞`  | `+0`  | `-0`  | `NaN` -->
-    <tr>
-      <td><code>+x</code></td>
-      <td><code>+z</code></td>
-      <td><code>-z</code></td>
-      <td><code>+∞</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-x`  | `-z`  | `+z`  | `-∞`  | `+∞`  | `-0`  | `+0`  | `NaN` -->
-    <tr>
-      <td><code>-x</code></td>
-      <td><code>-z</code></td>
-      <td><code>+z</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `+0`  | `+0`  | `-0`  | `NaN` | `NaN` | `+0`  | `-0`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-0`  | `+0`  | `NaN` | `NaN` | `-0`  | `+0`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `-∞`  | `-∞`  | `+∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:   `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+  |       | `+y`  | `-y`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
+  | :---- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+  | `+x`  | `+z`  | `-z`  | `+∞`  | `-∞`  | `+0`  | `-0`  | `NaN` |
+  | `-x`  | `-z`  | `+z`  | `-∞`  | `+∞`  | `-0`  | `+0`  | `NaN` |
+  | `+0`  | `+0`  | `-0`  | `NaN` | `NaN` | `+0`  | `-0`  | `NaN` |
+  | `-0`  | `-0`  | `+0`  | `NaN` | `NaN` | `-0`  | `+0`  | `NaN` |
+  | `+∞`  | `+∞`  | `-∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `NaN` |
+  | `-∞`  | `-∞`  | `+∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `NaN` |
+  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` |
 
 - Decimal division:
 
@@ -3477,96 +3315,15 @@ The predefined remainder operators are listed below. The operators all compute t
   The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are positive finite values. `z` is the result of `x % y` and is computed as `x – n * y`, where n is the largest possible integer that is less than or equal to `x / y`. This method of computing the remainder is analogous to that used for integer operands, but differs from the IEC 60559 definition (in which `n` is the integer closest to `x / y`).
 
   <!-- Custom Word conversion: remainder -->
-  <table>
-  <!-- md equivalent: ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-      <td><b><code>+y</code></b></td>
-      <td><b><code>-y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>–∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `+x`  | `+z`  | `+z`  | `NaN` | `NaN` | `+x`  | `+x`  | `NaN` -->
-    <tr>
-      <td><code>+x</code></td>
-      <td><code>+z</code></td>
-      <td><code>+z</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+x</code></td>
-      <td><code>+x</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-x`  | `-z`  | `-z`  | `NaN` | `NaN` | `-x`  | `-x`  | `NaN` -->
-    <tr>
-      <td><code>-x</code></td>
-      <td><code>-z</code></td>
-      <td><code>-z</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-x</code></td>
-      <td><code>-x</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+0`  | `+0`  | `+0`  | `NaN` | `NaN` | `+0`  | `+0`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-0`  | `-0`  | `NaN` | `NaN` | `-0`  | `-0`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+  |       | `+y`  | `-y`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
+  | :---- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+  | `+x`  | `+z`  | `+z`  | `NaN` | `NaN` | `+x`  | `+x`  | `NaN` |
+  | `-x`  | `-z`  | `-z`  | `NaN` | `NaN` | `-x`  | `-x`  | `NaN` |
+  | `+0`  | `+0`  | `+0`  | `NaN` | `NaN` | `+0`  | `+0`  | `NaN` |
+  | `-0`  | `-0`  | `-0`  | `NaN` | `NaN` | `-0`  | `-0`  | `NaN` |
+  | `+∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` |
+  | `-∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` |
+  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` |
 
 - Decimal remainder:
 
@@ -3608,78 +3365,14 @@ The predefined addition operators are listed below. For numeric and enumeration 
   The sum is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are nonzero finite values, and `z` is the result of `x + y`,. If `x` and `y` have the same magnitude but opposite signs, `z` is positive zero. If `x + y` is too large to represent in the destination type, `z` is an infinity with the same sign as `x + y`.
 
   <!-- Custom Word conversion: addition -->
-  <table>
-  <!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`* -->
-    <tr>
-      <td></td>
-      <td><b><code>y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>–∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>x</code></td>
-      <td><code>z</code></td>
-      <td><code>x</code></td>
-      <td><code>x</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+0`  | `y`   | `+0`  | `+0`  | `+∞`  | `–∞`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>y</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>+∞</code></td>
-      <td><code>–∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>y</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:   `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+  |       | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
+  | :---- | :---: | :---: | :---: | :---: | :---: | :---: |
+  | `x`   | `z`   | `x`   | `x`   | `+∞`  | `-∞`  | `NaN` |
+  | `+0`  | `y`   | `+0`  | `+0`  | `+∞`  | `–∞`  | `NaN` |
+  | `-0`  | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
+  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `NaN` |
+  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `-∞`  | `NaN` |
+  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` |
   
 - Decimal addition:
 
@@ -3774,78 +3467,14 @@ The predefined subtraction operators are listed below. The operators all subtrac
   The difference is computed according to the rules of IEC 60559 arithmetic. The following table lists the results of all possible combinations of nonzero finite values, zeros, infinities, and NaNs. In the table, `x` and `y` are nonzero finite values, and `z` is the result of `x – y`. If `x` and `y` are equal, `z` is positive zero. If `x – y` is too large to represent in the destination type, `z` is an infinity with the same sign as `x – y`.
 
   <!-- Custom Word conversion: subtraction -->
-  <table>
-  <!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-      <td><b><code>y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>–∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>x</code></td>
-      <td><code>z</code></td>
-      <td><code>x</code></td>
-      <td><code>x</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+0`  | `-y`  | `+0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>-y</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-y`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-y</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `-∞`  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>–∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+  |       | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` |
+  | :---- | :---: | :---: | :---: | :---: | :---: | :---: |
+  | `x`   | `z`   | `x`   | `x`   | `-∞`  | `+∞`  | `NaN` |
+  | `+0`  | `-y`  | `+0`  | `+0`  | `-∞`  | `+∞`  | `NaN` |
+  | `-0`  | `-y`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` |
+  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `+∞`  | `NaN` |
+  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `NaN` |
+  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` |
   
   (In the above table the `-y` entries denote the *negation* of `y`, not that the value is negative.)
 - Decimal subtraction:

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3214,95 +3214,95 @@ The predefined multiplication operators are listed below. The operators all comp
   
   <!-- Custom Word conversion: multiplication -->
   <table>
-  <!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-     <td><b><code>+y</code></b></td>
-      <td><b><code>-y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>-∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `+x`  | `+z`  | `-z`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>+x</code></td>
-      <td><code>+z</code></td>
-      <td><code>-z</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-x`  | `-z`  | `+z`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>-x</code></td>
-      <td><code>-z</code></td>
-      <td><code>+z</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:   `+0`  | `+0`  | `-0`  | `+0`  | `-0`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-0`  | `+0`  | `-0`  | `+0`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+<!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+  <tr>
+    <td></td>
+   <td><b><code>+y</code></b></td>
+    <td><b><code>-y</code></b></td>
+    <td><b><code>+0</code></b></td>
+    <td><b><code>-0</code></b></td>
+    <td><b><code>+∞</code></b></td>
+    <td><b><code>-∞</code></b></td>
+    <td><b><code>NaN</code></b></td>
+  </tr>
+<!-- md equivalent: `+x`  | `+z`  | `-z`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
+  <tr>
+    <td><code>+x</code></td>
+    <td><code>+z</code></td>
+    <td><code>-z</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-x`  | `-z`  | `+z`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
+  <tr>
+    <td><code>-x</code></td>
+    <td><code>-z</code></td>
+    <td><code>+z</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>-∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent:   `+0`  | `+0`  | `-0`  | `+0`  | `-0`  | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>+0</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-0`  | `-0`  | `+0`  | `-0`  | `+0`  | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>-0</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `+∞`  | `-∞`  | `NaN` -->
+  <tr>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `-∞`  | `+∞`  | `NaN` -->
+  <tr>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>-∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+</table>
 
   (Except were otherwise noted, in the floating-point tables in [§11.9.2](expressions.md#1192-multiplication-operator)–[§11.9.6](expressions.md#1196-subtraction-operator) the use of “`+`” means the value is positive; the use of “`-`” means the value is negative; and the lack of a sign means the value may be positive or negative or has no sign (NaN).)
 - Decimal multiplication:
@@ -3347,95 +3347,95 @@ The predefined division operators are listed below. The operators all compute th
 
   <!-- Custom Word conversion: division -->
   <table>
-  <!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-      <td><b><code>+y</code></b></td>
-      <td><b><code>-y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>-∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent:   `+x`  | `+z`  | `-z`  | `+∞`  | `-∞`  | `+0`  | `-0`  | `NaN` -->
-    <tr>
-      <td><code>+x</code></td>
-      <td><code>+z</code></td>
-      <td><code>-z</code></td>
-      <td><code>+∞</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-x`  | `-z`  | `+z`  | `-∞`  | `+∞`  | `-0`  | `+0`  | `NaN` -->
-    <tr>
-      <td><code>-x</code></td>
-      <td><code>-z</code></td>
-      <td><code>+z</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `+0`  | `+0`  | `-0`  | `NaN` | `NaN` | `+0`  | `-0`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-0`  | `+0`  | `NaN` | `NaN` | `-0`  | `+0`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `-∞`  | `-∞`  | `+∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:   `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+<!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+  <tr>
+    <td></td>
+    <td><b><code>+y</code></b></td>
+    <td><b><code>-y</code></b></td>
+    <td><b><code>+0</code></b></td>
+    <td><b><code>-0</code></b></td>
+    <td><b><code>+∞</code></b></td>
+    <td><b><code>-∞</code></b></td>
+    <td><b><code>NaN</code></b></td>
+  </tr>
+<!-- md equivalent:   `+x`  | `+z`  | `-z`  | `+∞`  | `-∞`  | `+0`  | `-0`  | `NaN` -->
+  <tr>
+    <td><code>+x</code></td>
+    <td><code>+z</code></td>
+    <td><code>-z</code></td>
+    <td><code>+∞</code></td>
+    <td><code>–∞</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-x`  | `-z`  | `+z`  | `-∞`  | `+∞`  | `-0`  | `+0`  | `NaN` -->
+  <tr>
+    <td><code>-x</code></td>
+    <td><code>-z</code></td>
+    <td><code>+z</code></td>
+    <td><code>-∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent:  `+0`  | `+0`  | `-0`  | `NaN` | `NaN` | `+0`  | `-0`  | `NaN` -->
+  <tr>
+    <td><code>+0</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-0`  | `-0`  | `+0`  | `NaN` | `NaN` | `-0`  | `+0`  | `NaN` -->
+  <tr>
+    <td><code>-0</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent:  `-∞`  | `-∞`  | `+∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent:   `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+</table>
 
 - Decimal division:
 
@@ -3478,95 +3478,95 @@ The predefined remainder operators are listed below. The operators all compute t
 
   <!-- Custom Word conversion: remainder -->
   <table>
-  <!-- md equivalent: ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-      <td><b><code>+y</code></b></td>
-      <td><b><code>-y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>–∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `+x`  | `+z`  | `+z`  | `NaN` | `NaN` | `+x`  | `+x`  | `NaN` -->
-    <tr>
-      <td><code>+x</code></td>
-      <td><code>+z</code></td>
-      <td><code>+z</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+x</code></td>
-      <td><code>+x</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-x`  | `-z`  | `-z`  | `NaN` | `NaN` | `-x`  | `-x`  | `NaN` -->
-    <tr>
-      <td><code>-x</code></td>
-      <td><code>-z</code></td>
-      <td><code>-z</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-x</code></td>
-      <td><code>-x</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+0`  | `+0`  | `+0`  | `NaN` | `NaN` | `+0`  | `+0`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-0`  | `-0`  | `NaN` | `NaN` | `-0`  | `-0`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-0</code></td>
-      <td><code>-0</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+<!-- md equivalent: ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+  <tr>
+    <td></td>
+    <td><b><code>+y</code></b></td>
+    <td><b><code>-y</code></b></td>
+    <td><b><code>+0</code></b></td>
+    <td><b><code>-0</code></b></td>
+    <td><b><code>+∞</code></b></td>
+    <td><b><code>–∞</code></b></td>
+    <td><b><code>NaN</code></b></td>
+  </tr>
+<!-- md equivalent: `+x`  | `+z`  | `+z`  | `NaN` | `NaN` | `+x`  | `+x`  | `NaN` -->
+  <tr>
+    <td><code>+x</code></td>
+    <td><code>+z</code></td>
+    <td><code>+z</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>+x</code></td>
+    <td><code>+x</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-x`  | `-z`  | `-z`  | `NaN` | `NaN` | `-x`  | `-x`  | `NaN` -->
+  <tr>
+    <td><code>-x</code></td>
+    <td><code>-z</code></td>
+    <td><code>-z</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>-x</code></td>
+    <td><code>-x</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+0`  | `+0`  | `+0`  | `NaN` | `NaN` | `+0`  | `+0`  | `NaN` -->
+  <tr>
+    <td><code>+0</code></td>
+    <td><code>+0</code></td>
+    <td><code>+0</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>+0</code></td>
+    <td><code>+0</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-0`  | `-0`  | `-0`  | `NaN` | `NaN` | `-0`  | `-0`  | `NaN` -->
+  <tr>
+    <td><code>-0</code></td>
+    <td><code>-0</code></td>
+    <td><code>-0</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>-0</code></td>
+    <td><code>-0</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+</table>
 - Decimal remainder:
 
   ```csharp
@@ -3608,77 +3608,77 @@ The predefined addition operators are listed below. For numeric and enumeration 
 
   <!-- Custom Word conversion: addition -->
   <table>
-  <!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`* -->
-    <tr>
-      <td></td>
-      <td><b><code>y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>–∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>x</code></td>
-      <td><code>z</code></td>
-      <td><code>x</code></td>
-      <td><code>x</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+0`  | `y`   | `+0`  | `+0`  | `+∞`  | `–∞`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>y</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>+∞</code></td>
-      <td><code>–∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>y</code></td>
-      <td><code>+0</code></td>
-      <td><code>-0</code></td>
-      <td><code>+∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:   `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `-∞`  | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>-∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+<!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`* -->
+  <tr>
+    <td></td>
+    <td><b><code>y</code></b></td>
+    <td><b><code>+0</code></b></td>
+    <td><b><code>-0</code></b></td>
+    <td><b><code>+∞</code></b></td>
+    <td><b><code>–∞</code></b></td>
+    <td><b><code>NaN</code></b></td>
+  </tr>
+<!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `+∞`  | `-∞`  | `NaN` -->
+  <tr>
+    <td><code>x</code></td>
+    <td><code>z</code></td>
+    <td><code>x</code></td>
+    <td><code>x</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+0`  | `y`   | `+0`  | `+0`  | `+∞`  | `–∞`  | `NaN` -->
+  <tr>
+    <td><code>+0</code></td>
+    <td><code>y</code></td>
+    <td><code>+0</code></td>
+    <td><code>+0</code></td>
+    <td><code>+∞</code></td>
+    <td><code>–∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-0`  | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
+  <tr>
+    <td><code>-0</code></td>
+    <td><code>y</code></td>
+    <td><code>+0</code></td>
+    <td><code>-0</code></td>
+    <td><code>+∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `NaN` -->
+  <tr>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent:   `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `-∞`  | `NaN` -->
+  <tr>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>-∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent:  `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+</table>
   
 - Decimal addition:
 
@@ -3774,77 +3774,77 @@ The predefined subtraction operators are listed below. The operators all subtrac
 
   <!-- Custom Word conversion: subtraction -->
   <table>
-  <!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-    <tr>
-      <td></td>
-      <td><b><code>y</code></b></td>
-      <td><b><code>+0</code></b></td>
-      <td><b><code>-0</code></b></td>
-      <td><b><code>+∞</code></b></td>
-      <td><b><code>–∞</code></b></td>
-      <td><b><code>NaN</code></b></td>
-    </tr>
-  <!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>x</code></td>
-      <td><code>z</code></td>
-      <td><code>x</code></td>
-      <td><code>x</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+0`  | `-y`  | `+0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>+0</code></td>
-      <td><code>-y</code></td>
-      <td><code>+0</code></td>
-      <td><code>+0</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `-0`  | `-y`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>-0</code></td>
-      <td><code>-y</code></td>
-      <td><code>-0</code></td>
-      <td><code>+0</code></td>
-      <td><code>–∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `+∞`  | `NaN` -->
-    <tr>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>+∞</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent:  `-∞`  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `NaN` -->
-    <tr>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>-∞</code></td>
-      <td><code>–∞</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-    <tr>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-      <td><code>NaN</code></td>
-    </tr>
-  </table>
+<!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+  <tr>
+    <td></td>
+    <td><b><code>y</code></b></td>
+    <td><b><code>+0</code></b></td>
+    <td><b><code>-0</code></b></td>
+    <td><b><code>+∞</code></b></td>
+    <td><b><code>–∞</code></b></td>
+    <td><b><code>NaN</code></b></td>
+  </tr>
+<!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `-∞`  | `+∞`  | `NaN` -->
+  <tr>
+    <td><code>x</code></td>
+    <td><code>z</code></td>
+    <td><code>x</code></td>
+    <td><code>x</code></td>
+    <td><code>–∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+0`  | `-y`  | `+0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
+  <tr>
+    <td><code>+0</code></td>
+    <td><code>-y</code></td>
+    <td><code>+0</code></td>
+    <td><code>+0</code></td>
+    <td><code>–∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `-0`  | `-y`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
+  <tr>
+    <td><code>-0</code></td>
+    <td><code>-y</code></td>
+    <td><code>-0</code></td>
+    <td><code>+0</code></td>
+    <td><code>–∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `+∞`  | `NaN` -->
+  <tr>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>+∞</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent:  `-∞`  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `NaN` -->
+  <tr>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>-∞</code></td>
+    <td><code>–∞</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+<!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+  <tr>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+    <td><code>NaN</code></td>
+  </tr>
+</table>
   
   (In the above table the `-y` entries denote the *negation* of `y`, not that the value is negative.)
 - Decimal subtraction:

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3567,6 +3567,7 @@ The predefined remainder operators are listed below. The operators all compute t
       <td><code>NaN</code></td>
     </tr>
   </table>
+
 - Decimal remainder:
 
   ```csharp

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3214,95 +3214,95 @@ The predefined multiplication operators are listed below. The operators all comp
   
   <!-- Custom Word conversion: multiplication -->
   <table>
-<!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-  <tr>
-    <td></td>
-   <td><b><code>+y</code></b></td>
-    <td><b><code>-y</code></b></td>
-    <td><b><code>+0</code></b></td>
-    <td><b><code>-0</code></b></td>
-    <td><b><code>+∞</code></b></td>
-    <td><b><code>-∞</code></b></td>
-    <td><b><code>NaN</code></b></td>
-  </tr>
-<!-- md equivalent: `+x`  | `+z`  | `-z`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
-  <tr>
-    <td><code>+x</code></td>
-    <td><code>+z</code></td>
-    <td><code>-z</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-x`  | `-z`  | `+z`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-  <tr>
-    <td><code>-x</code></td>
-    <td><code>-z</code></td>
-    <td><code>+z</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>-∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent:   `+0`  | `+0`  | `-0`  | `+0`  | `-0`  | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>+0</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-0`  | `-0`  | `+0`  | `-0`  | `+0`  | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>-0</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `+∞`  | `-∞`  | `NaN` -->
-  <tr>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `-∞`  | `+∞`  | `NaN` -->
-  <tr>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>-∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-</table>
+  <!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+    <tr>
+      <td></td>
+     <td><b><code>+y</code></b></td>
+      <td><b><code>-y</code></b></td>
+      <td><b><code>+0</code></b></td>
+      <td><b><code>-0</code></b></td>
+      <td><b><code>+∞</code></b></td>
+      <td><b><code>-∞</code></b></td>
+      <td><b><code>NaN</code></b></td>
+    </tr>
+  <!-- md equivalent: `+x`  | `+z`  | `-z`  | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
+    <tr>
+      <td><code>+x</code></td>
+      <td><code>+z</code></td>
+      <td><code>-z</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-x`  | `-z`  | `+z`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
+    <tr>
+      <td><code>-x</code></td>
+      <td><code>-z</code></td>
+      <td><code>+z</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>-∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent:   `+0`  | `+0`  | `-0`  | `+0`  | `-0`  | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>+0</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-0`  | `-0`  | `+0`  | `-0`  | `+0`  | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>-0</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `+∞`  | `-∞`  | `NaN` -->
+    <tr>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `-∞`  | `+∞`  | `NaN` -->
+    <tr>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>-∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  </table>
 
   (Except were otherwise noted, in the floating-point tables in [§11.9.2](expressions.md#1192-multiplication-operator)–[§11.9.6](expressions.md#1196-subtraction-operator) the use of “`+`” means the value is positive; the use of “`-`” means the value is negative; and the lack of a sign means the value may be positive or negative or has no sign (NaN).)
 - Decimal multiplication:
@@ -3347,95 +3347,95 @@ The predefined division operators are listed below. The operators all compute th
 
   <!-- Custom Word conversion: division -->
   <table>
-<!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-  <tr>
-    <td></td>
-    <td><b><code>+y</code></b></td>
-    <td><b><code>-y</code></b></td>
-    <td><b><code>+0</code></b></td>
-    <td><b><code>-0</code></b></td>
-    <td><b><code>+∞</code></b></td>
-    <td><b><code>-∞</code></b></td>
-    <td><b><code>NaN</code></b></td>
-  </tr>
-<!-- md equivalent:   `+x`  | `+z`  | `-z`  | `+∞`  | `-∞`  | `+0`  | `-0`  | `NaN` -->
-  <tr>
-    <td><code>+x</code></td>
-    <td><code>+z</code></td>
-    <td><code>-z</code></td>
-    <td><code>+∞</code></td>
-    <td><code>–∞</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-x`  | `-z`  | `+z`  | `-∞`  | `+∞`  | `-0`  | `+0`  | `NaN` -->
-  <tr>
-    <td><code>-x</code></td>
-    <td><code>-z</code></td>
-    <td><code>+z</code></td>
-    <td><code>-∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent:  `+0`  | `+0`  | `-0`  | `NaN` | `NaN` | `+0`  | `-0`  | `NaN` -->
-  <tr>
-    <td><code>+0</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-0`  | `-0`  | `+0`  | `NaN` | `NaN` | `-0`  | `+0`  | `NaN` -->
-  <tr>
-    <td><code>-0</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent:  `-∞`  | `-∞`  | `+∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent:   `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-</table>
+  <!-- md equivalent:   ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+    <tr>
+      <td></td>
+      <td><b><code>+y</code></b></td>
+      <td><b><code>-y</code></b></td>
+      <td><b><code>+0</code></b></td>
+      <td><b><code>-0</code></b></td>
+      <td><b><code>+∞</code></b></td>
+      <td><b><code>-∞</code></b></td>
+      <td><b><code>NaN</code></b></td>
+    </tr>
+  <!-- md equivalent:   `+x`  | `+z`  | `-z`  | `+∞`  | `-∞`  | `+0`  | `-0`  | `NaN` -->
+    <tr>
+      <td><code>+x</code></td>
+      <td><code>+z</code></td>
+      <td><code>-z</code></td>
+      <td><code>+∞</code></td>
+      <td><code>–∞</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-x`  | `-z`  | `+z`  | `-∞`  | `+∞`  | `-0`  | `+0`  | `NaN` -->
+    <tr>
+      <td><code>-x</code></td>
+      <td><code>-z</code></td>
+      <td><code>+z</code></td>
+      <td><code>-∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent:  `+0`  | `+0`  | `-0`  | `NaN` | `NaN` | `+0`  | `-0`  | `NaN` -->
+    <tr>
+      <td><code>+0</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-0`  | `-0`  | `+0`  | `NaN` | `NaN` | `-0`  | `+0`  | `NaN` -->
+    <tr>
+      <td><code>-0</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+∞`  | `+∞`  | `-∞`  | `+∞`  | `-∞`  | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent:  `-∞`  | `-∞`  | `+∞`  | `-∞`  | `+∞`  | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent:   `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  </table>
 
 - Decimal division:
 
@@ -3478,95 +3478,95 @@ The predefined remainder operators are listed below. The operators all compute t
 
   <!-- Custom Word conversion: remainder -->
   <table>
-<!-- md equivalent: ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-  <tr>
-    <td></td>
-    <td><b><code>+y</code></b></td>
-    <td><b><code>-y</code></b></td>
-    <td><b><code>+0</code></b></td>
-    <td><b><code>-0</code></b></td>
-    <td><b><code>+∞</code></b></td>
-    <td><b><code>–∞</code></b></td>
-    <td><b><code>NaN</code></b></td>
-  </tr>
-<!-- md equivalent: `+x`  | `+z`  | `+z`  | `NaN` | `NaN` | `+x`  | `+x`  | `NaN` -->
-  <tr>
-    <td><code>+x</code></td>
-    <td><code>+z</code></td>
-    <td><code>+z</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>+x</code></td>
-    <td><code>+x</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-x`  | `-z`  | `-z`  | `NaN` | `NaN` | `-x`  | `-x`  | `NaN` -->
-  <tr>
-    <td><code>-x</code></td>
-    <td><code>-z</code></td>
-    <td><code>-z</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>-x</code></td>
-    <td><code>-x</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+0`  | `+0`  | `+0`  | `NaN` | `NaN` | `+0`  | `+0`  | `NaN` -->
-  <tr>
-    <td><code>+0</code></td>
-    <td><code>+0</code></td>
-    <td><code>+0</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>+0</code></td>
-    <td><code>+0</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-0`  | `-0`  | `-0`  | `NaN` | `NaN` | `-0`  | `-0`  | `NaN` -->
-  <tr>
-    <td><code>-0</code></td>
-    <td><code>-0</code></td>
-    <td><code>-0</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>-0</code></td>
-    <td><code>-0</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-</table>
+  <!-- md equivalent: ` `   | **`+y`**  | **`-y`**  | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+    <tr>
+      <td></td>
+      <td><b><code>+y</code></b></td>
+      <td><b><code>-y</code></b></td>
+      <td><b><code>+0</code></b></td>
+      <td><b><code>-0</code></b></td>
+      <td><b><code>+∞</code></b></td>
+      <td><b><code>–∞</code></b></td>
+      <td><b><code>NaN</code></b></td>
+    </tr>
+  <!-- md equivalent: `+x`  | `+z`  | `+z`  | `NaN` | `NaN` | `+x`  | `+x`  | `NaN` -->
+    <tr>
+      <td><code>+x</code></td>
+      <td><code>+z</code></td>
+      <td><code>+z</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>+x</code></td>
+      <td><code>+x</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-x`  | `-z`  | `-z`  | `NaN` | `NaN` | `-x`  | `-x`  | `NaN` -->
+    <tr>
+      <td><code>-x</code></td>
+      <td><code>-z</code></td>
+      <td><code>-z</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>-x</code></td>
+      <td><code>-x</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+0`  | `+0`  | `+0`  | `NaN` | `NaN` | `+0`  | `+0`  | `NaN` -->
+    <tr>
+      <td><code>+0</code></td>
+      <td><code>+0</code></td>
+      <td><code>+0</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>+0</code></td>
+      <td><code>+0</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-0`  | `-0`  | `-0`  | `NaN` | `NaN` | `-0`  | `-0`  | `NaN` -->
+    <tr>
+      <td><code>-0</code></td>
+      <td><code>-0</code></td>
+      <td><code>-0</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>-0</code></td>
+      <td><code>-0</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-∞`  | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  </table>
 - Decimal remainder:
 
   ```csharp
@@ -3608,77 +3608,77 @@ The predefined addition operators are listed below. For numeric and enumeration 
 
   <!-- Custom Word conversion: addition -->
   <table>
-<!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`* -->
-  <tr>
-    <td></td>
-    <td><b><code>y</code></b></td>
-    <td><b><code>+0</code></b></td>
-    <td><b><code>-0</code></b></td>
-    <td><b><code>+∞</code></b></td>
-    <td><b><code>–∞</code></b></td>
-    <td><b><code>NaN</code></b></td>
-  </tr>
-<!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `+∞`  | `-∞`  | `NaN` -->
-  <tr>
-    <td><code>x</code></td>
-    <td><code>z</code></td>
-    <td><code>x</code></td>
-    <td><code>x</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+0`  | `y`   | `+0`  | `+0`  | `+∞`  | `–∞`  | `NaN` -->
-  <tr>
-    <td><code>+0</code></td>
-    <td><code>y</code></td>
-    <td><code>+0</code></td>
-    <td><code>+0</code></td>
-    <td><code>+∞</code></td>
-    <td><code>–∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-0`  | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
-  <tr>
-    <td><code>-0</code></td>
-    <td><code>y</code></td>
-    <td><code>+0</code></td>
-    <td><code>-0</code></td>
-    <td><code>+∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `NaN` -->
-  <tr>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent:   `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `-∞`  | `NaN` -->
-  <tr>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>-∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent:  `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-</table>
+  <!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`* -->
+    <tr>
+      <td></td>
+      <td><b><code>y</code></b></td>
+      <td><b><code>+0</code></b></td>
+      <td><b><code>-0</code></b></td>
+      <td><b><code>+∞</code></b></td>
+      <td><b><code>–∞</code></b></td>
+      <td><b><code>NaN</code></b></td>
+    </tr>
+  <!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `+∞`  | `-∞`  | `NaN` -->
+    <tr>
+      <td><code>x</code></td>
+      <td><code>z</code></td>
+      <td><code>x</code></td>
+      <td><code>x</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+0`  | `y`   | `+0`  | `+0`  | `+∞`  | `–∞`  | `NaN` -->
+    <tr>
+      <td><code>+0</code></td>
+      <td><code>y</code></td>
+      <td><code>+0</code></td>
+      <td><code>+0</code></td>
+      <td><code>+∞</code></td>
+      <td><code>–∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-0`  | `y`   | `+0`  | `-0`  | `+∞`  | `-∞`  | `NaN` -->
+    <tr>
+      <td><code>-0</code></td>
+      <td><code>y</code></td>
+      <td><code>+0</code></td>
+      <td><code>-0</code></td>
+      <td><code>+∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `NaN` -->
+    <tr>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent:   `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `-∞`  | `NaN` -->
+    <tr>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>-∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent:  `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  </table>
   
 - Decimal addition:
 
@@ -3774,77 +3774,77 @@ The predefined subtraction operators are listed below. The operators all subtrac
 
   <!-- Custom Word conversion: subtraction -->
   <table>
-<!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
-  <tr>
-    <td></td>
-    <td><b><code>y</code></b></td>
-    <td><b><code>+0</code></b></td>
-    <td><b><code>-0</code></b></td>
-    <td><b><code>+∞</code></b></td>
-    <td><b><code>–∞</code></b></td>
-    <td><b><code>NaN</code></b></td>
-  </tr>
-<!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `-∞`  | `+∞`  | `NaN` -->
-  <tr>
-    <td><code>x</code></td>
-    <td><code>z</code></td>
-    <td><code>x</code></td>
-    <td><code>x</code></td>
-    <td><code>–∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+0`  | `-y`  | `+0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-  <tr>
-    <td><code>+0</code></td>
-    <td><code>-y</code></td>
-    <td><code>+0</code></td>
-    <td><code>+0</code></td>
-    <td><code>–∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `-0`  | `-y`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
-  <tr>
-    <td><code>-0</code></td>
-    <td><code>-y</code></td>
-    <td><code>-0</code></td>
-    <td><code>+0</code></td>
-    <td><code>–∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `+∞`  | `NaN` -->
-  <tr>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>+∞</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent:  `-∞`  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `NaN` -->
-  <tr>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>-∞</code></td>
-    <td><code>–∞</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-<!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
-  <tr>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-    <td><code>NaN</code></td>
-  </tr>
-</table>
+  <!-- md equivalent: ` `   | **`y`**   | **`+0`**  | **`-0`**  | **`+∞`**  | **`-∞`**  | **`NaN`** -->
+    <tr>
+      <td></td>
+      <td><b><code>y</code></b></td>
+      <td><b><code>+0</code></b></td>
+      <td><b><code>-0</code></b></td>
+      <td><b><code>+∞</code></b></td>
+      <td><b><code>–∞</code></b></td>
+      <td><b><code>NaN</code></b></td>
+    </tr>
+  <!-- md equivalent: `x`   | `z`   | `x`   | `x`   | `-∞`  | `+∞`  | `NaN` -->
+    <tr>
+      <td><code>x</code></td>
+      <td><code>z</code></td>
+      <td><code>x</code></td>
+      <td><code>x</code></td>
+      <td><code>–∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+0`  | `-y`  | `+0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
+    <tr>
+      <td><code>+0</code></td>
+      <td><code>-y</code></td>
+      <td><code>+0</code></td>
+      <td><code>+0</code></td>
+      <td><code>–∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `-0`  | `-y`  | `-0`  | `+0`  | `-∞`  | `+∞`  | `NaN` -->
+    <tr>
+      <td><code>-0</code></td>
+      <td><code>-y</code></td>
+      <td><code>-0</code></td>
+      <td><code>+0</code></td>
+      <td><code>–∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `+∞`  | `+∞`  | `+∞`  | `+∞`  | `NaN` | `+∞`  | `NaN` -->
+    <tr>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>+∞</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent:  `-∞`  | `-∞`  | `-∞`  | `-∞`  | `-∞`  | `NaN` | `NaN` -->
+    <tr>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>-∞</code></td>
+      <td><code>–∞</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  <!-- md equivalent: `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` | `NaN` -->
+    <tr>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+      <td><code>NaN</code></td>
+    </tr>
+  </table>
   
   (In the above table the `-y` entries denote the *negation* of `y`, not that the value is negative.)
 - Decimal subtraction:


### PR DESCRIPTION
Turn on the config that runs smarten on each PR merge.

Note the changes in expressions.md.  Our smarten tool out-dents that table. There are two possible fixes: 

1. replace the HTML table with a markdown table. Issue: Will the Word converter work?
2. Fix the smarten code. Issue: That's not quite so simple.

Ping @jskeet @Nigel-Ecma for thoughts.
