### PR TITLE
Add example-extractor annotation to Chapters 6, 7, 8, 9, and 10

### DIFF
--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -77,6 +77,7 @@ The textual order in which names are declared is generally of no significance. I
 
 > *Example*: The declaration space of a namespace is “open ended”, and two namespace declarations with the same fully qualified name contribute to the same declaration space. For example
 >
+> <!-- Example: {template:"standalone-lib", name:"Declarations1", replaceEllipsis:true} -->
 > ```csharp
 > namespace Megacorp.Data
 > {
@@ -279,6 +280,7 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 <!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityDomains",ignoredWarnings:["CS0169","CS0649"]} -->
 > ```csharp
 > public class A
 > {
@@ -326,6 +328,7 @@ As described in [§7.4](basic-concepts.md#74-members), all members of a base cla
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityDomainsNot",expectedErrors:["CS0122"],ignoredWarnings:["CS0414"]} -->
 > ```csharp
 > class A
 > {
@@ -365,6 +368,7 @@ In addition to these forms of access, a derived class can access a protected ins
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"ProtectedAccess1",expectedErrors:["CS1540"]} -->
 > ```csharp
 > public class A
 > {
@@ -395,6 +399,7 @@ In addition to these forms of access, a derived class can access a protected ins
 <!-- markdownlint-enable MD028 -->
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib", name:"ProtectedAccess2"} -->
 > ```csharp
 > class C<T>
 > {
@@ -423,6 +428,7 @@ In addition to these forms of access, a derived class can access a protected ins
 <!-- markdownlint-enable MD028 -->
 > *Note:* The accessibility domain ([§7.5.3](basic-concepts.md#753-accessibility-domains)) of a protected member declared in a generic class includes the program text of all class declarations derived from any type constructed from that generic class. In the example:
 >
+> <!-- Example: {template:"standalone-lib", name:"ProtectedAccess3"} -->
 > ```csharp
 > class C<T>
 > {
@@ -461,6 +467,7 @@ The following accessibility constraints exist:
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityConstraints1",replaceEllipsis:true,expectedErrors:["CS0060"]} -->
 > ```csharp
 > class A {...}
 > public class B: A {...}
@@ -474,6 +481,7 @@ The following accessibility constraints exist:
 <!-- markdownlint-enable MD028 -->
 > *Example*: Likewise, in the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityConstraints2",replaceEllipsis:true,expectedErrors:["CS0050"]} -->
 > ```csharp
 > class A {...}
 >
@@ -516,6 +524,7 @@ The types `object` and `dynamic` are not distinguished when comparing signatures
 
 > *Example*: The following example shows a set of overloaded method declarations along with their signatures.
 >
+> <!-- Example: {template:"standalone-lib", name:"SignatureOverloading",expectedErrors:["CS0663","CS0111","CS0111","CS0111","CS0111"]} -->
 > ```csharp
 > interface ITest
 > {
@@ -578,6 +587,7 @@ Within the scope of a namespace, class, struct, or enumeration member it is poss
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib", name:"ScopeGeneral1", ignoredWarnings:["CS0414"]} -->
 > ```csharp
 > class A
 > {
@@ -598,6 +608,7 @@ Within the scope of a local variable, it is a compile-time error to refer to the
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib",name:"ScopeGeneral2",expectedErrors:["CS0844"], ignoredWarnings:["CS0219"],ignoredWarnings:["CS0414"]} -->
 > ```csharp
 > class A
 > {
@@ -632,6 +643,7 @@ Within the scope of a local variable, it is a compile-time error to refer to the
 >
 > The meaning of a name within a block may differ based on the context in which the name is used. In the example
 >
+> <!-- Example: {template:"standalone-console",name:"ScopeGeneral3",expectedOutput:["hello,", "world", "A"]} -->
 > ```csharp
 > using System;
 >
@@ -668,6 +680,7 @@ Name hiding through nesting can occur as a result of nesting namespaces or types
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib",name:"HidingNesting1", ignoredWarnings:["CS0219"],ignoredWarnings:["CS0414"]} -->
 > ```csharp
 > class A
 > {
@@ -692,6 +705,7 @@ When a name in an inner scope hides a name in an outer scope, it hides all overl
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib",name:"HidingNesting2",expectedErrors:["CS1503"]} -->
 > ```csharp
 > class Outer
 > {
@@ -729,6 +743,7 @@ Contrary to hiding a name from an outer scope, hiding a visible name from an inh
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib",name:"HidingInherit1",expectedWarnings:["CS0108"]} -->
 > ```csharp
 > class Base
 > {
@@ -749,6 +764,7 @@ The warning caused by hiding an inherited name can be eliminated through use of 
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib",name:"HidingInherit2"} -->
 > ```csharp
 > class Base
 > {
@@ -769,6 +785,7 @@ A declaration of a new member hides an inherited member only within the scope of
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib",name:"HidingInherit3"} -->
 > ```csharp
 > class Base
 > {
@@ -886,6 +903,7 @@ In other words, the fully qualified name of `N` is the complete hierarchical pa
 
 > *Example*: The example below shows several namespace and type declarations along with their associated fully qualified names.
 >
+> <!-- Example: {template:"standalone-lib",name:"FullyQualifiedNames"} -->
 > ```csharp
 > class A {}                 // A
 > namespace X                // X
@@ -935,6 +953,7 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 
 > *Example*: Since the garbage collector is allowed wide latitude in deciding when to collect objects and run finalizers, a conforming implementation might produce output that differs from that shown by the following code. The program
 >
+> <!-- Example: {template:"standalone-console",name:"MemoryManagement1", expectedOutput:["??ordering"]} -->
 > ```csharp
 > using System;
 > class A
@@ -989,6 +1008,7 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 >
 > In subtle cases, the distinction between “eligible for finalization” and “eligible for collection” can be important. For example,
 >
+> <!-- Example: {template:"standalone-console",name:"MemoryManagement2", expectedOutput:["??ordering"]} -->
 > ```csharp
 > using System;
 > class A

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -680,7 +680,7 @@ Name hiding through nesting can occur as a result of nesting namespaces or types
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib",name:"HidingNesting1", ignoredWarnings:["CS0219"],ignoredWarnings:["CS0414"]} -->
+> <!-- Example: {template:"standalone-lib",name:"HidingNesting1", ignoredWarnings:["CS0219", "CS0414"]} -->
 > ```csharp
 > class A
 > {

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -953,7 +953,7 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 
 > *Example*: Since the garbage collector is allowed wide latitude in deciding when to collect objects and run finalizers, a conforming implementation might produce output that differs from that shown by the following code. The program
 >
-> <!-- Example: {template:"standalone-console",name:"MemoryManagement1", expectedOutput:["??ordering"]} -->
+> <!-- ImplementationDefinedExample: {template:"standalone-console",name:"MemoryManagement1", expectedOutput:["xx"]} -->
 > ```csharp
 > using System;
 > class A
@@ -1008,7 +1008,7 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 >
 > In subtle cases, the distinction between “eligible for finalization” and “eligible for collection” can be important. For example,
 >
-> <!-- Example: {template:"standalone-console",name:"MemoryManagement2", expectedOutput:["??ordering"]} -->
+> <!-- ImplementationDefinedExample: {template:"standalone-console",name:"MemoryManagement2", expectedOutput:["xx"]} -->
 > ```csharp
 > using System;
 > class A

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -481,7 +481,7 @@ The following accessibility constraints exist:
 <!-- markdownlint-enable MD028 -->
 > *Example*: Likewise, in the following code
 >
-> <!-- Example: {template:"standalone-lib", name:"AccessibilityConstraints2",replaceEllipsis:true,expectedErrors:["CS0050"]} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"AccessibilityConstraints2",replaceEllipsis:true,expectedErrors:["CS0050"]} -->
 > ```csharp
 > class A {...}
 >
@@ -643,7 +643,7 @@ Within the scope of a local variable, it is a compile-time error to refer to the
 >
 > The meaning of a name within a block may differ based on the context in which the name is used. In the example
 >
-> <!-- Example: {template:"standalone-console",name:"ScopeGeneral3",expectedOutput:["hello,", "world", "A"]} -->
+> <!-- Example: {template:"standalone-console",name:"ScopeGeneral3",expectedOutput:["hello, world", "A"]} -->
 > ```csharp
 > using System;
 >

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -21,7 +21,7 @@ Some conversions in the language are defined from expressions to types, others f
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib", name:"Conversions2", expectedErrors:["CS0246"], ignoredWarnings:["CS0219"]} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"Conversions2", expectedErrors:["CS0246"], ignoredWarnings:["CS0219"]} -->
 > ```csharp
 > enum Color { Red, Blue, Green }
 >
@@ -256,7 +256,7 @@ This implicit conversion seemingly violates the advice in the beginning of [§10
 
 > *Example*: The following illustrates implicit dynamic conversions:
 >
-> <!-- Example: {template:"standalone-console", name:"ImplicitDynamic", expectedErrors:["CS0266"]} -->
+> <!-- Example: {template:"code-in-main", name:"ImplicitDynamic", expectedErrors:["CS0266"]} -->
 > ```csharp
 > object o = "object";
 > dynamic d = "dynamic";
@@ -737,7 +737,7 @@ Specifically, an anonymous function `F` is compatible with a delegate type `D`
 
 > *Example*: The following examples illustrate these rules:
 >
-> <!-- Example: {template:"standalone-lib", name:"AnonymousFunctionsConv1", expectedErrors:["CS1593","CS1661","CS1678","CS8030","CS1688","CS1661","CS1676","CS1643","CS0126","CS0029","CS1662","CS0029","CS1662"]} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"AnonymousFunctionsConv1", expectedErrors:["CS1593","CS1661","CS1678","CS8030","CS1688","CS1661","CS1676","CS1643","CS0126","CS0029","CS1662","CS0029","CS1662"]} -->
 > ```csharp
 > delegate void D(int x);
 > D d1 = delegate { };                         // Ok

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -6,6 +6,7 @@ A ***conversion*** causes an expression to be converted to, or treated as being 
 
 > *Example*: For instance, the conversion from type `int` to type `long` is implicit, so expressions of type `int` can implicitly be treated as type `long`. The opposite conversion, from type `long` to type `int`, is explicit and so an explicit cast is required.
 >
+> <!-- Example: {template:"standalone-console", name:"Conversions1"} -->
 > ```csharp
 > int a = 123;
 > long b = a;      // implicit conversion from int to long
@@ -20,6 +21,7 @@ Some conversions in the language are defined from expressions to types, others f
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib", name:"Conversions2", expectedErrors:["CS0246"], ignoredWarnings:["CS0219"]} -->
 > ```csharp
 > enum Color { Red, Blue, Green }
 >
@@ -159,6 +161,7 @@ Boxing a value of a *nullable_value_type* produces a null reference if it is the
 
 > *Note*: The process of boxing may be imagined in terms of the existence of a boxing class for every value type. For example, consider a `struct S` implementing an interface `I`, with a boxing class called `S_Boxing`.
 >
+> <!-- Example: {template:"standalone-lib", name:"BoxingConversions1", replaceEllipsis:true} -->
 > ```csharp
 > interface I
 > {
@@ -188,6 +191,7 @@ Boxing a value of a *nullable_value_type* produces a null reference if it is the
 >
 > Boxing a value `v` of type `S` now consists of executing the expression `new S_Boxing(v)` and returning the resulting instance as a value of the target type of the conversion. Thus, the statements
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"BoxingConversions2"} -->
 > ```csharp
 > S s = new S();
 > object box = s;
@@ -202,6 +206,7 @@ Boxing a value of a *nullable_value_type* produces a null reference if it is the
 >
 > The imagined boxing type described above does not actually exist. Instead, a boxed value of type `S` has the runtime type `S`, and a runtime type check using the `is` operator with a value type as the right operand tests whether the left operand is a boxed version of the right operand. For example,
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"BoxingConversions3"} -->
 > ```csharp
 > int i = 123;
 > object box = i;
@@ -214,6 +219,7 @@ Boxing a value of a *nullable_value_type* produces a null reference if it is the
 >
 > A boxing conversion implies making a copy of the value being boxed. This is different from a conversion of a *reference_type* to type `object`, in which the value continues to reference the same instance and simply is regarded as the less derived type `object`. For example, given the declaration
 >
+> <!-- IncompleteExample: {template:"standalone-lib", name:"BoxingConversions4", expectedErrors:["x","x"], expectedWarnings:["x","x"]} -->
 > ```csharp
 > struct Point
 > {
@@ -250,6 +256,7 @@ This implicit conversion seemingly violates the advice in the beginning of [§10
 
 > *Example*: The following illustrates implicit dynamic conversions:
 >
+> <!-- Example: {template:"standalone-console", name:"ImplicitDynamic", expectedErrors:["CS0266"]} -->
 > ```csharp
 > object o = "object";
 > dynamic d = "dynamic";
@@ -441,6 +448,7 @@ Unboxing to a *nullable_value_type* produces the null value of the *nullable_val
 
 > *Note*: Referring to the imaginary boxing class described in [§10.2.9](conversions.md#1029-boxing-conversions), an unboxing conversion of an object box to a *value_type* `S` consists of executing the expression `((S_Boxing)box).value`. Thus, the statements
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"Unboxing", expectedErrors:["x","x"], expectedWarnings:["x","x"]} -->
 > ```csharp
 > object box = new S();
 > S s = (S)box;
@@ -467,6 +475,7 @@ If dynamic binding of the conversion is not desired, the expression can be first
 
 > *Example*: Assume the following class is defined:
 >
+> <!-- Example: {template:"standalone-lib", name:"ExplicitDynamic1"} -->
 > ```csharp
 > class C
 > {
@@ -486,6 +495,7 @@ If dynamic binding of the conversion is not desired, the expression can be first
 >
 > The following illustrates explicit dynamic conversions:
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"ExplicitDynamic2"} -->
 > ```csharp
 > object o = "1";
 > dynamic d = "2";
@@ -524,6 +534,7 @@ The above rules do not permit a direct explicit conversion from an unconstrained
 
 > *Example*: Consider the following declaration:
 >
+> <!-- Example: {template:"standalone-lib", name:"ExplicitConvWithTypeParams1", expectedErrors:["CS0030"]} -->
 > ```csharp
 > class X<T>
 > {
@@ -536,6 +547,7 @@ The above rules do not permit a direct explicit conversion from an unconstrained
 >
 > If the direct explicit conversion of `t` to `long` were permitted, one might easily expect that `X<int>.F(7)` would return `7L`. However, it would not, because the standard numeric conversions are only considered when the types are known to be numeric at binding-time. In order to make the semantics clear, the above example must instead be written:
 >
+> <!-- Example: {template:"standalone-lib", name:"ExplicitConvWithTypeParams2"} -->
 > ```csharp
 > class X<T>
 > {
@@ -725,6 +737,7 @@ Specifically, an anonymous function `F` is compatible with a delegate type `D`
 
 > *Example*: The following examples illustrate these rules:
 >
+> <!-- Example: {template:"standalone-lib", name:"AnonymousFunctionsConv1", expectedErrors:["CS1593","CS1661","CS1678","CS8030","CS1688","CS1661","CS1676","CS1643","CS0126","CS0029","CS1662","CS0029","CS1662"]} -->
 > ```csharp
 > delegate void D(int x);
 > D d1 = delegate { };                         // Ok
@@ -772,12 +785,14 @@ Specifically, an anonymous function `F` is compatible with a delegate type `D`
 <!-- markdownlint-enable MD028 -->
 > *Example*: The examples that follow use a generic delegate type `Func<A,R>` that represents a function that takes an argument of type `A` and returns a value of type `R`:
 >
+> <!-- Example: {template:"standalone-lib", name:"AnonymousFunctionsConv2"} -->
 > ```csharp
 > delegate R Func<A,R>(A arg);
 > ```
 >
 > In the assignments
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"AnonymousFunctionsConv3", expectedWarnings:["x"]} -->
 > ```csharp
 > Func<int,int> f1 = x => x + 1; // Ok
 > Func<int,double> f2 = x => x + 1; // Ok
@@ -809,6 +824,7 @@ The invocation list of a delegate produced from an anonymous function contains a
 
 Conversions of semantically identical anonymous functions with the same (possibly empty) set of captured outer variable instances to the same delegate types are permitted (but not required) to return the same delegate instance. The term semantically identical is used here to mean that execution of the anonymous functions will, in all cases, produce the same effects given the same arguments. This rule permits code such as the following to be optimized.
 
+<!-- IncompleteExample: {template:"standalone-lib", name:"EvalAnonFunct", replaceEllipsis:true} -->
 ```csharp
 delegate double Function(double x);
 
@@ -868,6 +884,7 @@ The compile-time application of the conversion from a method group `E` to a del
 
 > *Example*: The following demonstrates method group conversions:
 >
+> <!-- IncompleteExample: {template:"standalone-lib", name:"MethodGroupConversions1", replaceEllipsis:true, expectedErrors:["CS0123","CS0123","CS0123"]} -->
 > ```csharp
 > delegate string D1(object o);
 > delegate object D2(string s);
@@ -921,6 +938,7 @@ A method group conversion can refer to a generic method, either by explicitly sp
 
 > *Example*:
 >
+> <!-- IncompleteExample: {template:"standalone-lib", name:"MethodGroupConversions2", replaceEllipsis:true, expectedErrors:["CS0411"]} -->
 > ```csharp
 > delegate int D(string s, int i);
 > delegate int E();

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -56,7 +56,7 @@ The productions for *simple_name* ([§11.7.4](expressions.md#1174-simple-names))
 
 > *Example*: The statement:
 >
-> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities1"} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"GrammarAmbiguities1"} -->
 > ```csharp
 > F(G<A, B>(7));
 > ```
@@ -79,14 +79,14 @@ then the *type_argument_list* is retained as part of the *simple_name*, *member_
 <!-- markdownlint-enable MD028 -->
 > *Example*: The statement:
 >
-> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities2"} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"GrammarAmbiguities2"} -->
 > ```csharp
 > F(G<A, B>(7));
 > ```
 >
 > will, according to this rule, be interpreted as a call to `F` with one argument, which is a call to a generic method `G` with two type arguments and one regular argument. The statements
 >
-> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities3"} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"GrammarAmbiguities3"} -->
 > ```csharp
 > F(G<A, B>7);
 > F(G<A, B>>7);
@@ -94,14 +94,14 @@ then the *type_argument_list* is retained as part of the *simple_name*, *member_
 >
 > will each be interpreted as a call to `F` with two arguments. The statement
 >
-> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities4"} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"GrammarAmbiguities4"} -->
 > ```csharp
 > x = F<A> + y;
 > ```
 >
 > will be interpreted as a less-than operator, greater-than operator and unary-plus operator, as if the statement had been written `x = (F < A) > (+y)`, instead of as a *simple_name* with a *type_argument_list* followed by a binary-plus operator. In the statement
 >
-> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities5"} -->
+> <!-- IncompleteExample: {template:"standalone-lib", name:"GrammarAmbiguities5"} -->
 > ```csharp
 > x = y is C<T> && z;
 > ```
@@ -904,7 +904,7 @@ fragment Quote_Escape_Sequence
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-lib", name:"StringLiterals"} -->
+> <!-- Example: {template:"code-in-main", name:"StringLiterals", ignoredWarnings=["CS0219"]} -->
 > ```csharp
 > string a = "Happy birthday, Joel"; // Happy birthday, Joel
 > string b = @"Happy birthday, Joel"; // Happy birthday, Joel
@@ -1332,7 +1332,7 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 >
 > Pre-processing directives are not processed when they appear inside multi-line input elements. For example, the program:
 >
-> <!-- Example: {template:"standalone-console",name:"PreproDirectivesNotProcessed",expectedOutput:["hello,", "#if Debug", "world", "#else", "Nebraska", "#endif"]} -->
+> <!-- Example: {template:"standalone-console",name:"PreproDirectivesNotProcessed",expectedOutput:["hello,", "#if Debug", "        world", "#else", "        Nebraska", "#endif", "        "]} -->
 > ```csharp
 > class Hello
 > {

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -192,7 +192,7 @@ A ***delimited comment*** begins with the characters `/*` and ends with the cha
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console",name:"HelloWorld1",expectedOutput:[ "hello, world"]} -->
+> <!-- Example: {template:"standalone-console",name:"HelloWorld1",expectedOutput:["hello, world"]} -->
 > ```csharp
 > /* Hello, world program
 >    This program writes "hello, world" to the console

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -56,6 +56,7 @@ The productions for *simple_name* ([§11.7.4](expressions.md#1174-simple-names))
 
 > *Example*: The statement:
 >
+> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities1"} -->
 > ```csharp
 > F(G<A, B>(7));
 > ```
@@ -78,12 +79,14 @@ then the *type_argument_list* is retained as part of the *simple_name*, *member_
 <!-- markdownlint-enable MD028 -->
 > *Example*: The statement:
 >
+> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities2"} -->
 > ```csharp
 > F(G<A, B>(7));
 > ```
 >
 > will, according to this rule, be interpreted as a call to `F` with one argument, which is a call to a generic method `G` with two type arguments and one regular argument. The statements
 >
+> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities3"} -->
 > ```csharp
 > F(G<A, B>7);
 > F(G<A, B>>7);
@@ -91,12 +94,14 @@ then the *type_argument_list* is retained as part of the *simple_name*, *member_
 >
 > will each be interpreted as a call to `F` with two arguments. The statement
 >
+> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities4"} -->
 > ```csharp
 > x = F<A> + y;
 > ```
 >
 > will be interpreted as a less-than operator, greater-than operator and unary-plus operator, as if the statement had been written `x = (F < A) > (+y)`, instead of as a *simple_name* with a *type_argument_list* followed by a binary-plus operator. In the statement
 >
+> <!-- Example: {template:"standalone-lib", name:"GrammarAmbiguities5"} -->
 > ```csharp
 > x = y is C<T> && z;
 > ```
@@ -187,6 +192,7 @@ A ***delimited comment*** begins with the characters `/*` and ends with the cha
 
 > *Example*: The example
 >
+> <!-- Example: {template:"standalone-console",name:"HelloWorld1",expectedOutput:[ "hello, world"]} -->
 > ```csharp
 > /* Hello, world program
 >    This program writes "hello, world" to the console
@@ -208,6 +214,7 @@ A ***single-line comment*** begins with the characters `//` and extends to the 
 
 > *Example*: The example
 >
+> <!-- Example: {template:"standalone-console",name:"HelloWorld2",expectedOutput:[ "hello, world"]} -->
 > ```csharp
 > // Hello, world program
 > // This program writes "hello, world" to the console
@@ -348,6 +355,7 @@ Multiple translations are not performed. For instance, the string literal `"\u00
 <!-- markdownlint-enable MD028 -->
 > *Example*: The example
 >
+> <!-- Example: {template:"standalone-lib", name:"UnicodeCharacterEscapeSequences"} -->
 > ```csharp
 > class Class1
 > {
@@ -364,6 +372,7 @@ Multiple translations are not performed. For instance, the string literal `"\u00
 >
 > shows several uses of `\u0066`, which is the escape sequence for the letter “`f`”. The program is equivalent to
 >
+> <!-- Example: {template:"standalone-lib", name:"UnicodeCharacterEscapeSequencesNot"} -->
 > ```csharp
 > class Class1
 > {
@@ -491,6 +500,7 @@ The prefix “`@`” enables the use of keywords as identifiers, which is usefu
 <!-- markdownlint-enable MD028 -->
 > *Example*: The example:
 >
+> <!-- Example: {template:"standalone-lib", name:"IdentifierAtPrefix"} -->
 > ```csharp
 > class @class
 > {
@@ -894,6 +904,7 @@ fragment Quote_Escape_Sequence
 
 > *Example*: The example
 >
+> <!-- Example: {template:"standalone-lib", name:"StringLiterals"} -->
 > ```csharp
 > string a = "Happy birthday, Joel"; // Happy birthday, Joel
 > string b = @"Happy birthday, Joel"; // Happy birthday, Joel
@@ -927,6 +938,7 @@ Each string literal does not necessarily result in a new string instance. When t
 
 > *Example*: For instance, the output produced by
 >
+> <!-- Example: {template:"standalone-console",name:"ObjectReferenceEquality",expectedOutput:["True"]} -->
 > ```csharp
 > class Test
 > {
@@ -1052,6 +1064,7 @@ Pre-processing directives are not part of the syntactic grammar of C#. However,
 
 > *Example*: When compiled, the program
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproGeneral1"} -->
 > ```csharp
 > #define A
 > #undef B
@@ -1072,6 +1085,7 @@ Pre-processing directives are not part of the syntactic grammar of C#. However,
 >
 > results in the exact same sequence of tokens as the program
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproGeneral2"} -->
 > ```csharp
 > class C
 > {
@@ -1165,6 +1179,7 @@ Any `#define` and `#undef` directives in a compilation unit shall occur before t
 
 > *Example*: The example:
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproDefinitionDirectives1", replaceEllipsis:true} -->
 > ```csharp
 > #define Enterprise
 > #if Professional || Enterprise
@@ -1186,6 +1201,7 @@ Any `#define` and `#undef` directives in a compilation unit shall occur before t
 <!-- markdownlint-enable MD028 -->
 > *Example*: The following example results in a compile-time error because a #define follows real code:
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproDefinitionDirectives2", expectedErrors:["CS1032"]} -->
 > ```csharp
 > #define A
 > namespace N
@@ -1203,6 +1219,7 @@ A `#define` may define a conditional compilation symbol that is already defined,
 
 > *Example*: The example below defines a conditional compilation symbol A and then defines it again.
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproSymbolRedefinition"} -->
 > ```csharp
 > #define A
 > #define A
@@ -1216,6 +1233,7 @@ A `#undef` may “undefine” a conditional compilation symbol that is not defin
 
 > *Example*: The example below defines a conditional compilation symbol `A` and then undefines it twice; although the second `#undef` has no effect, it is still valid.
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproSymbolUndef"} -->
 > ```csharp
 > #define A
 > #undef A
@@ -1271,6 +1289,7 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 <!-- markdownlint-enable MD028 -->
 > *Example*: The following example illustrates how conditional compilation directives can nest:
 >
+> <!-- IncompleteExample: {template:"standalone-lib", name:"PreproConditionalCompilation", replaceEllipsis:true} -->
 > ```csharp
 > #define Debug // Debugging on
 > #undef Trace // Tracing off
@@ -1292,6 +1311,7 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 >
 > Except for pre-processing directives, skipped source code is not subject to lexical analysis. For example, the following is valid despite the unterminated comment in the `#else` section:
 >
+> <!-- IncompleteExample: {template:"standalone-lib", name:"PreproInvalidSkippedSource", replaceEllipsis:true} -->
 > ```csharp
 > #define Debug // Debugging on
 > class PurchaseTransaction
@@ -1312,6 +1332,7 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 >
 > Pre-processing directives are not processed when they appear inside multi-line input elements. For example, the program:
 >
+> <!-- Example: {template:"standalone-console",name:"PreproDirectivesNotProcessed",expectedOutput:["hello,", "#if Debug", "world", "#else", "Nebraska", "#endif"]} -->
 > ```csharp
 > class Hello
 > {
@@ -1341,6 +1362,7 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 >
 > In peculiar cases, the set of pre-processing directives that is processed might depend on the evaluation of the *pp_expression*. The example:
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproTokenStream"} -->
 > ```csharp
 > #if X
 >     /*
@@ -1370,6 +1392,7 @@ fragment PP_Message
 
 > *Example*: The example
 >
+> <!-- Example: {template:"standalone-lib", name:"PreproErrorDirective", replaceEllipsis:true} -->
 > ```csharp
 > #if Debug && Retail
 >     #error A build can't be both debug and retail

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -214,7 +214,7 @@ A ***single-line comment*** begins with the characters `//` and extends to the 
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console",name:"HelloWorld2",expectedOutput:[ "hello, world"]} -->
+> <!-- Example: {template:"standalone-console",name:"HelloWorld2",expectedOutput:["hello, world"]} -->
 > ```csharp
 > // Hello, world program
 > // This program writes "hello, world" to the console

--- a/standard/types.md
+++ b/standard/types.md
@@ -225,6 +225,7 @@ Like any other instance constructor, the default constructor of a value type is 
 <!-- markdownlint-enable MD028 -->
 > *Example*: In the code below, variables `i`, `j` and `k` are all initialized to zero.
 >
+> <!-- Example: {template:"standalone-lib", name:"DefaultConstructors", ignoredWarnings:["CS0219"]} -->
 > ```csharp
 > class A
 > {
@@ -269,6 +270,7 @@ Because a simple type aliases a struct type, every simple type has members.
 
 > *Example*: `int` has the members declared in `System.Int32` and the members inherited from `System.Object`, and the following statements are permitted:
 >
+> <!-- Example: {template:"standalone-console", name:"SimpleTypes"} -->
 > ```csharp
 > int i = int.MaxValue;      // System.Int32.MaxValue constant
 > string s = i.ToString();   // System.Int32.ToString() instance method
@@ -421,6 +423,7 @@ When a *namespace_or_type_name* is evaluated, only generic types with the correc
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib", name:"ConstructedTypes1", replaceEllipsis:true, ignoredWarnings:["CS0169"]} -->
 > ```csharp
 > namespace Widgets
 > {
@@ -446,6 +449,7 @@ The detailed rules for name lookup in the *namespace_or_type_name* productions i
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-lib", name:"ConstructedTypes2", replaceEllipsis:true, ignoredWarnings:["CS0649"]} -->
 > ```csharp
 > class Outer<T>
 > {
@@ -529,6 +533,7 @@ Since type parameters are not inherited, constraints are never inherited either.
 
 > *Example*: In the following, `D` needs to specify the constraint on its type parameter `T` so that `T` satisfies the constraint imposed by the base `class` `B<T>`. In contrast, `class` `E` need not specify a constraint, because `List<T>` implements `IEnumerable` for any `T`.
 >
+> <!-- IncompleteExample: {template:"standalone-lib", name:"SatisfyingConstraints", replaceEllipsis:true]} -->
 > ```csharp
 > class B<T> where T: IEnumerable {...}
 > class D<T> : B<T> where T: IEnumerable {...}
@@ -572,6 +577,7 @@ If a conversion exists from a lambda expression to a delegate type `D`, a conver
 
 > *Example*: The following program represents a lambda expression both as executable code and as an expression tree. Because a conversion exists to `Func<int,int>`, a conversion also exists to `Expression<Func<int,int>>`:
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"ExpressionTreeTypes", expectedOutput:["x", "x", "x"],expectedErrors:["x","x"],expectedWarnings:["x","x"]} -->
 > ```csharp
 > Func<int,int> del = x => x + 1;             // Code
 > Expression<Func<int,int>> exp = x => x + 1; // Data

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -16,6 +16,7 @@ C# defines seven categories of variables: static variables, instance variables, 
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"VariableCategories", ignoredWarnings:["CS0169","CS0219"], ignoredWarnings:["CS0649"]} -->
 > ```csharp
 > class A
 > {
@@ -136,6 +137,7 @@ A local variable introduced by a *local_variable_declaration* is not automatical
 
 > *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). It is possible to use a variable without executing its *local_variable_initializer*; e.g., within the initializer expression itself or by using a *goto_statement* to bypass the initialization:
 >
+> <!-- Example: {template:"standalone-console", name:"LocalVariables", expectedErrors:["CS0165"], expectedWarnings:["CS0162"]} -->
 > ```csharp
 > goto L;
 > 
@@ -432,6 +434,7 @@ finally «finally_block»
 
 > *Example*: The following example demonstrates how the different blocks of a `try` statement ([§12.11](statements.md#1211-the-try-statement)) affect definite assignment.
 >
+> <!-- Example: {template:"standalone-lib", name:"TryCatchFinally", ignoredWarnings:["CS0219"], expectedWarnings:["CS0162"]} -->
 > ```csharp
 > class A
 > {
@@ -523,6 +526,7 @@ For a constant expression with value `true`:
 
 > *Example*:
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"ConstantExpressions1", expectedWarnings:["CS0162]} -->
 > ```csharp
 > int x;
 > if (true) {}
@@ -541,6 +545,7 @@ For a constant expression with value `false`:
 
 > *Example*:
 >
+> <!-- IncompleteExample: {template:"standalone-console", name:"ConstantExpressions2", expectedWarnings:["CS0162"]} -->
 > ```csharp
 > int x;
 > if (false)
@@ -611,6 +616,7 @@ For an expression *expr* of the form:
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"SimpleAssignment"} -->
 > ```csharp
 > class A
 > {
@@ -645,6 +651,7 @@ For an expression *expr* of the form:
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"AndAnd"} -->
 > ```csharp
 > class A
 > {
@@ -687,6 +694,7 @@ For an expression *expr* of the form:
 
 > *Example*: In the following code
 >
+> <!-- Example: {template:"standalone-lib", name:"OrOr"} -->
 > ```csharp
 > class A
 > {
@@ -767,6 +775,7 @@ For a *lambda_expression* or *anonymous_method_expression* *expr* with a body (e
 > *Example*: The example
 >
 > ```csharp
+> <!-- Example: {template:"standalone-lib", name:"AnonymousFunctions1", replaceEllipsis:true, expectedErrors:["CS0165"]} -->
 > class A
 > {
 >     delegate bool Filter(int i);
@@ -790,6 +799,7 @@ For a *lambda_expression* or *anonymous_method_expression* *expr* with a body (e
 <!-- markdownlint-enable MD028 -->
 > *Example*: The example
 >
+> <!-- IncompleteExample: {template:"standalone-lib", name:"AnonymousFunctions2", replaceEllipsis:true, expectedErrors:["CS0165"]} -->
 > ```csharp
 > class A
 > {

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -137,7 +137,7 @@ A local variable introduced by a *local_variable_declaration* is not automatical
 
 > *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). It is possible to use a variable without executing its *local_variable_initializer*; e.g., within the initializer expression itself or by using a *goto_statement* to bypass the initialization:
 >
-> <!-- Example: {template:"standalone-console", name:"LocalVariables", expectedErrors:["CS0165"], expectedWarnings:["CS0162"]} -->
+> <!-- Example: {template:"code-in-main", name:"LocalVariables", expectedErrors:["CS0165"], expectedWarnings:["CS0162"]} -->
 > ```csharp
 > goto L;
 > 


### PR DESCRIPTION
@jskeet, for now, I'm ignoring the new template, code-in-main. Once I've moved all my annotation to the master, I'll go back and identify which examples should be changed from standalone-console to code-in-main, and handle that in a separate PR.