### PR TITLE
Minor tweaks to #line directive and associated attributes

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -808,7 +808,7 @@ One exception is query expressions. These are considered syntactic expansions, a
 If more than one caller-info attribute is specified on a given parameter, they are recognized in the following order: `CallerLineNumber`, `CallerFilePath`, `CallerMemberName`. Consider the following parameter declaration:
 
 ```csharp
-[CallerMemberName][CallerFilePath][CallerLineNumber]object p = ...
+[CallerMemberName, CallerFilePath, CallerLineNumber] object p = ...
 ```
 
 `CallerLineNumber` takes precedence, and the other two attributes are ignored. If `CallerLineNumber` were omitted, `CallerFilePath` would take precedence, and `CallerMemberName` would be ignored. The lexical ordering of these attributes is irrelevant.

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -805,11 +805,17 @@ Caller information is only substituted when a function is explicitly invoked in 
 
 One exception is query expressions. These are considered syntactic expansions, and if the calls they expand to omit optional parameters with caller-info attributes, caller information will be substituted. The location used is the location of the query clause which the call was generated from.
 
-If more than one caller-info attribute is specified on a given parameter, they are preferred in the following order: `CallerLineNumber`, `CallerFilePath`, `CallerMemberName`.
+If more than one caller-info attribute is specified on a given parameter, they are recognized in the following order: `CallerLineNumber`, `CallerFilePath`, `CallerMemberName`. Consider the following parameter declaration:
+
+```csharp
+[CallerMemberName][CallerFilePath][CallerLineNumber]object p = ...
+```
+
+`CallerLineNumber` takes precedence, and the other two attributes are ignored. If `CallerLineNumber` were omitted, `CallerFilePath` would take precedence, and `CallerMemberName` would be ignored. The lexical ordering of these attributes is irrelevant.
 
 #### 21.5.5.2 The CallerLineNumber attribute
 
-The `System.Runtime.CompilerServices.CallerLineNumberAttribute` is allowed on optional parameters when there is a standard implicit conversion ([§10.4.2](conversions.md#1042-standard-implicit-conversions)) from the constant value `int.MaxValue` to the parameter’s type. This ensures that any non-negative line number up to that value can be passed without error.
+The attribute `System.Runtime.CompilerServices.CallerLineNumberAttribute` is allowed on optional parameters when there is a standard implicit conversion ([§10.4.2](conversions.md#1042-standard-implicit-conversions)) from the constant value `int.MaxValue` to the parameter’s type. This ensures that any non-negative line number up to that value can be passed without error.
 
 If a function invocation from a location in source code omits an optional parameter with the `CallerLineNumberAttribute`, then a numeric literal representing that location’s line number is used as an argument to the invocation instead of the default parameter value.
 
@@ -819,7 +825,7 @@ The line number may be affected by `#line` directives ([§6.5.8](lexical-structu
 
 #### 21.5.5.3 The CallerFilePath attribute
 
-The `System.Runtime.CompilerServices.CallerFilePathAttribute` is allowed on optional parameters when there is a standard implicit conversion ([§10.4.2](conversions.md#1042-standard-implicit-conversions)) from `string` to the parameter’s type.
+The attribute `System.Runtime.CompilerServices.CallerFilePathAttribute` is allowed on optional parameters when there is a standard implicit conversion ([§10.4.2](conversions.md#1042-standard-implicit-conversions)) from `string` to the parameter’s type.
 
 If a function invocation from a location in source code omits an optional parameter with the `CallerFilePathAttribute`, then a string literal representing that location’s file path is used as an argument to the invocation instead of the default parameter value.
 
@@ -829,7 +835,7 @@ The file path may be affected by `#line` directives ([§6.5.8](lexical-structure
 
 #### 21.5.5.4 The CallerMemberName attribute
 
-The `System.Runtime.CompilerServices.CallerMemberNameAttribute` is allowed on optional parameters when there is a standard implicit conversion ([§10.4.2](conversions.md#1042-standard-implicit-conversions)) from `string` to the parameter’s type.
+The attribute `System.Runtime.CompilerServices.CallerMemberNameAttribute` is allowed on optional parameters when there is a standard implicit conversion ([§10.4.2](conversions.md#1042-standard-implicit-conversions)) from `string` to the parameter’s type.
 
 If a function invocation from a location within the body of a function member or within an attribute applied to the function member itself or its return type, parameters or type parameters in source code omits an optional parameter with the `CallerMemberNameAttribute`, then a string literal representing the name of that member is used as an argument to the invocation instead of the default parameter value.
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1476,13 +1476,15 @@ fragment PP_Compilation_Unit_Name_Character
     ;
 ```
 
-When no `#line` directives are present, the compiler reports true line numbers and compilation unit names in its output. When processing a `#line` directive that includes a *Line_Indicator* that is not `default`, the compiler treats the line *after* the directive as having the given line number (and compilation unit name, if specified).
+When no `#line` directives are present, the compiler reports true line numbers and compilation unit names in its output. When processing a `#line` directive that includes a *PP_Line_Indicator* that is not `default`, the compiler treats the line *after* the directive as having the given line number (and compilation unit name, if specified).
+
+The maximum value allowed for `Decimal_Digit+` is implementation-defined.
 
 A `#line default` directive undoes the effect of all preceding `#line` directives. The compiler reports true line information for subsequent lines, precisely as if no `#line` directives had been processed.
 
-A `#line hidden` directive has no effect on the compilation unit and line numbers reported in error messages, or produced by use of `CallerLineNumberAttribute` ([§21.5.5.2](attributes.md#21552-the-callerlinenumber-attribute)). It is intended to affect source-level debugging tools so that, when debugging, all lines between a `#line` hidden directive and the subsequent `#line` directive (that is not `#line hidden`) have no line number information, and are skipped entirely when stepping through code.
+A `#line hidden` directive has no effect on the compilation unit and line numbers reported in error messages, or produced by use of `CallerLineNumberAttribute` ([§21.5.5.2](attributes.md#21552-the-callerlinenumber-attribute)). It is intended to affect source-level debugging tools so that, when debugging, all lines between a `#line hidden` directive and the subsequent `#line` directive (that is not `#line hidden`) have no line number information, and are skipped entirely when stepping through code.
 
-> *Note*: Although a *Compilation_Unit_Name* might contain text that looks like an escape sequence, such text is not an escape sequence; in this context a ‘`\`’ character simply designates an ordinary backslash character. *end note*
+> *Note*: Although a *PP_Compilation_Unit_Name* might contain text that looks like an escape sequence, such text is not an escape sequence; in this context a ‘`\`’ character simply designates an ordinary backslash character. *end note*
 
 ### 6.5.9 Pragma directives
 

--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -24,21 +24,21 @@ The behavior is undefined in the following circumstances:
 A conforming implementation is required to document its choice of behavior in each of the areas listed in this subclause. The following are implementation-defined:
 
 1. The behavior when an identifier not in Normalization Form C is encountered ([§6.4.3](lexical-structure.md#643-identifiers)).
-2. The maximum value allowed for `Decimal_Digit+` in `PP_Line_Indicator` ([§6.5.8](lexical-structure.md#658-line-directives)).
-3. The interpretation of the *input_characters* in the *pp_pragma-text* of a #pragma directive ([§6.5.9](lexical-structure.md#659-pragma-directives)).
-4. The values of any application parameters passed to `Main` by the host environment prior to application startup ([§7.1](basic-concepts.md#71-application-startup)).
-5. The precise structure of the expression tree, as well as the exact process for creating it, when an anonymous function is converted to an expression-tree ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
-6. Whether a `System.ArithmeticException` (or a subclass thereof) is thrown or the overflow goes unreported with the resulting value being that of the left operand, when in an `unchecked` context and the left operand of an integer division is the maximum negative `int` or `long` value and the right operand is `–1` ([§11.9.3](expressions.md#1193-division-operator)).
-7. When a `System.ArithmeticException` (or a subclass thereof) is thrown when performing a decimal remainder operation ([§11.9.4](expressions.md#1194-remainder-operator)).
-8. The impact of thread termination when a thread has no handler for an exception, and the thread is itself terminated ([§12.10.6](statements.md#12106-the-throw-statement)).
-9. The impact of thread termination when no matching `catch` clause is found for an exception and the code that initially started that thread is reached. ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
-10. The mappings between pointers and integers ([§22.5.1](unsafe-code.md#2251-general)).
-11. The effect of applying the unary `*` operator to a `null` pointer ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
-12. The behavior when pointer arithmetic overflows the domain of the pointer type ([§22.6.6](unsafe-code.md#2266-pointer-increment-and-decrement), [§22.6.7](unsafe-code.md#2267-pointer-arithmetic)).
-13. The result of the `sizeof` operator for non-pre-defined value types ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
-14. The behavior of the `fixed` statement if the array expression is `null` or if the array has zero elements ([§22.7](unsafe-code.md#227-the-fixed-statement)).
-15. The behavior of the `fixed` statement if the string expression is `null` ([§22.7](unsafe-code.md#227-the-fixed-statement)).
-16. The value returned when a stack allocation of size zero is made ([§22.9](unsafe-code.md#229-stack-allocation)).
+1. The maximum value allowed for `Decimal_Digit+` in `PP_Line_Indicator` ([§6.5.8](lexical-structure.md#658-line-directives)).
+1. The interpretation of the *input_characters* in the *pp_pragma-text* of a #pragma directive ([§6.5.9](lexical-structure.md#659-pragma-directives)).
+1. The values of any application parameters passed to `Main` by the host environment prior to application startup ([§7.1](basic-concepts.md#71-application-startup)).
+1. The precise structure of the expression tree, as well as the exact process for creating it, when an anonymous function is converted to an expression-tree ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
+1. Whether a `System.ArithmeticException` (or a subclass thereof) is thrown or the overflow goes unreported with the resulting value being that of the left operand, when in an `unchecked` context and the left operand of an integer division is the maximum negative `int` or `long` value and the right operand is `–1` ([§11.9.3](expressions.md#1193-division-operator)).
+1. When a `System.ArithmeticException` (or a subclass thereof) is thrown when performing a decimal remainder operation ([§11.9.4](expressions.md#1194-remainder-operator)).
+1. The impact of thread termination when a thread has no handler for an exception, and the thread is itself terminated ([§12.10.6](statements.md#12106-the-throw-statement)).
+1. The impact of thread termination when no matching `catch` clause is found for an exception and the code that initially started that thread is reached. ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
+1. The mappings between pointers and integers ([§22.5.1](unsafe-code.md#2251-general)).
+1. The effect of applying the unary `*` operator to a `null` pointer ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
+1. The behavior when pointer arithmetic overflows the domain of the pointer type ([§22.6.6](unsafe-code.md#2266-pointer-increment-and-decrement), [§22.6.7](unsafe-code.md#2267-pointer-arithmetic)).
+1. The result of the `sizeof` operator for non-pre-defined value types ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
+1. The behavior of the `fixed` statement if the array expression is `null` or if the array has zero elements ([§22.7](unsafe-code.md#227-the-fixed-statement)).
+1. The behavior of the `fixed` statement if the string expression is `null` ([§22.7](unsafe-code.md#227-the-fixed-statement)).
+1. The value returned when a stack allocation of size zero is made ([§22.9](unsafe-code.md#229-stack-allocation)).
 
 ## B.4 Unspecified behavior
 

--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -24,20 +24,21 @@ The behavior is undefined in the following circumstances:
 A conforming implementation is required to document its choice of behavior in each of the areas listed in this subclause. The following are implementation-defined:
 
 1. The behavior when an identifier not in Normalization Form C is encountered ([§6.4.3](lexical-structure.md#643-identifiers)).
-1. The interpretation of the *input_characters* in the *pp_pragma-text* of a #pragma directive ([§6.5.9](lexical-structure.md#659-pragma-directives)).
-1. The values of any application parameters passed to `Main` by the host environment prior to application startup ([§7.1](basic-concepts.md#71-application-startup)).
-1. The precise structure of the expression tree, as well as the exact process for creating it, when an anonymous function is converted to an expression-tree ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
-1. Whether a `System.ArithmeticException` (or a subclass thereof) is thrown or the overflow goes unreported with the resulting value being that of the left operand, when in an `unchecked` context and the left operand of an integer division is the maximum negative `int` or `long` value and the right operand is `–1` ([§11.9.3](expressions.md#1193-division-operator)).
-1. When a `System.ArithmeticException` (or a subclass thereof) is thrown when performing a decimal remainder operation ([§11.9.4](expressions.md#1194-remainder-operator)).
-1. The impact of thread termination when a thread has no handler for an exception, and the thread is itself terminated ([§12.10.6](statements.md#12106-the-throw-statement)).
-1. The impact of thread termination when no matching `catch` clause is found for an exception and the code that initially started that thread is reached. ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
-1. The mappings between pointers and integers ([§22.5.1](unsafe-code.md#2251-general)).
-1. The effect of applying the unary `*` operator to a `null` pointer ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
-1. The behavior when pointer arithmetic overflows the domain of the pointer type ([§22.6.6](unsafe-code.md#2266-pointer-increment-and-decrement), [§22.6.7](unsafe-code.md#2267-pointer-arithmetic)).
-1. The result of the `sizeof` operator for non-pre-defined value types ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
-1. The behavior of the `fixed` statement if the array expression is `null` or if the array has zero elements ([§22.7](unsafe-code.md#227-the-fixed-statement)).
-1. The behavior of the `fixed` statement if the string expression is `null` ([§22.7](unsafe-code.md#227-the-fixed-statement)).
-1. The value returned when a stack allocation of size zero is made ([§22.9](unsafe-code.md#229-stack-allocation)).
+2. The maximum value allowed for `Decimal_Digit+` in `PP_Line_Indicator` ([§6.5.8](lexical-structure.md#658-line-directives)).
+3. The interpretation of the *input_characters* in the *pp_pragma-text* of a #pragma directive ([§6.5.9](lexical-structure.md#659-pragma-directives)).
+4. The values of any application parameters passed to `Main` by the host environment prior to application startup ([§7.1](basic-concepts.md#71-application-startup)).
+5. The precise structure of the expression tree, as well as the exact process for creating it, when an anonymous function is converted to an expression-tree ([§10.7.3](conversions.md#1073-evaluation-of-lambda-expression-conversions-to-expression-tree-types)).
+6. Whether a `System.ArithmeticException` (or a subclass thereof) is thrown or the overflow goes unreported with the resulting value being that of the left operand, when in an `unchecked` context and the left operand of an integer division is the maximum negative `int` or `long` value and the right operand is `–1` ([§11.9.3](expressions.md#1193-division-operator)).
+7. When a `System.ArithmeticException` (or a subclass thereof) is thrown when performing a decimal remainder operation ([§11.9.4](expressions.md#1194-remainder-operator)).
+8. The impact of thread termination when a thread has no handler for an exception, and the thread is itself terminated ([§12.10.6](statements.md#12106-the-throw-statement)).
+9. The impact of thread termination when no matching `catch` clause is found for an exception and the code that initially started that thread is reached. ([§20.4](exceptions.md#204-how-exceptions-are-handled)).
+10. The mappings between pointers and integers ([§22.5.1](unsafe-code.md#2251-general)).
+11. The effect of applying the unary `*` operator to a `null` pointer ([§22.6.2](unsafe-code.md#2262-pointer-indirection)).
+12. The behavior when pointer arithmetic overflows the domain of the pointer type ([§22.6.6](unsafe-code.md#2266-pointer-increment-and-decrement), [§22.6.7](unsafe-code.md#2267-pointer-arithmetic)).
+13. The result of the `sizeof` operator for non-pre-defined value types ([§22.6.9](unsafe-code.md#2269-the-sizeof-operator)).
+14. The behavior of the `fixed` statement if the array expression is `null` or if the array has zero elements ([§22.7](unsafe-code.md#227-the-fixed-statement)).
+15. The behavior of the `fixed` statement if the string expression is `null` ([§22.7](unsafe-code.md#227-the-fixed-statement)).
+16. The value returned when a stack allocation of size zero is made ([§22.9](unsafe-code.md#229-stack-allocation)).
 
 ## B.4 Unspecified behavior
 


### PR DESCRIPTION
Bill, the only normative change is the addition of the implementation-defined statement w.r.t the max value permitted for a line number. Prior to this edit, that was (implicitly) unspecified; now there is a requirement for an implementation to document it, which the current implementation does.