### PR TITLE
Allow an example to specify that it is expected to throw an exception

### DIFF
--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -128,6 +128,7 @@ Because of array covariance, assignments to elements of reference type arrays in
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-console", name:"CovarianceException", expectedException:"ArrayTypeMismatchException"} -->
 > ```csharp
 > class Test
 > {

--- a/tools/ExampleExtractor/ExampleMetadata.cs
+++ b/tools/ExampleExtractor/ExampleMetadata.cs
@@ -23,6 +23,7 @@ public class ExampleMetadata
     public List<string> ExpectedErrors { get; set; }
     public List<string> ExpectedWarnings { get; set; }
     public List<string> ExpectedOutput { get; set; }
+    public string ExpectedException { get; set; }
 
     // Information provided by the example extractor
     public string MarkdownFile { get; set; }


### PR DESCRIPTION
Only the name (without the namespace) is specified; the FQN could be quite long-winded in the metadata.

Towards #646.