### PR TITLE
Enhance/correct some examples in classes.md

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2222,7 +2222,7 @@ Output parameters are typically used in methods that produce multiple return val
 >     static void Main()
 >     {
 >         string dir, name;
->         SplitPath("c:\\Windows\\System\\hello.txt", out dir, out name);
+>         SplitPath(@"c:\Windows\System\hello.txt", out dir, out name);
 >         Console.WriteLine(dir);
 >         Console.WriteLine(name);
 >     }
@@ -4320,8 +4320,8 @@ The `true` and `false` unary operators require pair-wise declaration. A compile-
 > public class IntVector
 > {
 >     public IntVector(int length) {...}
->     public int Length { get { /* ... */ } }                          // Read-only property
->     public int this[int index] { get { /* ... */ } set { /*...*/} }  // Read-write indexer
+>     public int Length { get { ... } }                       // Read-only property
+>     public int this[int index] { get { ... } set { ... } }  // Read-write indexer
 >
 >     public static IntVector operator++(IntVector iv)
 >     {

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1013,8 +1013,6 @@ A type declared within a class or struct is called a ***nested type***. A type t
 >
 > <!-- Example: {template:"standalone-lib", name:"NestedTypes"} -->
 > ```csharp
-> using System;
->
 > class A
 > {
 >     class B
@@ -1085,7 +1083,6 @@ A nested type may hide ([§7.7.2.2](basic-concepts.md#7722-hiding-through-nestin
 >
 > <!-- Example: {template:"standalone-console", name:"Hiding", expectedOutput:["Derived.M.F"]} -->
 > ```csharp
-> using System;
 > class Base
 > {
 >     public static void M()
@@ -1126,9 +1123,6 @@ A nested type and its containing type do not have a special relationship with re
 >
 > <!-- Example: {template:"standalone-console", name:"ThisAccess", expectedOutput:["123"]} -->
 > ```csharp
->
-> using System;
->
 > class C
 > {
 >     int i = 123;
@@ -1176,8 +1170,6 @@ A nested type has access to all of the members that are accessible to its contai
 >
 > <!-- Example: {template:"standalone-console", name:"AccessToPrivateAndProtectedMembers1", expectedOutput:["C.F"]} -->
 > ```csharp
-> using System;
->
 > class C
 > {
 >     private static void F() => Console.WriteLine("C.F");
@@ -1204,7 +1196,6 @@ A nested type also may access protected members defined in a base type of its co
 >
 > <!-- Example: {template:"standalone-console", name:"AccessToPrivateAndProtectedMembers2", expectedOutput:["Base.F"]} -->
 > ```csharp
-> using System;
 > class Base
 > {
 >     protected void F() => Console.WriteLine("Base.F");
@@ -1316,7 +1307,6 @@ Both signatures are reserved, even if the property is read-only or write-only.
 > <!-- TODO: Check why CS0109 (The member 'B.get_P()' does not hide an accessible member. The new keyword is not required.) is emitted. -->
 > <!-- Example: {template:"standalone-console", name:"PropertyReservedSignatures", expectedWarnings:["CS0109","CS0109"], inferOutput:true} -->
 > ```csharp
-> using System;
 > class A
 > {
 >     public int P
@@ -1616,8 +1606,6 @@ Constants and readonly fields have different binary versioning semantics. When a
 >
 > <!-- IncompleteExample: {template:"standalone-console", name:"VersioningOfConstantsAndStaticReadonlyFields2", expectedOutput:["x", "x", "x"], expectedErrors:["x","x"], expectedWarnings:["x","x"]} -->
 > ```csharp
-> using System;
->
 > namespace Program2
 > {
 >     class Test
@@ -1652,9 +1640,6 @@ These restrictions ensure that all threads will observe volatile writes performe
 >
 > <!-- Example: {template:"standalone-console", name:"VolatileFields", inferOutput:true} -->
 > ```csharp
-> using System;
-> using System.Threading;
->
 > class Test
 > {
 >     public static int result;
@@ -1706,8 +1691,6 @@ The initial value of a field, whether it be a static field or an instance field,
 >
 > <!-- Example: {template:"standalone-console", name:"FieldInitialization", ignoredWarnings:["CS0649"], inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static bool b;
@@ -1741,8 +1724,6 @@ Field declarations may include *variable_initializer*s. For static fields, varia
 >
 > <!-- Example: {template:"standalone-console", name:"VariableInitializers1", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static double x = Math.Sqrt(2.0);
@@ -1775,8 +1756,6 @@ It is possible for static fields with variable initializers to be observed in th
 >
 > <!-- Example: {template:"standalone-console", name:"VariableInitializers2", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static int a = b + 1;
@@ -1807,8 +1786,6 @@ The static field variable initializers of a class correspond to a sequence of as
 >
 > <!-- UndefinedExample: {template:"standalone-console", name:"StaticFieldInitialization1", expectedOutput:["x", "x", "x"], expectedErrors:["x","x"], expectedWarnings:["x","x"]} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static void Main()
@@ -1854,8 +1831,6 @@ The static field variable initializers of a class correspond to a sequence of as
 >
 > <!-- Example: {template:"standalone-console", name:"StaticFieldInitialization2", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static void Main()
@@ -2125,8 +2100,6 @@ A method declared as an iterator ([§14.14](classes.md#1414-iterators)) may not 
 >
 > <!-- Example: {template:"standalone-console", name:"ReferenceParameters1", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static void Swap(ref int x, ref int y)
@@ -2200,7 +2173,6 @@ Output parameters are typically used in methods that produce multiple return val
 >
 > <!-- Example: {template:"standalone-console", name:"OutputParameters", inferOutput:true} -->
 > ```csharp
-> using System;
 > class Test
 > {
 >     static void SplitPath(string path, out string dir, out string name)
@@ -2259,7 +2231,6 @@ Except for allowing a variable number of arguments in an invocation, a parameter
 >
 > <!-- Example: {template:"standalone-console", name:"ParameterArrays1", inferOutput:true} -->
 > ```csharp
-> using System;
 > class Test
 > {
 >     static void F(params int[] args)
@@ -2306,7 +2277,6 @@ When performing overload resolution, a method with a parameter array might be ap
 >
 > <!-- Example: {template:"standalone-console", name:"ParameterArrays3", inferOutput:true} -->
 > ```csharp
-> using System;
 > class Test
 > {
 >     static void F(params object[] a) =>
@@ -2351,8 +2321,6 @@ When performing overload resolution, a method with a parameter array might be ap
 >
 > <!-- Example: {template:"standalone-console", name:"ParameterArrays4", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static void F(params string[] array) =>
@@ -2383,8 +2351,6 @@ When the type of a parameter array is `object[]`, a potential ambiguity arises b
 >
 > <!-- Example: {template:"standalone-console", name:"ParameterArrays5", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static void F(params object[] args)
@@ -2455,8 +2421,6 @@ For every virtual method declared in or inherited by a class, there exists a ***
 >
 > <!-- Example: {template:"standalone-console", name:"VirtualMethods1", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class A
 > {
 >     public void F() => Console.WriteLine("A.F");
@@ -2502,8 +2466,6 @@ Because methods are allowed to hide inherited methods, it is possible for a clas
 >
 > <!-- Example: {template:"standalone-console", name:"VirtualMethods2", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class A
 > {
 >     public virtual void F() => Console.WriteLine("A.F");
@@ -2607,7 +2569,7 @@ An override declaration can access the overridden base method using a *base_acce
 > {
 >     int x;
 >
->     public virtual void PrintFields() => System.Console.WriteLine($"x = {x}");
+>     public virtual void PrintFields() => Console.WriteLine($"x = {x}");
 > }
 >
 > class B : A
@@ -2617,7 +2579,7 @@ An override declaration can access the overridden base method using a *base_acce
 >     public override void PrintFields()
 >     {
 >         base.PrintFields();
->         System.Console.WriteLine($"y = {y}");
+>         Console.WriteLine($"y = {y}");
 >     }
 > }
 > ```
@@ -2681,8 +2643,6 @@ When an instance method declaration includes a `sealed` modifier, that method is
 >
 > <!-- Example: {template:"standalone-lib", name:"SealedMethods"} -->
 > ```csharp
-> using System;
->
 > class A
 > {
 >     public virtual void F() => Console.WriteLine("A.F");
@@ -2765,7 +2725,6 @@ An abstract method declaration is permitted to override a virtual method. This a
 >
 > <!-- Example: {template:"standalone-lib", name:"AbstractMethods3"} -->
 > ```csharp
-> using System;
 > class A
 > {
 >     public virtual void F() => Console.WriteLine("A.F");
@@ -2796,10 +2755,6 @@ The mechanism by which linkage to an external method is achieved, is implementat
 >
 > <!-- Example: {template:"standalone-lib", name:"ExternalMethods", ignoredWarnings:["SYSLIB0003"]} -->
 > ```csharp
-> using System.Text;
-> using System.Security.Permissions;
-> using System.Runtime.InteropServices;
->
 > class Path
 > {
 >     [DllImport("kernel32", SetLastError=true)]
@@ -2928,10 +2883,10 @@ Assume that another part is given, however, which provides implementing declarat
 partial class Customer
 {
     partial void OnNameChanging(string newName) =>
-        System.Console.WriteLine($"Changing {name} to {newName}");
+        Console.WriteLine($"Changing {name} to {newName}");
 
     partial void OnNameChanged() =>
-        System.Console.WriteLine($"Changed to {name}");
+        Console.WriteLine($"Changed to {name}");
 }
 ```
 
@@ -2955,10 +2910,10 @@ class Customer
     }
 
     void OnNameChanging(string newName) =>
-        System.Console.WriteLine($"Changing {name} to {newName}");
+        Console.WriteLine($"Changing {name} to {newName}");
 
     void OnNameChanged() =>
-        System.Console.WriteLine($"Changed to {name}");
+        Console.WriteLine($"Changed to {name}");
 }
 ```
 
@@ -2970,7 +2925,6 @@ When the first parameter of a method includes the `this` modifier, that method i
 >
 > <!-- Example: {template:"standalone-lib", name:"ExtensionMethods1"} -->
 > ```csharp
-> using System;
 > public static class Extensions
 > {
 >     public static int ToInt32(this string s) => Int32.Parse(s);
@@ -3003,7 +2957,7 @@ An extension method is a regular static method. In addition, where its enclosing
 >         string[] strings = { "1", "22", "333", "4444" };
 >         foreach (string s in strings.Slice(1, 2))
 >         {
->             System.Console.WriteLine(s.ToInt32());
+>             Console.WriteLine(s.ToInt32());
 >         }
 >     }
 > }
@@ -3020,7 +2974,7 @@ An extension method is a regular static method. In addition, where its enclosing
 >         string[] strings = { "1", "22", "333", "4444" };
 >         foreach (string s in Extensions.Slice(strings, 1, 2))
 >         {
->             System.Console.WriteLine(Extensions.ToInt32(s));
+>             Console.WriteLine(Extensions.ToInt32(s));
 >         }
 >     }
 > }
@@ -3398,7 +3352,6 @@ Properties can be used to delay initialization of a resource until the moment it
 >
 > <!-- Example: {template:"standalone-lib", name:"Accessors7", replaceEllipsis:true, customEllipsisReplacements:["static Stream OpenStandardInput() => null; static Stream OpenStandardOutput() => null; static Stream OpenStandardError() => null; "]} -->
 > ```csharp
-> using System.IO;
 > public class Console
 > {
 >     private static TextReader reader;
@@ -4089,7 +4042,6 @@ When an indexer declaration includes an `extern` modifier, the indexer is said t
 >
 > <!-- Example: {template:"standalone-lib", name:"Indexers1"} -->
 > ```csharp
-> using System;
 > class BitArray
 > {
 >     int[] bits;
@@ -4182,7 +4134,6 @@ When an indexer declaration includes an `extern` modifier, the indexer is said t
 >
 > <!-- Example: {template:"standalone-lib", name:"Indexers3"} -->
 > ```csharp
-> using System;
 > class Grid
 > {
 >     const int NumRows = 26;
@@ -4474,7 +4425,6 @@ The signature of a conversion operator consists of the source type and the targe
 >
 > <!-- Example: {template:"standalone-lib", name:"ConversionOperators5"} -->
 > ```csharp
-> using System;
 > public struct Digit
 > {
 >     byte value;
@@ -4612,7 +4562,6 @@ Variable initializers are transformed into assignment statements, and these assi
 >
 > <!-- Example: {template:"standalone-lib", name:"ConstructorExecution1"} -->
 > ```csharp
-> using System;
 > class A
 > {
 >     public A()
@@ -4648,9 +4597,6 @@ Variable initializers are transformed into assignment statements, and these assi
 >
 > <!-- Example: {template:"standalone-lib", name:"ConstructorExecution2", ignoredWarnings:["CS0414"]} -->
 > ```csharp
-> using System;
-> using System.Collections;
->
 > class A
 > {
 >     int x = 1, y = -1, count;
@@ -4687,7 +4633,6 @@ Variable initializers are transformed into assignment statements, and these assi
 > contains several variable initializers; it also contains constructor initializers of both forms (`base` and `this`). The example corresponds to the code shown below, where each comment indicates an automatically inserted statement (the syntax used for the automatically inserted constructor invocations isn’t valid, but merely serves to illustrate the mechanism).
 >
 > ```csharp
-> using System.Collections;
 > class A
 > {
 >     int x, y, count;
@@ -4834,8 +4779,6 @@ To initialize a new closed class type, first a new set of static fields ([§14.5
 >
 > <!-- Example: {template:"standalone-console", name:"StaticConstructors1", inferOutput:true} -->
 > ```csharp
-> using System;
->
 > class Test
 > {
 >     static void Main()
@@ -4891,7 +4834,6 @@ It is possible to construct circular dependencies that allow static fields with 
 >
 > <!-- Example: {template:"standalone-console", name:"StaticConstructors2", inferOutput:true} -->
 > ```csharp
-> using System;
 > class A
 > {
 >     public static int X;
@@ -4937,7 +4879,7 @@ Because the static constructor is executed exactly once for each closed construc
 >     {
 >         if (!typeof(T).IsEnum)
 >         {
->             throw new System.ArgumentException("T must be an enum");
+>             throw new ArgumentException("T must be an enum");
 >         }
 >     }
 > }
@@ -4990,7 +4932,6 @@ Finalizers are invoked automatically, and cannot be invoked explicitly. An insta
 >
 > <!-- UndefinedExample: {template:"standalone-console", name:"Finalizers1", inferOutput: true} -->
 > ```csharp
-> using System;
 > class A
 > {
 >     ~A()

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -887,10 +887,10 @@ All members of a generic class can use type parameters from any enclosing class,
 >     static void Main()
 >     {
 >         C<int> x1 = new C<int>(1);
->         Console.WriteLine(x1.f1);              // Prints 1
+>         System.Console.WriteLine(x1.f1);              // Prints 1
 >
 >         C<double> x2 = new C<double>(3.1415);
->         Console.WriteLine(x2.f1);              // Prints 3.1415
+>         System.Console.WriteLine(x2.f1);              // Prints 3.1415
 >     }
 > }
 > ```
@@ -2071,16 +2071,19 @@ A *parameter_array* may occur after an optional parameter, but cannot have a def
 >
 > <!-- IncompleteExample: {template:"standalone-lib", name:"MethodParameters"} -->
 > ```csharp
-> public void M(
->     ref int i,
->     decimal d,
->     bool b = false,
->     bool? n = false,
->     string s = "Hello",
->     object o = null,
->     T t = default(T),
->     params int[] a
-> ) { }
+> class A<T>
+> {
+>     public void M(
+>         ref int i,
+>         decimal d,
+>         bool b = false,
+>         bool? n = false,
+>         string s = "Hello",
+>         object o = null,
+>         T t = default(T),
+>         params int[] a
+>     ) { }
+> }
 > ```
 >
 > In the *formal_parameter_list* for `M`, `i` is a required `ref` parameter, `d` is a required value parameter, `b`, `s`, `o` and `t` are optional value parameters and `a` is a parameter array.
@@ -2604,7 +2607,7 @@ An override declaration can access the overridden base method using a *base_acce
 > {
 >     int x;
 >
->     public virtual void PrintFields() => Console.WriteLine($"x = {x}");
+>     public virtual void PrintFields() => System.Console.WriteLine($"x = {x}");
 > }
 >
 > class B : A
@@ -2614,7 +2617,7 @@ An override declaration can access the overridden base method using a *base_acce
 >     public override void PrintFields()
 >     {
 >         base.PrintFields();
->         Console.WriteLine($"y = {y}");
+>         System.Console.WriteLine($"y = {y}");
 >     }
 > }
 > ```
@@ -2925,10 +2928,10 @@ Assume that another part is given, however, which provides implementing declarat
 partial class Customer
 {
     partial void OnNameChanging(string newName) =>
-        Console.WriteLine($"Changing {name} to {newName}");
+        System.Console.WriteLine($"Changing {name} to {newName}");
 
     partial void OnNameChanged() =>
-        Console.WriteLine($"Changed to {name}");
+        System.Console.WriteLine($"Changed to {name}");
 }
 ```
 
@@ -2952,10 +2955,10 @@ class Customer
     }
 
     void OnNameChanging(string newName) =>
-        Console.WriteLine($"Changing {name} to {newName}");
+        System.Console.WriteLine($"Changing {name} to {newName}");
 
     void OnNameChanged() =>
-        Console.WriteLine($"Changed to {name}");
+        System.Console.WriteLine($"Changed to {name}");
 }
 ```
 
@@ -2967,6 +2970,7 @@ When the first parameter of a method includes the `this` modifier, that method i
 >
 > <!-- Example: {template:"standalone-lib", name:"ExtensionMethods1"} -->
 > ```csharp
+> using System;
 > public static class Extensions
 > {
 >     public static int ToInt32(this string s) => Int32.Parse(s);
@@ -2999,7 +3003,7 @@ An extension method is a regular static method. In addition, where its enclosing
 >         string[] strings = { "1", "22", "333", "4444" };
 >         foreach (string s in strings.Slice(1, 2))
 >         {
->             Console.WriteLine(s.ToInt32());
+>             System.Console.WriteLine(s.ToInt32());
 >         }
 >     }
 > }
@@ -3016,7 +3020,7 @@ An extension method is a regular static method. In addition, where its enclosing
 >         string[] strings = { "1", "22", "333", "4444" };
 >         foreach (string s in Extensions.Slice(strings, 1, 2))
 >         {
->             Console.WriteLine(Extensions.ToInt32(s));
+>             System.Console.WriteLine(Extensions.ToInt32(s));
 >         }
 >     }
 > }
@@ -4316,8 +4320,8 @@ The `true` and `false` unary operators require pair-wise declaration. A compile-
 > public class IntVector
 > {
 >     public IntVector(int length) {...}
->     public int Length { ... }           // Read-only property
->     public int this[int index] { ... }  // Read-write indexer
+>     public int Length { get { /* ... */ } }                          // Read-only property
+>     public int this[int index] { get { /* ... */ } set { /*...*/} }  // Read-write indexer
 >
 >     public static IntVector operator++(IntVector iv)
 >     {
@@ -4715,11 +4719,11 @@ Variable initializers are transformed into assignment statements, and these assi
 >         items.Add("default");
 >     }
 >
->     public B(int n) : base(n – 1)
+>     public B(int n) : base(n - 1)
 >     {
 >         sqrt2 = Math.Sqrt(2.0);      // Variable initializer
 >         items = new ArrayList(100);  // Variable initializer
->         A(n – 1);                    // Invoke A(int) constructor
+>         A(n - 1);                    // Invoke A(int) constructor
 >         max = n;
 >     }
 > }
@@ -4933,7 +4937,7 @@ Because the static constructor is executed exactly once for each closed construc
 >     {
 >         if (!typeof(T).IsEnum)
 >         {
->             throw new ArgumentException("T must be an enum");
+>             throw new System.ArgumentException("T must be an enum");
 >         }
 >     }
 > }

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -868,7 +868,7 @@ All members of a generic class can use type parameters from any enclosing class,
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"TypeParameterSubstitution", expectedOutput:["1","3.1415"]} -->
+> <!-- IncompleteExample: {template:"standalone-console", name:"TypeParameterSubstitution", expectedOutput:["1","3.1415"]} -->
 > ```csharp
 > class C<V>
 > {
@@ -887,10 +887,10 @@ All members of a generic class can use type parameters from any enclosing class,
 >     static void Main()
 >     {
 >         C<int> x1 = new C<int>(1);
->         System.Console.WriteLine(x1.f1);              // Prints 1
+>         Console.WriteLine(x1.f1);              // Prints 1
 >
 >         C<double> x2 = new C<double>(3.1415);
->         System.Console.WriteLine(x2.f1);              // Prints 3.1415
+>         Console.WriteLine(x2.f1);              // Prints 3.1415
 >     }
 > }
 > ```

--- a/tools/example-templates/code-in-main/Program.cs
+++ b/tools/example-templates/code-in-main/Program.cs
@@ -1,3 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Text;
+using System.Threading;
+
 class Program
 {
     static void Main()

--- a/tools/example-templates/standalone-console/Program.cs
+++ b/tools/example-templates/standalone-console/Program.cs
@@ -1,1 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Text;
+using System.Threading;
+
 $example-code

--- a/tools/example-templates/standalone-lib/Library.cs
+++ b/tools/example-templates/standalone-lib/Library.cs
@@ -1,1 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Text;
+using System.Threading;
+
 $example-code


### PR DESCRIPTION
As a result of using the test harness, I made the following edits:

- used `System` namespace prefixes (later, removed these)
- replaced all en-dashes with hyphens
- added a wrapper class
- changed instance method to static
- removed backticks and other spurious characters from inside examples and console output
- added accessors
- fixed escape sequences