### PR TITLE
Remove chevrons from example code when extracting it

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1515,12 +1515,13 @@ In a member access of the form `E.I`, if `E` is a single identifier, and if the 
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib",name:"ColorColorProblem","replaceEllipsis":true} -->
 > ```csharp
 > struct Color
 > {
 >     public static readonly Color White = new Color(...);
 >     public static readonly Color Black = new Color(...);
->     public Color Complement() {...}
+>     public Color Complement() => new Color(...);
 > }
 >
 > class A

--- a/tools/ExampleExtractor/Example.cs
+++ b/tools/ExampleExtractor/Example.cs
@@ -45,6 +45,8 @@ internal class Example
         {
             code = code.Replace("...", "/* ... */");
         }
+        // Remove chevrons, used for emphasis in places.
+        code = code.Replace("«", "").Replace("»", "");
         Code = code;
     }
 


### PR DESCRIPTION
The Color Color problem code needed a tiny change to avoid the ellipsis needing to return anything, but then it works.