### PR TITLE
Make 11.7.3, "Interpolated string expressions," narrative match the grammar

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1198,7 +1198,7 @@ A *primary_expression* that consists of a *literal* ([§6.4.5](lexical-structure
 
 ### 11.7.3 Interpolated string expressions
 
-An *interpolated_string_expression* consists of a `$` character immediately followed by text within `"` characters. Within the quoted text there are zero or more ***interpolations*** delimited by `{` and `}` characters, each of which encloses an *expression* and optional formatting specifications.
+An *interpolated_string_expression* consists of `$` or `$@` immediately followed by text within `"` characters. Within the quoted text there are zero or more ***interpolations*** delimited by `{` and `}` characters, each of which encloses an *expression* and optional formatting specifications.
 
 Interpolated string expressions have two forms; regular (*interpolated_regular_string_expression*)
 and verbatim (*interpolated_verbatim_string_expression*); which are lexically similar to, but differ semantically from, the two forms of string


### PR DESCRIPTION
In [11.7.3 Interpolated string expressions](https://github.com/RexJaeschke/csharpstandard/blob/draft-v7/standard/expressions.md#1173-interpolated-string-expressions), we have the following: 
 
> An *interpolated_string_expression* consists of a `$` character immediately followed by text within `"` characters. …
 
However, this does *not* allow for an interpolated verbatim string expression, which starts with `$@`. As such, I propose this sentence be changed to the following:
 
> An *interpolated_string_expression* consists of `$` or `$@` immediately followed by text within `"` characters. …

I stumbled on this when I discovered that V8 allows `@$` as well, which I will have to add then.