### PR TITLE
add draft-v7 branch to runners

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - draft-v6
+      - draft-v7
     paths:
       - "standard/*.md"
       - ".markdownlint.json"

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -5,7 +5,8 @@ name: Update spec on merge
 on: 
   push:
     branches:
-      - draft-v6 
+      - draft-v6
+      - draft-v7
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
We weren't running these validations when we merged changes into the draft-v7 branch.