### PR TITLE
Allow output to be inferred from a section after the example instead of stated explicitly

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1314,7 +1314,7 @@ Both signatures are reserved, even if the property is read-only or write-only.
 > *Example*: In the following code
 >
 > <!-- TODO: Check why CS0109 (The member 'B.get_P()' does not hide an accessible member. The new keyword is not required.) is emitted. -->
-> <!-- Example: {template:"standalone-console",name:"PropertyReservedSignatures",expectedOutput:["123","123","456"],expectedWarnings:["CS0109","CS0109"]} -->
+> <!-- Example: {template:"standalone-console",name:"PropertyReservedSignatures",inferOutput: true, expectedWarnings:["CS0109","CS0109"]} -->
 > ```csharp
 > using System;
 > class A
@@ -1650,7 +1650,7 @@ These restrictions ensure that all threads will observe volatile writes performe
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"VolatileFields", expectedOutput:["result = 143"]} -->
+> <!-- Example: {template:"standalone-console", name:"VolatileFields", inferOutput: true} -->
 > ```csharp
 > using System;
 > using System.Threading;
@@ -1704,7 +1704,7 @@ The initial value of a field, whether it be a static field or an instance field,
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"FieldInitialization", expectedOutput:["b = False, i = 0"], ignoredWarnings:["CS0649"]} -->
+> <!-- Example: {template:"standalone-console", name:"FieldInitialization", inferOutput: true, ignoredWarnings:["CS0649"]} -->
 > ```csharp
 > using System;
 >
@@ -1739,7 +1739,7 @@ Field declarations may include *variable_initializer*s. For static fields, varia
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"VariableInitializers1", expectedOutput:["x = 1.4142135623730951, i = 100, s = Hello"]} -->
+> <!-- Example: {template:"standalone-console", name:"VariableInitializers1", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -1773,7 +1773,7 @@ It is possible for static fields with variable initializers to be observed in th
 
 > *Example*: However, this is strongly discouraged as a matter of style. The example
 >
-> <!-- Example: {template:"standalone-console", name:"VariableInitializers2", expectedOutput:["a = 1, b = 2"]} -->
+> <!-- Example: {template:"standalone-console", name:"VariableInitializers2", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -1852,7 +1852,7 @@ The static field variable initializers of a class correspond to a sequence of as
 >
 > because the execution of `X`’s initializer and `Y`’s initializer could occur in either order; they are only constrained to occur before the references to those fields. However, in the example:
 >
-> <!-- UndefinedExample: {template:"standalone-console", name:"StaticFieldInitialization2", expectedOutput:["x", "x", "x"]} -->
+> <!-- Example: {template:"standalone-console", name:"StaticFieldInitialization2", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -1885,7 +1885,7 @@ The static field variable initializers of a class correspond to a sequence of as
 >
 > the output shall be:
 >
-> ```csharp
+> ```console
 > Init B
 > Init A
 > 1 1
@@ -2120,7 +2120,7 @@ A method declared as an iterator ([§14.14](classes.md#1414-iterators)) may not 
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ReferenceParameters1", expectedOutput:["i = 2, j = 1"]} -->
+> <!-- Example: {template:"standalone-console", name:"ReferenceParameters1", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -2195,7 +2195,7 @@ Output parameters are typically used in methods that produce multiple return val
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"OutputParameters", expectedOutput:["c:\\Windows\\System\\","hello.txt"]} -->
+> <!-- Example: {template:"standalone-console", name:"OutputParameters", inferOutput: true} -->
 > ```csharp
 > using System;
 > class Test
@@ -2254,7 +2254,7 @@ Except for allowing a variable number of arguments in an invocation, a parameter
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays1", expectedOutput:["Array contains 3 elements: 1 2 3","Array contains 4 elements: 10 20 30 40","Array contains 0 elements:"]} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays1", inferOutput: true} -->
 > ```csharp
 > using System;
 > class Test
@@ -2301,7 +2301,7 @@ When performing overload resolution, a method with a parameter array might be ap
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays3", expectedOutput:["F()","F(object[])","F(object,object)","F(object[])","F(object[])"]} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays3", inferOutput: true} -->
 > ```csharp
 > using System;
 > class Test
@@ -2329,11 +2329,11 @@ When performing overload resolution, a method with a parameter array might be ap
 > produces the output
 >
 > ```console
-> F();
-> F(object[]);
-> F(object,object);
-> F(object[]);
-> F(object[]);
+> F()
+> F(object[])
+> F(object,object)
+> F(object[])
+> F(object[])
 > ```
 >
 > In the example, two of the possible expanded forms of the method with a parameter array are already included in the class as regular methods. These expanded forms are therefore not considered when performing overload resolution, and the first and third method invocations thus select the regular methods. When a class declares a method with a parameter array, it is not uncommon to also include some of the expanded forms as regular methods. By doing so, it is possible to avoid the allocation of an array instance that occurs when an expanded form of a method with a parameter array is invoked.
@@ -2346,7 +2346,7 @@ When performing overload resolution, a method with a parameter array might be ap
 >
 > *Example*: The example:
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays4", expectedOutput:["True","False"]} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays4", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -2378,7 +2378,7 @@ When the type of a parameter array is `object[]`, a potential ambiguity arises b
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays5", expectedOutput:["System.Int32 System.String System.Double","System.Object[]","System.Object[]","System.Int32 System.String System.Double"]} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays5", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -2450,7 +2450,7 @@ For every virtual method declared in or inherited by a class, there exists a ***
 
 > *Example*: The following example illustrates the differences between virtual and non-virtual methods:
 >
-> <!-- Example: {template:"standalone-console", name:"VirtualMethods1", expectedOutput:["A.F","B.F","B.G","B.G"]} -->
+> <!-- Example: {template:"standalone-console", name:"VirtualMethods1", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -2497,7 +2497,7 @@ Because methods are allowed to hide inherited methods, it is possible for a clas
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"VirtualMethods2", expectedOutput:["B.F","B.F","D.F","D.F"]} -->
+> <!-- Example: {template:"standalone-console", name:"VirtualMethods2", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -4828,7 +4828,7 @@ To initialize a new closed class type, first a new set of static fields ([§14.5
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"StaticConstructors1", expectedOutput:["Init A","A.F","Init B","B.F"]} -->
+> <!-- Example: {template:"standalone-console", name:"StaticConstructors1", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -4885,7 +4885,7 @@ It is possible to construct circular dependencies that allow static fields with 
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"StaticConstructors2", expectedOutput:["X = 1, Y = 2"]} -->
+> <!-- Example: {template:"standalone-console", name:"StaticConstructors2", inferOutput: true} -->
 > ```csharp
 > using System;
 > class A
@@ -4984,7 +4984,7 @@ Finalizers are invoked automatically, and cannot be invoked explicitly. An insta
 
 > *Example*: The output of the example
 >
-> <!-- UndefinedExample: {template:"standalone-console", name:"Finalizers1", expectedOutput:["B's finalizer","A's finalizer"]} -->
+> <!-- UndefinedExample: {template:"standalone-console", name:"Finalizers1", inferOutput: true} -->
 > ```csharp
 > using System;
 > class A

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -259,7 +259,7 @@ Attempting to invoke a delegate instance whose value is `null` results in an exc
 
 > *Example*: The following example shows how to instantiate, combine, remove, and invoke delegates:
 >
-> <!-- Example: {template:"standalone-console", name:"DelegateInvocation", expectedOutput:["C.M1: -1","C.M2: -2","C.M1: 10","C.M2: 10","C.M1: 20","C.M2: 20","C.M1: 20","C.M1: 30","C.M2: 30","C.M1: 30","C.M3: 30","C.M1: 40","C.M2: 40","C.M3: 40","C.M1: 50","C.M2: 50","C.M1: 60","C.M1: 60"]} -->
+> <!-- Example: {template:"standalone-console", name:"DelegateInvocation", inferOutput:true} -->
 > ```csharp
 > using System;
 >

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -154,7 +154,7 @@ The associated value of an enum member is assigned either implicitly or explicit
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"PrintingEnumValues", expectedOutput:["Red = 0","Green = 10","Blue = 11"]} -->
+> <!-- Example: {template:"standalone-console", name:"PrintingEnumValues", inferOutput: true} -->
 > ```csharp
 > using System;
 > enum Color

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -602,7 +602,7 @@ The expressions of an argument list are always evaluated in textual order.
 
 > *Example*: Thus, the example
 >
-> <!-- Example: {template:"standalone-console", name:"Run-timeEvalOfArgLists1", expectedOutput:["x = 0, y = 1, z = 2","x = 4, y = -1, z = 3"]} -->
+> <!-- Example: {template:"standalone-console", name:"Run-timeEvalOfArgLists1", inferOutput: true} -->
 > ```csharp
 > class Test
 > {
@@ -1748,7 +1748,7 @@ The preceding rules mean that instance methods take precedence over extension me
 >
 > In the example, `B`’s method takes precedence over the first extension method, and `C`’s method takes precedence over both extension methods.
 >
-> <!-- Example: {template:"standalone-console", name:"ExtensionMethodInvocations2", expectedOutput:["E.F(1)","D.G(2)","C.H(3)"]} -->
+> <!-- Example: {template:"standalone-console", name:"ExtensionMethodInvocations2", inferOutput: true} -->
 > ```csharp
 > public static class C
 > {
@@ -2652,7 +2652,7 @@ The `typeof` operator can be used on a type parameter. The result is the `System
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"TypeofOperator", expectedOutput:["System.Int32","System.Int32","System.String","System.Double[]","System.Void","System.Int32","X`1[System.Int32]","X`1[X`1[System.Int32]]","X`1[T]"]} -->
+> <!-- Example: {template:"standalone-console", name:"TypeofOperator", inferOutput: true} -->
 > ```csharp
 > using System;
 > class X<T>
@@ -3890,7 +3890,7 @@ For an operation of the form `x == y` or `x != y`, if any applicable `operat
 <!-- markdownlint-enable MD028 -->
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ReferenceTypeEqualityOperators2", expectedOutput:["True","False","False","False"], ignoredWarnings:["CS0618"]} -->
+> <!-- Example: {template:"standalone-console", name:"ReferenceTypeEqualityOperators2", inferOutput: true, ignoredWarnings:["CS0618"]} -->
 > ```csharp
 > using System;
 > class Test
@@ -4548,7 +4548,7 @@ When an outer variable is referenced by an anonymous function, the outer variabl
 
 > *Example*: In the example
 >
-> <!-- Example: {template:"standalone-console", name:"CapturedOuterVariables", expectedOutput:["1", "2", "3"]} -->
+> <!-- Example: {template:"standalone-console", name:"CapturedOuterVariables", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -4575,7 +4575,7 @@ When an outer variable is referenced by an anonymous function, the outer variabl
 >
 > the local variable `x` is captured by the anonymous function, and the lifetime of `x` is extended at least until the delegate returned from `F` becomes eligible for garbage collection. Since each invocation of the anonymous function operates on the same instance of `x`, the output of the example is:
 >
-> ```csharp
+> ```console
 > 1
 > 2
 > 3
@@ -4626,7 +4626,7 @@ When not captured, there is no way to observe exactly how often a local variable
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables3", expectedOutput:["1", "3", "5"]} -->
+> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables3", inferOutput: true} -->
 > ```csharp
 > using System;
 > delegate void D();
@@ -4663,7 +4663,7 @@ When not captured, there is no way to observe exactly how often a local variable
 >
 > However, when the declaration of `x` is moved outside the loop:
 >
-> <!-- IncompleteExample: {template:"standalone-console", name:"InstantiationOfLocalVariables4", expectedOutput:["5", "5", "5"]} -->
+> <!-- IncompleteExample: {template:"standalone-console", name:"InstantiationOfLocalVariables4", inferOutput: true} -->
 > ```csharp
 > static D[] F()
 > {
@@ -4694,7 +4694,7 @@ If a for-loop declares an iteration variable, that variable itself is considered
 
 > *Example*: Thus, if the example is changed to capture the iteration variable itself:
 >
-> <!-- IncompleteExample: {template:"standalone-console", name:"InstantiationOfLocalVariables5", expectedOutput:["3", "3", "3"]} -->
+> <!-- IncompleteExample: {template:"standalone-console", name:"InstantiationOfLocalVariables5", inferOutput: true} -->
 > ```csharp
 > static D[] F()
 > {
@@ -4721,7 +4721,7 @@ It is possible for anonymous function delegates to share some captured variables
 
 > *Example*: For example, if `F` is changed to
 >
-> <!-- IncompleteExample: {template:"standalone-console", name:"InstantiationOfLocalVariables6", expectedOutput:["1 1", "2 1", "3 1"]} -->
+> <!-- IncompleteExample: {template:"standalone-console", name:"InstantiationOfLocalVariables6", inferOutput: true} -->
 > ```csharp
 > static D[] F()
 > {
@@ -4750,7 +4750,7 @@ Separate anonymous functions can capture the same instance of an outer variable.
 
 > *Example*: In the example:
 >
-> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables7", expectedOutput:["5", "10"]} -->
+> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables7", inferOutput: true} -->
 > ```csharp
 > using System;
 >

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1332,7 +1332,7 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 >
 > Pre-processing directives are not processed when they appear inside multi-line input elements. For example, the program:
 >
-> <!-- Example: {template:"standalone-console",name:"PreproDirectivesNotProcessed",expectedOutput:["hello,", "#if Debug", "        world", "#else", "        Nebraska", "#endif"]} -->
+> <!-- Example: {template:"standalone-console",name:"PreproDirectivesNotProcessed", inferOutput: true} -->
 > ```csharp
 > class Hello
 > {
@@ -1354,9 +1354,9 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 > ```console
 > hello,
 > #if Debug
->     world
+>         world
 > #else
->     Nebraska
+>         Nebraska
 > #endif
 > ```
 >

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -1089,7 +1089,7 @@ The order in which `foreach` traverses the elements of an array, is as follows: 
 
 > *Example*: The following example prints out each value in a two-dimensional array, in element order:
 >
-> <!-- Example: {template:"standalone-console", name:"ForeachStatement2", replaceEllipsis:true, expectedOutput:["1.2 2.3 3.4 4.5 5.6 6.7 7.8 8.9"]} -->
+> <!-- Example: {template:"standalone-console", name:"ForeachStatement2", replaceEllipsis:true, inferOutput: true} -->
 > ```csharp
 > using System;
 > class Test
@@ -1159,7 +1159,7 @@ Execution of jump statements is complicated by the presence of intervening `try`
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"JumpStatements", expectedOutput:["Before break","Innermost finally block","Outermost finally block","After break"]} -->
+> <!-- Example: {template:"standalone-console", name:"JumpStatements", inferOutput: true} -->
 > ```csharp
 > using System;
 > class Test
@@ -1429,7 +1429,7 @@ Within a `catch` block, a `throw` statement ([§12.10.6](statements.md#12106-the
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"TryStatement1", expectedOutput:["Exception in F: G","Exception in Main: G"]} -->
+> <!-- Example: {template:"standalone-console", name:"TryStatement1", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -1499,7 +1499,7 @@ If an exception is thrown during execution of a `finally` block, and is not caug
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"TryStatement2", expectedOutput:["Filter","Finally","Catch"]} -->
+> <!-- Example: {template:"standalone-console", name:"TryStatement2", inferOutput: true} -->
 > ```csharp
 > using System;
 > 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -275,7 +275,7 @@ The meaning of `this` in a struct differs from the meaning of `this` in a class,
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"MeaningOfThis1", expectedOutput:["1", "2", "3"]} -->
+> <!-- Example: {template:"standalone-console", name:"MeaningOfThis1", inferOutput: true} -->
 > ```csharp
 > using System;
 > struct Counter
@@ -318,7 +318,7 @@ Similarly, boxing never implicitly occurs when accessing a member on a constrain
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"MeaningOfThis2", expectedOutput:["0", "1", "1"]} -->
+> <!-- Example: {template:"standalone-console", name:"MeaningOfThis2", inferOutput: true} -->
 > ```csharp
 > using System;
 >

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -616,7 +616,7 @@ Given two expressions, `P` and `Q`, of a pointer type `T*`, the expression `P â€
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"PointerArithmetic", expectedOutput:["p - q = -14","q - p = 14"]} -->
+> <!-- Example: {template:"standalone-console", name:"PointerArithmetic", inferOutput: true} -->
 > ```csharp
 > using System;
 > class Test
@@ -754,7 +754,7 @@ Within a `fixed` statement that obtains a pointer `p` to an array instance `a`, 
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"FixedStatement2", expectedOutput:["[0,0,0] =  0 [0,0,1] =  1 [0,0,2] =  2 [0,0,3] =  3","[0,1,0] =  4 [0,1,1] =  5 [0,1,2] =  6 [0,1,3] =  7","[0,2,0] =  8 [0,2,1] =  9 [0,2,2] = 10 [0,2,3] = 11","[1,0,0] = 12 [1,0,1] = 13 [1,0,2] = 14 [1,0,3] = 15","[1,1,0] = 16 [1,1,1] = 17 [1,1,2] = 18 [1,1,3] = 19","[1,2,0] = 20 [1,2,1] = 21 [1,2,2] = 22 [1,2,3] = 23"]} -->
+> <!-- Example: {template:"standalone-console", name:"FixedStatement2", inferOutput: true} -->
 > ```csharp
 > using System;
 >
@@ -791,9 +791,9 @@ Within a `fixed` statement that obtains a pointer `p` to an array instance `a`, 
 > which produces the output:
 >
 > ```console
-> [0,0,0] = 0 [0,0,1] = 1 [0,0,2] = 2 [0,0,3] = 3
-> [0,1,0] = 4 [0,1,1] = 5 [0,1,2] = 6 [0,1,3] = 7
-> [0,2,0] = 8 [0,2,1] = 9 [0,2,2] = 10 [0,2,3] = 11
+> [0,0,0] =  0 [0,0,1] =  1 [0,0,2] =  2 [0,0,3] =  3
+> [0,1,0] =  4 [0,1,1] =  5 [0,1,2] =  6 [0,1,3] =  7
+> [0,2,0] =  8 [0,2,1] =  9 [0,2,2] = 10 [0,2,3] = 11
 > [1,0,0] = 12 [1,0,1] = 13 [1,0,2] = 14 [1,0,3] = 15
 > [1,1,0] = 16 [1,1,1] = 17 [1,1,2] = 18 [1,1,3] = 19
 > [1,2,0] = 20 [1,2,1] = 21 [1,2,2] = 22 [1,2,3] = 23

--- a/tools/ExampleExtractor/ExampleMetadata.cs
+++ b/tools/ExampleExtractor/ExampleMetadata.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 #nullable disable
 
@@ -24,6 +19,13 @@ public class ExampleMetadata
     public List<string> ExpectedWarnings { get; set; }
     public List<string> IgnoredWarnings { get; set; }
     public List<string> ExpectedOutput { get; set; }
+    /// <summary>
+    /// If this is set, ExpectedOutput must be null. The expected
+    /// output is inferred by finding a console output section shortly after the example.
+    /// This is always false in the metadata after extraction: the inferred output
+    /// is placed in ExpectedOutput instead.
+    /// </summary>
+    public bool InferOutput { get; set; }
     public string ExpectedException { get; set; }
 
     // Information provided by the example extractor


### PR DESCRIPTION
This allows us to test that the claimed output in the standard is *really* the output. In various cases, this wasn't actually the case...

We still need ExpectedOutput at the moment for cases where the standard doesn't have the expected output in a triple-backtick-fenced block, but we could potentially aim to improve that over time.

@RexJaeschke: I've added you to the review list just to make you aware of the functionality :)