### PR TITLE
Fix long lines in all but one case

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -501,7 +501,8 @@ The attribute instance represented by `T`, `C`, `P`, and `N`, and associated wi
 >         foreach (Type t in Assembly.Load(assemblyName).GetTypes()) 
 >         {
 >             Console.WriteLine($"Type : {t}");
->             var helpers = (HelpAttribute[]) t.GetCustomAttributes(helpType, false);
+>             var attributes = t.GetCustomAttributes(helpType, false);
+>             var helpers = (HelpAttribute[]) attributes;
 >             foreach (var helper in helpers)
 >             {
 >                 Console.WriteLine($"\tUrl : {helper.Url}");

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -4132,8 +4132,8 @@ When an indexer declaration includes an `extern` modifier, the indexer is said t
 >
 > The following `CountPrimes` class uses a `BitArray` and the classical “sieve” algorithm to compute the number of primes between 2 and a given maximum:
 >
-> <!-- Incomplete$Example: {template:"standalone-console", name:"Indexers2", additionalFiles:["MyBitArray.cs"], expectedOutput:["x", "x", > ```csharp
-> <!-- FIX: needs an integer Command-Line Argument to Main --.
+> <!-- Example: {template:"standalone-console", name:"Indexers2", additionalFiles:["MyBitArray.cs"], expectedOutput:["Found 6 primes between 2 and 13"], executionArgs:["13"]} -->
+> ```csharp
 > class CountPrimes
 > {
 >     static int Count(int max)
@@ -4153,7 +4153,7 @@ When an indexer declaration includes an `extern` modifier, the indexer is said t
 >         }
 >         return count;
 >     }
->
+> 
 >     static void Main(string[] args)
 >     {
 >         int max = int.Parse(args[0]);
@@ -4161,7 +4161,6 @@ When an indexer declaration includes an `extern` modifier, the indexer is said t
 >         Console.WriteLine($"Found {count} primes between 2 and {max}");
 >     }
 > }
->
 > ```
 >
 > Note that the syntax for accessing elements of the `BitArray` is precisely the same as for a `bool[]`.
@@ -4307,8 +4306,8 @@ The `true` and `false` unary operators require pair-wise declaration. A compile-
 > public class IntVector
 > {
 >     public IntVector(int length) {...}
->     public int Length { get { ... } }                       // Read-only property
->     public int this[int index] { get { ... } set { ... } }  // Read-write indexer
+>     public int Length { get { ... } }                      // Read-only property
+>     public int this[int index] { get { ... } set { ... } } // Read-write indexer
 >
 >     public static IntVector operator++(IntVector iv)
 >     {

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -912,12 +912,12 @@ The ***inferred return type*** is determined as follows:
 >
 >     static void M()
 >     {
->         double seconds = F("1:15:30", s => TimeSpan.Parse(s), t => t.TotalSeconds);
+>         double hours = F("1:15:30", s => TimeSpan.Parse(s), t => t.TotalHours);
 >     }
 > }
 > ```
 >
-> type inference for the invocation proceeds as follows: First, the argument “1:15:30” is related to the value parameter, inferring `X` to be string. Then, the parameter of the first anonymous function, `s`, is given the inferred type `string`, and the expression `TimeSpan.Parse(s)` is related to the return type of `f1`, inferring `Y` to be `System.TimeSpan`. Finally, the parameter of the second anonymous function, `t`, is given the inferred type `System.TimeSpan`, and the expression `t.TotalSeconds` is related to the return type of `f2`, inferring `Z` to be `double`. Thus, the result of the invocation is of type `double`.
+> type inference for the invocation proceeds as follows: First, the argument “1:15:30” is related to the value parameter, inferring `X` to be string. Then, the parameter of the first anonymous function, `s`, is given the inferred type `string`, and the expression `TimeSpan.Parse(s)` is related to the return type of `f1`, inferring `Y` to be `System.TimeSpan`. Finally, the parameter of the second anonymous function, `t`, is given the inferred type `System.TimeSpan`, and the expression `t.TotalHours` is related to the return type of `f2`, inferring `Z` to be `double`. Thus, the result of the invocation is of type `double`.
 >
 > *end example*
 
@@ -1068,25 +1068,25 @@ Given two types `T₁` and `T₂`, `T₁` is a ***better conversion target*** th
 >
 > public abstract class G1<U>
 > {
->     public abstract int F1(U u);               // Overload resolution for G<int>.F1
->     public abstract int F1(int i);             // will pick non-generic
+>     public abstract int F1(U u);           // Overload resolution for G<int>.F1
+>     public abstract int F1(int i);         // will pick non-generic
 >
->     public abstract void F2(I1<U> a);          // Valid overload
+>     public abstract void F2(I1<U> a);      // Valid overload
 >     public abstract void F2(I2<U> a);
 > }
 >
 > abstract class G2<U,V>
 > {
->     public abstract void F3(U u, V v);         // Valid, but overload resolution for
->     public abstract void F3(V v, U u);         // G2<int,int>.F3 will fail
+>     public abstract void F3(U u, V v);     // Valid, but overload resolution for
+>     public abstract void F3(V v, U u);     // G2<int,int>.F3 will fail
 >
->     public abstract void F4(U u, I1<V> v);     // Valid, but overload resolution for
->     public abstract void F4(I1<V> v, U u);     // G2<I1<int>,int>.F4 will fail
+>     public abstract void F4(U u, I1<V> v); // Valid, but overload resolution for
+>     public abstract void F4(I1<V> v, U u); // G2<I1<int>,int>.F4 will fail
 >
 >     public abstract void F5(U u1, I1<V> v2);   // Valid overload
 >     public abstract void F5(V v1, U u2);
 >
->     public abstract void F6(ref U u);          // Valid overload
+>     public abstract void F6(ref U u);      // Valid overload
 >     public abstract void F6(out V v);
 > }
 > ```

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -465,15 +465,18 @@ Grammar note: When recognising a *local_function_body* if both the *null_conditi
 > {
 >     if (start < 'a' || start > 'z')
 >     {
->         throw new ArgumentOutOfRangeException(paramName: nameof(start), message: "start must be a letter");
+>         throw new ArgumentOutOfRangeException(paramName: nameof(start),
+>             message: "start must be a letter");
 >     }
 >     if (end < 'a' || end > 'z')
 >     {
->         throw new ArgumentOutOfRangeException(paramName: nameof(end), message: "end must be a letter");
+>         throw new ArgumentOutOfRangeException(paramName: nameof(end),
+>             message: "end must be a letter");
 >     }
 >     if (end <= start)
 >     {
->         throw new ArgumentException($"{nameof(end)} must be greater than {nameof(start)}");
+>         throw new ArgumentException(
+>             $"{nameof(end)} must be greater than {nameof(start)}");
 >     }
 >     return AlphabetSubsetImplementation();
 >
@@ -512,12 +515,16 @@ Local function bodies are always reachable. The endpoint of a local function dec
 >     int M() 
 >     {
 >         L();
->         return 1; // Beginning of L is not reachable
+>         return 1;
+> 
+>         // Beginning of L is not reachable
 >         int L() 
->         { 
->             return 2; // The body of L is reachable
+>         {
+>             // The body of L is reachable
+>             return 2;
 >         }
->         return 3; // Not reachable, because beginning point of L is not reachable
+>         // Not reachable, because beginning point of L is not reachable
+>         return 3;
 >     }
 > }
 > ```

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -321,7 +321,8 @@ do «do_body» while ( «expr» ) ;
 For a statement of the form:
 
 ```csharp
-for ( «for_initializer» ; «for_condition» ; «for_iterator» ) «embedded_statement»
+for ( «for_initializer» ; «for_condition» ; «for_iterator» )
+    «embedded_statement»
 ```
 
 definite-assignment checking is done as if the statement were written:


### PR DESCRIPTION
The following line in lexical_structure.md (and then grammar.md) is 81 characters long. It looks okay in the Word doc and would be hard to fix without a line break that reduces readability:

```text
    | '.' Decimal_Digit Decorated_Decimal_Digit* Exponent_Part? Real_Type_Suffix?
```

I'm tempted to leave that and possibly hard-code warning suppression for that line.

(We *could* up the line limit from 80 to 81, but I'd prefer not to do that.)