### PR TITLE
Make smarten resilient to new spec files

### DIFF
--- a/tools/run-smarten.sh
+++ b/tools/run-smarten.sh
@@ -1,40 +1,8 @@
 #!/bin/bash
 set -eu -o pipefail
 
-declare -r SPEC_DIRECTORY=../standard
-declare -r EXTENSION=md
 
-declare -a SPEC_FILES=(
-    "foreword.md"
-    "introduction.md"
-    "scope.md"
-    "normative-references.md"
-    "terms-and-definitions.md"
-    "general-description.md"
-    "conformance.md"
-    "lexical-structure.md"
-    "basic-concepts.md" 
-    "types.md"
-    "variables.md"
-    "conversions.md"
-    "expressions.md"
-    "statements.md"
-    "namespaces.md"
-    "classes.md"
-    "structs.md"
-    "arrays.md"
-    "interfaces.md"
-    "enums.md"
-    "delegates.md"
-    "exceptions.md"
-    "attributes.md"
-    "unsafe-code.md"
-    "grammar.md"
-    "portability-issues.md"
-    "standard-library.md"
-    "documentation-comments.md"
-    "bibliography.md"
-    )
+declare -a SPEC_FILES=($(ls ../standard/*.md))
 
 # unpack the package to ./smarten
 tar -xvf ../.github/workflows/dependencies/EcmaTC49.Smarten.tar
@@ -42,7 +10,7 @@ tar -xvf ../.github/workflows/dependencies/EcmaTC49.Smarten.tar
 for file in "${SPEC_FILES[@]}"
 do
     echo "$file"
-    ./smarten/Smarten_CL.exe $SPEC_DIRECTORY/$file $SPEC_DIRECTORY/$file
+    ./smarten/Smarten_CL.exe $file $file
 done
 
 # finally, remove the unpacked smarten executable:


### PR DESCRIPTION
This tool is easy to fix in the script because it needs to read all markdown files.

For the grammar extractor and validator, I'm going to fix them in another commit in the patterns PR.

Both those tools require some knowledge of which files contain which content. So, given that we add or remove clauses infrequently, it's wiser just to update the scripts.
