### PR TITLE
C# 7.x: ref struct

### DIFF
--- a/standard/structs.md
+++ b/standard/structs.md
@@ -560,7 +560,7 @@ The result of a stackalloc expression has safe-scope of current-method. It is no
 
 A `new` expression that invokes a constructor obeys the same rules as a method invocation that is considered to return the type being constructed.
 
-In addition the safe-scope is no wider than the smallest of the safe-scopes of all arguments and operands of all object initializer expressions, recursively, if any initializer is present.
+In addition the safe-scope is the smallest of the safe-scopes of all arguments and operands of all object initializer expressions, recursively, if any initializer is present.
 
 > *Note*: These rules rely on `Span<T>` not having a constructor of the following form:
 >

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -506,7 +506,7 @@ Automatically implemented properties ([§15.7.4](classes.md#1574-automatically-i
 
 #### safe-scope-rules-general General
 
-At compile-time, each expression whose type is a ref struct is associated with a scope where that instance is safe, its ***safe-scope***. The ***safe-scope*** is a scope, enclosing an expression, to which it is safe for the value to escape to. If that scope is the entire function member, we say that the value is ***safe-to-return*** from the function member.
+At compile-time, each expression whose type is a ref struct is associated with a scope where that instance is safe, its ***safe-scope***. The safe-scope is a scope, enclosing an expression, to which it is safe for the value to escape to. If that scope is the entire function member, we say that the value is ***safe-to-return*** from the function member.
 
 The safe-scope records which scope a ref struct may be copied into. Given an assignment from an expression `E1` with a safe-scope `S1`, to an expression `E2` with safe-scope `S2`, it is an error if `S2` is a wider scope than `S1`.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -506,7 +506,7 @@ Automatically implemented properties ([§15.7.4](classes.md#1574-automatically-i
 
 #### §safe-context-rules-general General
 
-At compile-time, each expression whose type is a ref struct is associated with a context where that instance is safe, its ***safe-context***. The safe-context is a context, enclosing an expression, which it is safe for the value to escape to. If that context is the entire function member, we say that the value is ***safe-to-return*** from the function member.
+At compile-time, each expression whose type is a ref struct is associated with a context where that instance and all its fields can be safely accessed, its ***safe-context***. The safe-context is a context, enclosing an expression, which it is safe for the value to escape to. If that context is the entire function member, we say that the value is ***safe-to-return*** from the function member.
 
 The safe-context records which context a ref struct may be copied into. Given an assignment from an expression `E1` with a safe-context `S1`, to an expression `E2` with safe-context `S2`, it is an error if `S2` is a wider context than `S1`.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -16,17 +16,19 @@ A *struct_declaration* is a *type_declaration* ([§14.7](namespaces.md#147-type-
 
 ```ANTLR
 struct_declaration
-    : attributes? struct_modifier* 'partial'? 'struct'
+    : attributes? struct_modifier* 'ref'? 'partial'? 'struct'
       identifier type_parameter_list? struct_interfaces?
       type_parameter_constraints_clause* struct_body ';'?
     ;
 ```
 
-A *struct_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *struct_modifier*s ([§16.2.2](structs.md#1622-struct-modifiers)), followed by an optional partial modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword `struct` and an *identifier* that names the struct, followed by an optional *type_parameter_list* specification ([§15.2.3](classes.md#1523-type-parameters)), followed by an optional *struct_interfaces* specification ([§16.2.4](structs.md#1624-struct-interfaces)), followed by an optional *type_parameter_constraints-clauses* specification ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by a *struct_body* ([§16.2.5](structs.md#1625-struct-body)), optionally followed by a semicolon.
+A *struct_declaration* consists of an optional set of *attributes* ([§22](attributes.md#22-attributes)), followed by an optional set of *struct_modifier*s ([§16.2.2](structs.md#1622-struct-modifiers)), followed by an optional `ref` modifier (§ref-modifier-new-clause), followed by an optional partial modifier ([§15.2.7](classes.md#1527-partial-declarations)), followed by the keyword `struct` and an *identifier* that names the struct, followed by an optional *type_parameter_list* specification ([§15.2.3](classes.md#1523-type-parameters)), followed by an optional *struct_interfaces* specification ([§16.2.4](structs.md#1624-struct-interfaces)), followed by an optional *type_parameter_constraints-clauses* specification ([§15.2.5](classes.md#1525-type-parameter-constraints)), followed by a *struct_body* ([§16.2.5](structs.md#1625-struct-body)), optionally followed by a semicolon.
 
 A struct declaration shall not supply a *type_parameter_constraints_clauses* unless it also supplies a *type_parameter_list*.
 
 A struct declaration that supplies a *type_parameter_list* is a generic struct declaration. Additionally, any struct nested inside a generic class declaration or a generic struct declaration is itself a generic struct declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
+
+A struct declaration that includes a 'ref' keyword may not have a *struct_interfaces* part.
 
 ### 16.2.2 Struct modifiers
 
@@ -59,6 +61,22 @@ A readonly struct has the following constraints:
 - It shall not declare any field-like events ([§15.8.2](classes.md#1582-field-like-events)).
 
 When an instance of a readonly struct is passed to a method, its `this` is treated like an `in` argument/parameter, which disallows write access to any instance fields (except by constructors).
+
+### §ref-modifier-new-clause Ref modifier
+
+The `ref` modifier indicates that the *struct_declaration* declares a type whose instances are allocated on the execution stack.
+
+It is a compile-time error if a ref struct type is used in any of the following contexts:
+
+- As the element type of an array.
+- As the declared type of a field of a class or a non-ref struct.
+- To implement an interface.
+- Being boxed to `System.ValueType` or `System.Object`.
+- As a type argument.
+- An async method.
+- An iterator.
+
+A ref struct can't be captured by a lambda expression or a local function.
 
 ### 16.2.3 Partial modifier
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -530,8 +530,8 @@ A formal parameter of a ref struct type, including the `this` parameter of an in
 A local variable of a ref struct type has a safe-scope as follows:
 
 - If the variable is an iteration variable of a `foreach` loop, then the variable's safe-scope is the same as the safe-scope of the `foreach` loop's expression.
-- A local of `ref struct` type which is uninitialized at the point of declaration has a safe-scope of calling method.
-- Otherwise the variable's declaration requires an initializer. The variable's safe-scope is the same as the safe-scope of its initializer.
+- Otherwise if the variable's declaration has an initializer then the variable's safe-scope is the same as the safe-scope of that initializer.
+
 
 #### safe-scope-rules-field Field safe scope
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -76,6 +76,8 @@ It is a compile-time error if a ref struct type is used in any of the following 
 - An async method.
 - An iterator.
 
+> *Note*: A `ref struct` may not declare `async` methods nor use a `yield return` or `yield break` statement because the implicit `this` parameter cannot be used in those contexts. *end note*
+
 A ref struct can't be captured by a lambda expression or a local function.
 
 The *ref_safe_scope* rules for *reference_variables* apply to instances of ref struct.

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -28,7 +28,7 @@ A struct declaration shall not supply a *type_parameter_constraints_clauses* unl
 
 A struct declaration that supplies a *type_parameter_list* is a generic struct declaration. Additionally, any struct nested inside a generic class declaration or a generic struct declaration is itself a generic struct declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
 
-A struct declaration that includes a `ref` keyword may not have a *struct_interfaces* part.
+A struct declaration that includes a `ref` keyword shall not have a *struct_interfaces* part.
 
 ### 16.2.2 Struct modifiers
 
@@ -76,9 +76,9 @@ It is a compile-time error if a ref struct type is used in any of the following 
 - An async method.
 - An iterator.
 
-> *Note*: A `ref struct` may not declare `async` methods nor use a `yield return` or `yield break` statement because the implicit `this` parameter cannot be used in those contexts. *end note*
+> *Note*: A `ref struct` shall not declare `async` methods nor use a `yield return` or `yield break` statement because the implicit `this` parameter cannot be used in those contexts. *end note*
 
-A ref struct can't be captured by a lambda expression or a local function.
+A ref struct shall not be captured by a lambda expression or a local function.
 
 The *ref_safe_scope* rules for *reference_variables* apply to instances of ref struct.
 
@@ -503,7 +503,7 @@ Automatically implemented properties ([§15.7.4](classes.md#1574-automatically-i
 
 A `ref struct` may contain *ref_like field*s. A *ref_like field* is a *reference_variable* (§ref-span-safety). An instance of a `ref struct` may not be copied outside the *ref_safe_scope* (§ref-span-safety-escape-scopes) of any of its ref-like fields. The *ref_safe_scope* of a ref struct is determined from its initializing expression.
 
-The default value of ref-like fields is the value of the `default` expression (§12.8.20) which is a null reference. The *ref_safe_scope* of a null reference is *caller_scope*. A `ref struct` initialized to its default value can be copied to the *caller_scope*.
+The default value of ref-like fields is the value of the `default` expression (§12.8.20) which is the 0 bit pattern. The *ref_safe_scope* of the `default` expression is *caller_scope*. A `ref struct` initialized to its default value can be copied to the *caller_scope*.
 
 An instance of a `ref struct` `S` requires an initializing ref expression, `ref e` for any ref like fields. The *ref_safe_scope* of `e` determines the *ref_safe_scope* for `S`.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -64,7 +64,7 @@ When an instance of a readonly struct is passed to a method, its `this` is treat
 
 ### §ref-modifier-new-clause Ref modifier
 
-The `ref` modifier indicates that the *struct_declaration* declares a type whose instances are allocated on the execution stack. The `ref` modifier declares that instances may contain ref-like fields, and may not be copied out of its safe-context (§safe-context-rules). The rules for determining the safe context of a `ref struct` are described in §safe-context-rules.
+The `ref` modifier indicates that the *struct_declaration* declares a type whose instances are allocated on the execution stack. These types are are called ***ref struct*** types. The `ref` modifier declares that instances may contain ref-like fields, and may not be copied out of its safe-context (§safe-context-rules). The rules for determining the safe context of a ref struct are described in §safe-context-rules.
 
 It is a compile-time error if a ref struct type is used in any of the following contexts:
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -64,7 +64,7 @@ When an instance of a readonly struct is passed to a method, its `this` is treat
 
 ### §ref-modifier-new-clause Ref modifier
 
-The `ref` modifier indicates that the *struct_declaration* declares a type whose instances are allocated on the execution stack. The `ref` modifier declares that instances may contain ref-like fields, and must obey the *ref_safe_scope* rules. Instances of the ref struct may not be copied out of the *ref_safe_scope* of any of its ref-like fields. The rules for determining the *safe_scope* of a `ref struct` are described in §ref-like-field-initialization.
+The `ref` modifier indicates that the *struct_declaration* declares a type whose instances are allocated on the execution stack. The `ref` modifier declares that instances may contain ref-like fields, and must obey the *ref_safe_scope* rules. Instances of the ref struct may not be copied out of the *ref_safe_scope* of any of its ref-like fields. The rules for determining the *ref_safe_scope* of a `ref struct` are described in §ref-like-field-initialization.
 
 It is a compile-time error if a ref struct type is used in any of the following contexts:
 
@@ -503,7 +503,7 @@ Automatically implemented properties ([§15.7.4](classes.md#1574-automatically-i
 
 A `ref struct` may contain *ref_like field*s. A *ref_like field* is a *reference_variable* (§ref-span-safety). An instance of a `ref struct` may not be copied outside the *ref_safe_scope* (§ref-span-safety-escape-scopes) of any of its ref-like fields. The *ref_safe_scope* of a ref struct is determined from its initializing expression.
 
-The default value of ref-like fields is the value of the `default` expression, a null reference. The *ref_safe_scope* of a null reference is *caller_scope*. A `ref struct` initialized to its default value can be copied to the *caller_scope*.
+The default value of ref-like fields is the value of the `default` expression (§12.8.20) which is a null reference. The *ref_safe_scope* of a null reference is *caller_scope*. A `ref struct` initialized to its default value can be copied to the *caller_scope*.
 
 An instance of a `ref struct` `S` requires an initializing ref expression, `ref e` for any ref like fields. The *ref_safe_scope* of `e` determines the *ref_safe_scope* for `S`.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -499,7 +499,7 @@ Automatically implemented properties ([§15.7.4](classes.md#1574-automatically-i
 
 ### §ref-like-field-initialization Ref safe scopes
 
-A `ref struct` may contain *ref_like field*s. A *ref_like field* is a *reference_variable* (§ref-span-safety). An instance of a `ref struct` may not be copied outside the *ref_safe_scope* (§ref-span-safety-escape-scopes) of any of its ref-like fields. The *ref_safe_scope* of a ref struct `s` , 
+A `ref struct` may contain *ref_like field*s. A *ref_like field* is a *reference_variable* (§ref-span-safety). An instance of a `ref struct` may not be copied outside the *ref_safe_scope* (§ref-span-safety-escape-scopes) of any of its ref-like fields. The *ref_safe_scope* of a ref struct is determined from its initializing expression.
 
 The default value of ref-like fields is the value of the `default` expression, a null reference. The *ref_safe_scope* of a null reference is *caller_scope*. A `ref struct` initialized to its default value can be copied to the *caller_scope*.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -83,7 +83,7 @@ It is a compile-time error if a ref struct type is used in any of the following 
 - An instance method of a `ref struct` type shall not be captured by method group conversion to a delegate type.
 - A ref struct shall not be captured by a lambda expression or a local function.
 
-These constraints ensure that no variable of `ref struct` type refers to stack memory or variables that are no longer valid.
+These constraints ensure that a variable of `ref struct` type does not refer to stack memory that is no longer valid, or to variables that are no longer valid.
 
 ### 16.2.3 Partial modifier
 
@@ -531,7 +531,7 @@ A local variable of a ref struct type has a safe-scope as follows:
 
 - If the variable is an iteration variable of a `foreach` loop, then the variable's safe-scope is the same as the safe-scope of the `foreach` loop's expression.
 - Otherwise if the variable's declaration has an initializer then the variable's safe-scope is the same as the safe-scope of that initializer.
-
+- Otherwise the variable is uninitialized at the point of declaration and has a safe-scope of the calling method.
 
 #### safe-scope-rules-field Field safe scope
 


### PR DESCRIPTION
Split out `ref struct` from #333.

This still needs to safety rules to be incorporated.  See https://github.com/dotnet/csharpstandard/issues/334 and https://github.com/dotnet/csharplang/blob/standard-proposals/proposals/csharp-7.2/span-safety.md#draft-language-specification .  Those safety rules are for ref return, ref locals, and ref structs.

Fixes #267 
Fixes #334 
