### PR TITLE
comment out 2 non-code lines

### DIFF
--- a/standard/namespaces.md
+++ b/standard/namespaces.md
@@ -30,9 +30,9 @@ The *namespace_member_declaration*s of each compilation unit of a program contri
 > *Example*:
 >
 > ```csharp
-> File A.cs:
+> // File A.cs:
 >     class A {}
-> File B.cs:
+> // File B.cs:
 >     class B {}
 > ```
 >


### PR DESCRIPTION
This allows the code to compile (as a single compilation unit, even though it's supposed to be in two separate compilation units).