### PR TITLE
Reconcile prose with grammar for compilation_unit 

### DIFF
--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -8,7 +8,7 @@ Using directives ([§13.5](namespaces.md#135-using-directives)) are provided to 
 
 ## 13.2 Compilation units
 
-A *compilation_unit* consists of zero or more *extern_alias_directive*s followed by zero or more *using_directive*s followed by zero or more *global_attributes* followed by zero or more *namespace_member_declaration*s. The *compilation_unit* defines the overall structure of the input.
+A *compilation_unit* consists of zero or more *extern_alias_directive*s followed by zero or more *using_directive*s followed by zero or one *global_attributes* followed by zero or more *namespace_member_declaration*s. The *compilation_unit* defines the overall structure of the input.
 
 ```ANTLR
 compilation_unit


### PR DESCRIPTION
Private mail to Jon: I’m working on namespace-related spec text, and I believe I’ve come across a contradiction between the [grammar and prose for *compilation_unit*](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/namespaces.md#132-compilation-units) that has existed since V1!
 
The prose says: 
 
> A *compilation_unit* consists of zero or more *extern_alias_directive*s followed by zero or more *using_directive*s followed by **zero or more** *global_attributes* followed by zero or more *namespace_member_declaration*s.
 
However, the grammar says:
 
> ```ANTLR
> compilation_unit
>     : extern_alias_directive* using_directive* global_attributes?
>       namespace_member_declaration*
>     ;
> ```
 
[In V5, prior to moving to ANTLR notation, the ? was the subscript opt.]
 
The ? means “zero or one” while the prose says “zero or more.” I believe the grammar is correct and that that prose should say “zero or one.”
 
Here’s my analysis: Consider a compilation unit starting with the following lines:
 
```csharp
[module: Attr1, Attr2]
[module: Attr3]
```
 
Is this a single *global_attributes* with 2 sections (the […]-delimited bits), or two *global_attributes* each with 1 section? As I read it, the grammar for *global_attributes* already allows for multiple sections, and that is how the above lines would be parsed, so there is no need to ever have/allow multiple *global_attributes*.

Jon's reply: Yes, that looks like it should be zero or one. If we were describing it in terms of "logical features" it would be zero or more "global attributes" (no underscore) but with the underscore, it's definitely the rule...