### PR TITLE
Correctly handle "  >" in an example inside an unnumbered list item

### DIFF
--- a/tools/ExampleExtractor/Example.cs
+++ b/tools/ExampleExtractor/Example.cs
@@ -91,7 +91,7 @@ internal class Example
             string TrimPrefix(string codeLine) =>
                 codeLine.StartsWith(prefix) ? codeLine.Substring(prefix.Length)
                         : codeLine.StartsWith(trimmedPrefix) ? codeLine.Substring(trimmedPrefix.Length)
-            // the following line handles the case of an example's blank line ("  >") inside an unnumbered list item (which is indented by 2 spaces)
+                        // An example may be in a list, in which case, each line starts with "  > "
                         : codeLine.StartsWith("  " + trimmedPrefix) ? codeLine.Substring(2 + trimmedPrefix.Length)
                         : throw new InvalidOperationException($"Example in {markdownFile} starting at line {openingLine} contains line without common prefix");
 

--- a/tools/ExampleExtractor/Example.cs
+++ b/tools/ExampleExtractor/Example.cs
@@ -91,6 +91,8 @@ internal class Example
             string TrimPrefix(string codeLine) =>
                 codeLine.StartsWith(prefix) ? codeLine.Substring(prefix.Length)
                         : codeLine.StartsWith(trimmedPrefix) ? codeLine.Substring(trimmedPrefix.Length)
+            // the following line handles the case of an example's blank line ("  >") inside an unnumbered list item (which is indented by 2 spaces)
+                        : codeLine.StartsWith("  " + trimmedPrefix) ? codeLine.Substring(2 + trimmedPrefix.Length)
                         : throw new InvalidOperationException($"Example in {markdownFile} starting at line {openingLine} contains line without common prefix");
 
         }


### PR DESCRIPTION
@jskeet, I'm figuring out the example metadata for the final (and by far the biggest) source file, expressions.md, which contains a valid example line format that the extraction tool can't handle. That is, empty (that is, no space *after* the `>`) code lines indented 2 spaces, because they are inside an unnumbered list item.

Consider the following (note the 2-space indentation on each code line subordinate to the list entry):

- String concatenation:

  blah, blah, blah

  > *Example*:
  >
  > ```csharp
  > using System;
  > class Test
  > {
  >     static void Main()
  >     {
  >         string s = null;
  >         Console.WriteLine("s = >" + s + "<");  // Displays s = ><
  >       <<<THIS BLANK LINE causes an exception
  >         ...
  >    }
  > }
  > ```
  >
  > *end example*

The raw text of the blank line in the code is `ss>`, where each `s` represents a space. The method `TrimPrefix` looks for  `ss>s` or `>`, neither of which matches, so an exception is thrown.

To fix this, I've added the extra test. It's hard-coded to 2 leading spaces, so won't detect code indented inside two levels of list nesting. However, none of our md files currently contain code inside more than one level of nesting.