### PR TITLE
Run quest nightly

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,0 +1,35 @@
+name: "bulk quest import"
+on:
+  schedule:
+    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "The reason for running the bulk import workflow"
+        required: true
+        default: "Initial import into Quest (Azure DevOps)"
+
+jobs:
+  bulk-import:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: "Print manual bulk import run reason"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "Reason: ${{ github.event.inputs.reason }}"
+
+      - name: bulk-sequester
+        id: bulk-sequester
+        uses: dotnet/docs-tools/actions/sequester@main
+        env:
+          ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
+          ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+        with:
+          org: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}
+          issue: '-1'
+          branch: ${{ github.ref_name }}

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -1,11 +1,5 @@
 name: "quest import"
 on:
-  issues:
-    types:
-      [ labeled, closed, reopened, assigned, unassigned ]
-  pull_request:
-    types:
-      [ labeled, closed, assigned, unassigned ]
   workflow_dispatch:
     inputs:
       reason:
@@ -26,7 +20,6 @@ jobs:
       contains(github.event.issue.labels.*.name, 'seQUESTered')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
 
     steps:
@@ -65,4 +58,3 @@ jobs:
           repo: ${{ github.repository }}
           issue: ${{ github.event.issue.number }}
           branch: ${{ github.ref_name }}
-          


### PR DESCRIPTION
In other repos, we've found that Quest can suffer from a race condition when a person updates multiple labels, triggering multiple runs in succession.

The best way to prevent that is to run nightly, during a time when it's unlikely that we're actively making updates. However, even if we are, this will be resilient because it will run once, and any updates made while it runs will update the following day.

See dotnet/docs-tools#131