### PR TITLE
Add tooling to reformat example metadata

### DIFF
--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -64,7 +64,7 @@ Similarly, a single-dimensional array `T[]` also implements the interface `Syste
 
 > *Example*: For example:
 >
-> <!-- Example: {template:"standalone-console", name:"ArraysGenericCollection", expectedErrors:["CS0266", "CS0266"]} -->
+> <!-- Example: {template:"standalone-console", name:"ArraysGenericCollection", expectedErrors:["CS0266","CS0266"]} -->
 > ```csharp
 > using System.Collections.Generic;
 > 

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -408,7 +408,7 @@ An expression `E` is an *attribute_argument_expression* if all of the following 
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib", name:"AttributeSpecification5", expectedErrors:["CS0416","CS0416"], ignoredWarnings:["CS0169"] } -->
+> <!-- Example: {template:"standalone-lib", name:"AttributeSpecification5", expectedErrors:["CS0416","CS0416"], ignoredWarnings:["CS0169"]} -->
 > ```csharp
 > using System;
 > [AttributeUsage(AttributeTargets.Class | AttributeTargets.Field)]

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -121,7 +121,7 @@ The textual order in which names are declared is generally of no significance. I
 <!-- markdownlint-enable MD028 -->
 > *Note*: As specified above, the declaration space of a block includes any nested blocks. Thus, in the following example, the `F` and `G` methods result in a compile-time error because the name `i` is declared in the outer block and cannot be redeclared in the inner block. However, the `H` and `I` methods are valid since the two `i`’s are declared in separate non-nested blocks.
 >
-> <!-- Example: {template:"standalone-lib", name:"Declarations2", expectedErrors:["CS0136","CS0136"], ignoredWarnings:["CS0219"] } -->
+> <!-- Example: {template:"standalone-lib", name:"Declarations2", expectedErrors:["CS0136","CS0136"], ignoredWarnings:["CS0219"]} -->
 > ```csharp
 > class A
 > {
@@ -297,7 +297,7 @@ The accessibility domain of a nested member `M` declared in a type `T` within 
 <!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib", name:"AccessibilityDomains",ignoredWarnings:["CS0169","CS0649"]} -->
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityDomains", ignoredWarnings:["CS0169","CS0649"]} -->
 > ```csharp
 > public class A
 > {
@@ -345,7 +345,7 @@ As described in [§7.4](basic-concepts.md#74-members), all members of a base cla
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib", name:"AccessibilityDomainsNot",expectedErrors:["CS0122"],ignoredWarnings:["CS0414"]} -->
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityDomainsNot", expectedErrors:["CS0122"], ignoredWarnings:["CS0414"]} -->
 > ```csharp
 > class A
 > {
@@ -385,7 +385,7 @@ In addition to these forms of access, a derived class can access a protected ins
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib", name:"ProtectedAccess1",expectedErrors:["CS1540"]} -->
+> <!-- Example: {template:"standalone-lib", name:"ProtectedAccess1", expectedErrors:["CS1540"]} -->
 > ```csharp
 > public class A
 > {
@@ -484,7 +484,7 @@ The following accessibility constraints exist:
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib", name:"AccessibilityConstraints1",replaceEllipsis:true,expectedErrors:["CS0060"]} -->
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityConstraints1", replaceEllipsis:true, expectedErrors:["CS0060"]} -->
 > ```csharp
 > class A {...}
 > public class B: A {...}
@@ -498,7 +498,7 @@ The following accessibility constraints exist:
 <!-- markdownlint-enable MD028 -->
 > *Example*: Likewise, in the following code
 >
-> <!-- Example: {template:"standalone-lib", name:"AccessibilityConstraints2",replaceEllipsis:true, customEllipsisReplacements:[null, "return default;", "return default;", "return default;"], expectedErrors:["CS0050"]} -->
+> <!-- Example: {template:"standalone-lib", name:"AccessibilityConstraints2", replaceEllipsis:true, customEllipsisReplacements:[null,"return default;","return default;","return default;"], expectedErrors:["CS0050"]} -->
 > ```csharp
 > class A {...}
 >
@@ -541,7 +541,7 @@ The types `object` and `dynamic` are not distinguished when comparing signatures
 
 > *Example*: The following example shows a set of overloaded method declarations along with their signatures.
 >
-> <!-- Example: {template:"standalone-lib", name:"SignatureOverloading",expectedErrors:["CS0663","CS0111","CS0111","CS0111","CS0111"]} -->
+> <!-- Example: {template:"standalone-lib", name:"SignatureOverloading", expectedErrors:["CS0663","CS0111","CS0111","CS0111","CS0111"]} -->
 > ```csharp
 > interface ITest
 > {
@@ -625,7 +625,7 @@ Within the scope of a local variable, it is a compile-time error to refer to the
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib",name:"ScopeGeneral2",expectedErrors:["CS0844"], ignoredWarnings:["CS0219"],ignoredWarnings:["CS0414"]} -->
+> <!-- Example: {template:"standalone-lib", name:"ScopeGeneral2", expectedErrors:["CS0844"], ignoredWarnings:["CS0219","CS0414"]} -->
 > ```csharp
 > class A
 > {
@@ -660,7 +660,7 @@ Within the scope of a local variable, it is a compile-time error to refer to the
 >
 > The meaning of a name within a block may differ based on the context in which the name is used. In the example
 >
-> <!-- Example: {template:"standalone-console",name:"ScopeGeneral3",expectedOutput:["hello, world", "A"]} -->
+> <!-- Example: {template:"standalone-console", name:"ScopeGeneral3", expectedOutput:["hello, world","A"]} -->
 > ```csharp
 > using System;
 >
@@ -697,7 +697,7 @@ Name hiding through nesting can occur as a result of nesting namespaces or types
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib",name:"HidingNesting1", ignoredWarnings:["CS0219", "CS0414"]} -->
+> <!-- Example: {template:"standalone-lib", name:"HidingNesting1", ignoredWarnings:["CS0219","CS0414"]} -->
 > ```csharp
 > class A
 > {
@@ -722,7 +722,7 @@ When a name in an inner scope hides a name in an outer scope, it hides all overl
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib",name:"HidingNesting2",expectedErrors:["CS1503"]} -->
+> <!-- Example: {template:"standalone-lib", name:"HidingNesting2", expectedErrors:["CS1503"]} -->
 > ```csharp
 > class Outer
 > {
@@ -760,7 +760,7 @@ Contrary to hiding a name from an outer scope, hiding a visible name from an inh
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib",name:"HidingInherit1",expectedWarnings:["CS0108"]} -->
+> <!-- Example: {template:"standalone-lib", name:"HidingInherit1", expectedWarnings:["CS0108"]} -->
 > ```csharp
 > class Base
 > {
@@ -781,7 +781,7 @@ The warning caused by hiding an inherited name can be eliminated through use of 
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib",name:"HidingInherit2"} -->
+> <!-- Example: {template:"standalone-lib", name:"HidingInherit2"} -->
 > ```csharp
 > class Base
 > {
@@ -802,7 +802,7 @@ A declaration of a new member hides an inherited member only within the scope of
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib",name:"HidingInherit3"} -->
+> <!-- Example: {template:"standalone-lib", name:"HidingInherit3"} -->
 > ```csharp
 > class Base
 > {
@@ -920,7 +920,7 @@ In other words, the fully qualified name of `N` is the complete hierarchical pa
 
 > *Example*: The example below shows several namespace and type declarations along with their associated fully qualified names.
 >
-> <!-- Example: {template:"standalone-lib",name:"FullyQualifiedNames"} -->
+> <!-- Example: {template:"standalone-lib", name:"FullyQualifiedNames"} -->
 > ```csharp
 > class A {}                 // A
 > namespace X                // X

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -868,7 +868,7 @@ All members of a generic class can use type parameters from any enclosing class,
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console",name:"TypeParameterSubstitution",expectedOutput:["1","3.1415"]} -->
+> <!-- Example: {template:"standalone-console", name:"TypeParameterSubstitution", expectedOutput:["1","3.1415"]} -->
 > ```csharp
 > class C<V>
 > {
@@ -917,7 +917,7 @@ The inherited members of a constructed class type are the members of the immedia
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib", name:"Inheritance", replaceEllipsis:true, customEllipsisReplacements: ["return default;", "return default;"]} -->
+> <!-- Example: {template:"standalone-lib", name:"Inheritance", replaceEllipsis:true, customEllipsisReplacements:["return default;","return default;"]} -->
 > ```csharp
 > class B<U>
 > {
@@ -1044,7 +1044,7 @@ Non-nested types can have `public` or `internal` declared accessibility and have
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-lib", name:"DeclaredAccessibility", replaceEllipsis:true, customEllipsisReplacements: [null, null, "return null;", "return null;", "return 0;"], ignoredWarnings:["CS0414"]} -->
+> <!-- Example: {template:"standalone-lib", name:"DeclaredAccessibility", replaceEllipsis:true, customEllipsisReplacements:[null,null,"return null;","return null;","return 0;"], ignoredWarnings:["CS0414"]} -->
 > ```csharp
 > public class List
 > {
@@ -1269,7 +1269,7 @@ Although it is bad programming style, a type parameter in a nested type can hide
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib", name:"NestedTypesInGenericClasses2",ignoredWarnings:["CS0649"], expectedWarnings:["CS0693"]} -->
+> <!-- Example: {template:"standalone-lib", name:"NestedTypesInGenericClasses2", expectedWarnings:["CS0693"], ignoredWarnings:["CS0649"]} -->
 > ```csharp
 > class Outer<T>
 > {
@@ -1314,7 +1314,7 @@ Both signatures are reserved, even if the property is read-only or write-only.
 > *Example*: In the following code
 >
 > <!-- TODO: Check why CS0109 (The member 'B.get_P()' does not hide an accessible member. The new keyword is not required.) is emitted. -->
-> <!-- Example: {template:"standalone-console",name:"PropertyReservedSignatures",inferOutput: true, expectedWarnings:["CS0109","CS0109"]} -->
+> <!-- Example: {template:"standalone-console", name:"PropertyReservedSignatures", expectedWarnings:["CS0109","CS0109"], inferOutput:true} -->
 > ```csharp
 > using System;
 > class A
@@ -1650,7 +1650,7 @@ These restrictions ensure that all threads will observe volatile writes performe
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"VolatileFields", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"VolatileFields", inferOutput:true} -->
 > ```csharp
 > using System;
 > using System.Threading;
@@ -1704,7 +1704,7 @@ The initial value of a field, whether it be a static field or an instance field,
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"FieldInitialization", inferOutput: true, ignoredWarnings:["CS0649"]} -->
+> <!-- Example: {template:"standalone-console", name:"FieldInitialization", ignoredWarnings:["CS0649"], inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -1739,7 +1739,7 @@ Field declarations may include *variable_initializer*s. For static fields, varia
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"VariableInitializers1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"VariableInitializers1", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -1852,7 +1852,7 @@ The static field variable initializers of a class correspond to a sequence of as
 >
 > because the execution of `X`’s initializer and `Y`’s initializer could occur in either order; they are only constrained to occur before the references to those fields. However, in the example:
 >
-> <!-- Example: {template:"standalone-console", name:"StaticFieldInitialization2", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"StaticFieldInitialization2", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -2120,7 +2120,7 @@ A method declared as an iterator ([§14.14](classes.md#1414-iterators)) may not 
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ReferenceParameters1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"ReferenceParameters1", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -2195,7 +2195,7 @@ Output parameters are typically used in methods that produce multiple return val
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"OutputParameters", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"OutputParameters", inferOutput:true} -->
 > ```csharp
 > using System;
 > class Test
@@ -2254,7 +2254,7 @@ Except for allowing a variable number of arguments in an invocation, a parameter
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays1", inferOutput:true} -->
 > ```csharp
 > using System;
 > class Test
@@ -2301,7 +2301,7 @@ When performing overload resolution, a method with a parameter array might be ap
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays3", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays3", inferOutput:true} -->
 > ```csharp
 > using System;
 > class Test
@@ -2346,7 +2346,7 @@ When performing overload resolution, a method with a parameter array might be ap
 >
 > *Example*: The example:
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays4", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays4", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -2378,7 +2378,7 @@ When the type of a parameter array is `object[]`, a potential ambiguity arises b
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ParameterArrays5", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"ParameterArrays5", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -2450,7 +2450,7 @@ For every virtual method declared in or inherited by a class, there exists a ***
 
 > *Example*: The following example illustrates the differences between virtual and non-virtual methods:
 >
-> <!-- Example: {template:"standalone-console", name:"VirtualMethods1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"VirtualMethods1", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -2497,7 +2497,7 @@ Because methods are allowed to hide inherited methods, it is possible for a clas
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"VirtualMethods2", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"VirtualMethods2", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -2568,7 +2568,7 @@ A compile-time error occurs unless all of the following are true for an override
 
 > *Example*: The following demonstrates how the overriding rules work for generic classes:
 >
-> <!-- Example: {template:"standalone-lib", name:"OverrideMethods1", replaceEllipsis:true, customEllipsisReplacements: ["return default;", "return default;", null, "return default;", "return default;", null, "return default;", "return default;", null ], expectedErrors:["CS0246","CS0115"]} -->
+> <!-- Example: {template:"standalone-lib", name:"OverrideMethods1", replaceEllipsis:true, customEllipsisReplacements:["return default;","return default;",null,"return default;","return default;",null,"return default;","return default;",null], expectedErrors:["CS0246","CS0115"]} -->
 > ```csharp
 > abstract class C<T>
 > {
@@ -3692,7 +3692,7 @@ When a property is declared as an override, any overridden accessors shall be ac
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-lib", name:"VirtualOverrideAaccessors", replaceEllipsis:true, customEllipsisReplacements:["return 0;", null, "return 0;"]} -->
+> <!-- Example: {template:"standalone-lib", name:"VirtualOverrideAaccessors", replaceEllipsis:true, customEllipsisReplacements:["return 0;",null,"return 0;"]} -->
 > ```csharp
 > public class B
 > {
@@ -4311,7 +4311,7 @@ The `true` and `false` unary operators require pair-wise declaration. A compile-
 
 > *Example*: The following example shows an implementation and subsequent usage of operator++ for an integer vector class:
 >
-> <!-- Example: {template:"standalone-console", name:"UnaryOperators", replaceEllipsis:true, customEllipsisReplacements:[null, "get { return 0; }", "get { return 0; } set {}"]} -->
+> <!-- Example: {template:"standalone-console", name:"UnaryOperators", replaceEllipsis:true, customEllipsisReplacements:[null,"get { return 0; }","get { return 0; } set {}"]} -->
 > ```csharp
 > public class IntVector
 > {
@@ -4384,7 +4384,7 @@ For the purposes of these rules, any type parameters associated with `S` or `T
 
 > *Example*: In the following:
 >
-> <!-- Example: {template:"standalone-lib", name:"ConversionOperators1", replaceEllipsis:true, customEllipsisReplacements:[null, "return default;", "return default;", "return default;"], expectedErrors:["CS0553"]} -->
+> <!-- Example: {template:"standalone-lib", name:"ConversionOperators1", replaceEllipsis:true, customEllipsisReplacements:[null,"return default;","return default;","return default;"], expectedErrors:["CS0553"]} -->
 > ```csharp
 > class C<T> {...}
 >
@@ -4828,7 +4828,7 @@ To initialize a new closed class type, first a new set of static fields ([§14.5
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"StaticConstructors1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"StaticConstructors1", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -4885,7 +4885,7 @@ It is possible to construct circular dependencies that allow static fields with 
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"StaticConstructors2", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"StaticConstructors2", inferOutput:true} -->
 > ```csharp
 > using System;
 > class A
@@ -5030,7 +5030,7 @@ Finalizers are implemented by overriding the virtual method `Finalize` on `Syste
 
 > *Example*: For instance, the program
 >
-> <!-- Example: {template:"standalone-lib", name:"Finalizers2", expectedErrors:["CS0249", "CS0245"], expectedWarnings:["CS0465"]} -->
+> <!-- Example: {template:"standalone-lib", name:"Finalizers2", expectedErrors:["CS0249","CS0245"], expectedWarnings:["CS0465"]} -->
 > ```csharp
 > class A
 > {

--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -98,7 +98,7 @@ This tag provides a mechanism to indicate that a fragment of text within a descr
 
 **Example:**
 
-<!-- Example: {template:"standalone-lib", name:"TagC" } -->
+<!-- Example: {template:"standalone-lib", name:"TagC"} -->
 ```csharp
 /// <summary>
 /// Class <c>Point</c> models a point in a two-dimensional plane.
@@ -711,7 +711,7 @@ IDs:
 
 **Fields** are represented by their fully qualified name.
 
-<!-- Example: {template:"standalone-lib", name:"IDStringsFields", additionalFiles:["Acme.cs"], ignoredWarnings:["CS0169","CS0649"]} -->
+<!-- Example: {template:"standalone-lib", name:"IDStringsFields", ignoredWarnings:["CS0169","CS0649"], additionalFiles:["Acme.cs"]} -->
 ```csharp
 namespace Acme
 {
@@ -779,7 +779,7 @@ IDs:
 
 **Finalizers**
 
-<!-- Example: {template:"standalone-lib", name:"IDStringsFinalizers", replaceEllipsis: true, additionalFiles:["Acme.cs"]} -->
+<!-- Example: {template:"standalone-lib", name:"IDStringsFinalizers", replaceEllipsis:true, additionalFiles:["Acme.cs"]} -->
 ```csharp
 namespace Acme
 {
@@ -798,7 +798,7 @@ IDs:
 
 **Methods**
 
-<!-- Example: {template:"standalone-lib", name:"IDStringsMethods", replaceEllipsis:true, customEllipsisReplacements: [null, null, null, "f = 0f;", null, null, null, null, null, null, null, "return null;"], additionalFiles:["Acme.cs"], ignoredWarnings:["CS0169","CS0649"]} -->
+<!-- Example: {template:"standalone-lib", name:"IDStringsMethods", replaceEllipsis:true, customEllipsisReplacements:[null,null,null,"f = 0f;",null,null,null,null,null,null,null,"return null;"], ignoredWarnings:["CS0169","CS0649"], additionalFiles:["Acme.cs"]} -->
 ```csharp
 namespace Acme
 {
@@ -878,7 +878,7 @@ IDs:
 
 **Events**
 
-<!-- Example: {template:"standalone-lib", name:"IDStringsEvents", additionalFiles:["Acme.cs"], ignoredWarnings:["CS0067"]} -->
+<!-- Example: {template:"standalone-lib", name:"IDStringsEvents", ignoredWarnings:["CS0067"], additionalFiles:["Acme.cs"]} -->
 ```csharp
 namespace Acme
 {

--- a/standard/enums.md
+++ b/standard/enums.md
@@ -154,7 +154,7 @@ The associated value of an enum member is assigned either implicitly or explicit
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"PrintingEnumValues", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"PrintingEnumValues", inferOutput:true} -->
 > ```csharp
 > using System;
 > enum Color

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -70,7 +70,7 @@ Static binding takes place at compile-time, whereas dynamic binding takes place 
 
 > *Example*: The following illustrates the notions of static and dynamic binding and of binding-time:
 >
-> <!-- Example: {template:"standalone-console", name:"BindingTime", expectedOutput: ["5", "5", "5"]} -->
+> <!-- Example: {template:"standalone-console", name:"BindingTime", expectedOutput:["5","5","5"]} -->
 > ```csharp
 > object o = 5;
 > dynamic d = 5;
@@ -602,7 +602,7 @@ The expressions of an argument list are always evaluated in textual order.
 
 > *Example*: Thus, the example
 >
-> <!-- Example: {template:"standalone-console", name:"Run-timeEvalOfArgLists1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"Run-timeEvalOfArgLists1", inferOutput:true} -->
 > ```csharp
 > class Test
 > {
@@ -1754,7 +1754,7 @@ The preceding rules mean that instance methods take precedence over extension me
 >
 > In the example, `B`’s method takes precedence over the first extension method, and `C`’s method takes precedence over both extension methods.
 >
-> <!-- Example: {template:"standalone-console", name:"ExtensionMethodInvocations2", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"ExtensionMethodInvocations2", inferOutput:true} -->
 > ```csharp
 > public static class C
 > {
@@ -2658,7 +2658,7 @@ The `typeof` operator can be used on a type parameter. The result is the `System
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"TypeofOperator", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"TypeofOperator", inferOutput:true} -->
 > ```csharp
 > using System;
 > class X<T>
@@ -3896,7 +3896,7 @@ For an operation of the form `x == y` or `x != y`, if any applicable `operat
 <!-- markdownlint-enable MD028 -->
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"ReferenceTypeEqualityOperators2", inferOutput: true, ignoredWarnings:["CS0618"]} -->
+> <!-- Example: {template:"standalone-console", name:"ReferenceTypeEqualityOperators2", ignoredWarnings:["CS0618"], inferOutput:true} -->
 > ```csharp
 > using System;
 > class Test
@@ -4554,7 +4554,7 @@ When an outer variable is referenced by an anonymous function, the outer variabl
 
 > *Example*: In the example
 >
-> <!-- Example: {template:"standalone-console", name:"CapturedOuterVariables", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"CapturedOuterVariables", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -4632,7 +4632,7 @@ When not captured, there is no way to observe exactly how often a local variable
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables3", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables3", inferOutput:true} -->
 > ```csharp
 > using System;
 > delegate void D();
@@ -4756,7 +4756,7 @@ Separate anonymous functions can capture the same instance of an outer variable.
 
 > *Example*: In the example:
 >
-> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables7", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"InstantiationOfLocalVariables7", inferOutput:true} -->
 > ```csharp
 > using System;
 >

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -192,7 +192,7 @@ A ***delimited comment*** begins with the characters `/*` and ends with the cha
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console",name:"HelloWorld1",expectedOutput:["hello, world"]} -->
+> <!-- Example: {template:"standalone-console", name:"HelloWorld1", expectedOutput:["hello, world"]} -->
 > ```csharp
 > /* Hello, world program
 >    This program writes "hello, world" to the console
@@ -214,7 +214,7 @@ A ***single-line comment*** begins with the characters `//` and extends to the 
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console",name:"HelloWorld2",expectedOutput:["hello, world"]} -->
+> <!-- Example: {template:"standalone-console", name:"HelloWorld2", expectedOutput:["hello, world"]} -->
 > ```csharp
 > // Hello, world program
 > // This program writes "hello, world" to the console
@@ -938,7 +938,7 @@ Each string literal does not necessarily result in a new string instance. When t
 
 > *Example*: For instance, the output produced by
 >
-> <!-- Example: {template:"standalone-console",name:"ObjectReferenceEquality",expectedOutput:["True"]} -->
+> <!-- Example: {template:"standalone-console", name:"ObjectReferenceEquality", expectedOutput:["True"]} -->
 > ```csharp
 > class Test
 > {
@@ -1332,7 +1332,7 @@ Any remaining conditional sections are skipped and no tokens, except those for p
 >
 > Pre-processing directives are not processed when they appear inside multi-line input elements. For example, the program:
 >
-> <!-- Example: {template:"standalone-console",name:"PreproDirectivesNotProcessed", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"PreproDirectivesNotProcessed", inferOutput:true} -->
 > ```csharp
 > class Hello
 > {

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -1089,7 +1089,7 @@ The order in which `foreach` traverses the elements of an array, is as follows: 
 
 > *Example*: The following example prints out each value in a two-dimensional array, in element order:
 >
-> <!-- Example: {template:"standalone-console", name:"ForeachStatement2", replaceEllipsis:true, inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"ForeachStatement2", replaceEllipsis:true, inferOutput:true} -->
 > ```csharp
 > using System;
 > class Test
@@ -1159,7 +1159,7 @@ Execution of jump statements is complicated by the presence of intervening `try`
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"JumpStatements", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"JumpStatements", inferOutput:true} -->
 > ```csharp
 > using System;
 > class Test
@@ -1429,7 +1429,7 @@ Within a `catch` block, a `throw` statement ([§12.10.6](statements.md#12106-the
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"TryStatement1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"TryStatement1", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -1499,7 +1499,7 @@ If an exception is thrown during execution of a `finally` block, and is not caug
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"TryStatement2", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"TryStatement2", inferOutput:true} -->
 > ```csharp
 > using System;
 > 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -275,7 +275,7 @@ The meaning of `this` in a struct differs from the meaning of `this` in a class,
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"MeaningOfThis1", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"MeaningOfThis1", inferOutput:true} -->
 > ```csharp
 > using System;
 > struct Counter
@@ -318,7 +318,7 @@ Similarly, boxing never implicitly occurs when accessing a member on a constrain
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"MeaningOfThis2", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"MeaningOfThis2", inferOutput:true} -->
 > ```csharp
 > using System;
 >

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -94,7 +94,7 @@ Other than establishing an unsafe context, thus permitting the use of pointer ty
 >
 > The situation is slightly different when a pointer type is part of the methodâ€™s signature
 >
-> <!-- Example: {template:"standalone-lib", name:"UnsafeContexts4", replaceEllipsis:true } -->
+> <!-- Example: {template:"standalone-lib", name:"UnsafeContexts4", replaceEllipsis:true} -->
 > ```csharp
 > public unsafe class A
 > {
@@ -616,7 +616,7 @@ Given two expressions, `P` and `Q`, of a pointer type `T*`, the expression `P â€
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"PointerArithmetic", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"PointerArithmetic", inferOutput:true} -->
 > ```csharp
 > using System;
 > class Test
@@ -754,7 +754,7 @@ Within a `fixed` statement that obtains a pointer `p` to an array instance `a`, 
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"FixedStatement2", inferOutput: true} -->
+> <!-- Example: {template:"standalone-console", name:"FixedStatement2", inferOutput:true} -->
 > ```csharp
 > using System;
 >
@@ -837,7 +837,7 @@ A `char*` value produced by fixing a string instance always points to a null-ter
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console", name:"FixedStatement4", expectedOutput:["x", "x", "x", "x"]} -->
+> <!-- Example: {template:"standalone-console", name:"FixedStatement4", expectedOutput:["x","x","x","x"]} -->
 > ```csharp
 > class Test
 > {
@@ -1040,7 +1040,7 @@ All stack-allocated memory blocks created during the execution of a function mem
 <!-- markdownlint-enable MD028 -->
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-console", name:"StackAllocation", expectedOutput:["12345", "-999"]} -->
+> <!-- Example: {template:"standalone-console", name:"StackAllocation", expectedOutput:["12345","-999"]} -->
 > ```csharp
 > using System;
 >

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -16,7 +16,7 @@ C# defines seven categories of variables: static variables, instance variables, 
 
 > *Example*: In the following code
 >
-> <!-- Example: {template:"standalone-lib", name:"VariableCategories", ignoredWarnings:["CS0169","CS0219"], ignoredWarnings:["CS0649"]} -->
+> <!-- Example: {template:"standalone-lib", name:"VariableCategories", ignoredWarnings:["CS0169","CS0219","CS0649"]} -->
 > ```csharp
 > class A
 > {
@@ -434,7 +434,7 @@ finally «finally_block»
 
 > *Example*: The following example demonstrates how the different blocks of a `try` statement ([§12.11](statements.md#1211-the-try-statement)) affect definite assignment.
 >
-> <!-- Example: {template:"standalone-lib", name:"TryCatchFinally", ignoredWarnings:["CS0219"], expectedWarnings:["CS0162"]} -->
+> <!-- Example: {template:"standalone-lib", name:"TryCatchFinally", expectedWarnings:["CS0162"], ignoredWarnings:["CS0219"]} -->
 > ```csharp
 > class A
 > {

--- a/tools/ExampleExtractor/ExampleMetadata.cs
+++ b/tools/ExampleExtractor/ExampleMetadata.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+﻿using Newtonsoft.Json;
 
 #nullable disable
 
@@ -12,38 +12,55 @@ public class ExampleMetadata
     public const string MetadataFile = "metadata.json";
 
     // Information loaded from the comment
+    [JsonProperty("template")]
     public string Template { get; set; }
+    [JsonProperty("name")]
     public string Name { get; set; }
+    [JsonProperty("replaceEllipsis")]
     public bool ReplaceEllipsis { get; set; }
+
     /// <summary>
     /// When set, and when <see cref="ReplaceEllipsis"/> is true, this list is used
     /// to provide the replacements, allowing for return statements etc.
     /// A null entry is used to mean the default "/* ... */" replacement. (The default
     /// is also used for anything beyond the length of this list.)
     /// </summary>
+    [JsonProperty("customEllipsisReplacements")]
     public List<string> CustomEllipsisReplacements { get; set; }
 
+    [JsonProperty("expectedErrors")]
     public List<string> ExpectedErrors { get; set; }
+    [JsonProperty("expectedWarnings")]
     public List<string> ExpectedWarnings { get; set; }
+    [JsonProperty("ignoredWarnings")]
     public List<string> IgnoredWarnings { get; set; }
+    [JsonProperty("expectedOutput")]
     public List<string> ExpectedOutput { get; set; }
+
     /// <summary>
     /// If this is set, ExpectedOutput must be null. The expected
     /// output is inferred by finding a console output section shortly after the example.
     /// This is always false in the metadata after extraction: the inferred output
     /// is placed in ExpectedOutput instead.
     /// </summary>
+    [JsonProperty("inferOutput")]
     public bool InferOutput { get; set; }
+
+    [JsonProperty("expectedException")]
     public string ExpectedException { get; set; }
 
     /// <summary>
     /// Additional files to copy from the special "additional-files" template directory.
     /// </summary>
+    [JsonProperty("additionalFiles")]
     public List<string> AdditionalFiles { get; set; }
 
     // Information provided by the example extractor
+    [JsonProperty("markdownFile")]
     public string MarkdownFile { get; set; }
+    [JsonProperty("startLine")]
     public int StartLine { get; set; }
+    [JsonProperty("endLine")]
     public int EndLine { get; set; }
 
     [JsonIgnore]

--- a/tools/ExampleFormatter/ExampleFormatter.csproj
+++ b/tools/ExampleFormatter/ExampleFormatter.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <ProjectReference Include="..\ExampleExtractor\ExampleExtractor.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/tools/ExampleFormatter/Program.cs
+++ b/tools/ExampleFormatter/Program.cs
@@ -1,0 +1,91 @@
+﻿using ExampleExtractor;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Text;
+
+if (args.Length != 1)
+{
+    Console.WriteLine("Arguments: <markdown-directory>");
+    return 1;
+}
+
+foreach (var markdownFile in Directory.GetFiles(args[0]))
+{
+    Reformat(markdownFile);
+}
+
+return 0;
+
+void Reformat(string file)
+{
+    const string ExamplePrefix = "<!-- Example: ";
+    const string ExampleSuffix = " -->";
+
+    Console.WriteLine($"Reformatting {Path.GetFileName(file)}");
+    var lines = File.ReadAllLines(file);
+    int changes = 0;
+
+    for (int i = 0; i < lines.Length; i++)
+    {
+        string line = lines[i];
+
+        int prefixIndex = line.IndexOf(ExamplePrefix);
+        if (prefixIndex == -1)
+        {
+            continue;
+        }
+        if (!line.EndsWith(ExampleSuffix))
+        {
+            Console.WriteLine($"  WARNING: '{line}' does not end with {ExampleSuffix}");
+        }
+        string json = line[(prefixIndex + ExamplePrefix.Length)..^ExampleSuffix.Length];
+        var metadata = JsonConvert.DeserializeObject<ExampleMetadata>(json)!;
+
+        var reformatted = FormatMetadata(metadata);
+        if (json == reformatted)
+        {
+            continue;
+        }
+        changes++;
+        lines[i] = line[0..(prefixIndex + ExamplePrefix.Length)] + reformatted + ExampleSuffix;
+    }
+
+    if (changes != 0)
+    {
+        Console.WriteLine($"  Lines changed: {changes}");
+        File.WriteAllLines(file, lines);
+    }
+
+    // Reformats the metadata to "not quite JSON" for brevity:
+    // - No quotes around property names
+    // - No space after opening { or before closing }
+    // - No space after property colon, e.g. name:"value"
+    // - Space between each property
+    string FormatMetadata(ExampleMetadata metadata)
+    {
+        var settings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
+        string plainJson = JsonConvert.SerializeObject(metadata, settings);
+        JObject reparsed = JObject.Parse(plainJson);
+        StringBuilder builder = new StringBuilder("{");
+        bool first = true;
+        foreach (var property in reparsed.Properties())
+        {
+            if (!first)
+            {
+                builder.Append(", ");
+            }
+            first = false;
+            builder.Append(property.Name).Append(":").Append(SerializeValue(property.Value));
+        }
+        builder.Append("}");
+        return builder.ToString();
+
+        string SerializeValue(JToken token)
+        {
+            var stringWriter = new StringWriter();
+            var jsonWriter = new JsonTextWriter(stringWriter);
+            JsonSerializer.CreateDefault().Serialize(jsonWriter, token);
+            return stringWriter.ToString();
+        }
+    }
+}

--- a/tools/tools.sln
+++ b/tools/tools.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleExtractor", "Example
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleTester", "ExampleTester\ExampleTester.csproj", "{829FE7D6-B7E7-48DF-923A-73A79921E997}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleFormatter", "ExampleFormatter\ExampleFormatter.csproj", "{82D1A159-5637-48C4-845D-CC1390995CC2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,18 @@ Global
 		{829FE7D6-B7E7-48DF-923A-73A79921E997}.Release|x64.Build.0 = Release|Any CPU
 		{829FE7D6-B7E7-48DF-923A-73A79921E997}.Release|x86.ActiveCfg = Release|Any CPU
 		{829FE7D6-B7E7-48DF-923A-73A79921E997}.Release|x86.Build.0 = Release|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Debug|x64.Build.0 = Debug|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Debug|x86.Build.0 = Debug|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Release|x64.ActiveCfg = Release|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Release|x64.Build.0 = Release|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Release|x86.ActiveCfg = Release|Any CPU
+		{82D1A159-5637-48C4-845D-CC1390995CC2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I'm very happy to debate the precise format here, but it feels like consistency is useful :)