### PR TITLE
Fix typo

### DIFF
--- a/standard/statements.md
+++ b/standard/statements.md
@@ -533,7 +533,7 @@ Local function bodies are always reachable. The endpoint of a local function dec
 >
 > In other words, the location of a local function declaration doesn’t affect the reachability of any statements in the containing function. *end example*
 
-If the argument to a local function is dynamic, the function to be called must be resolved at compile time, not runtime.
+If the argument to a local function is dynamic, the function to be called must be resolved at compile time, not run time.
 
 ## 13.7 Expression statements
 


### PR DESCRIPTION
By the way, what does this sentence mean? Is it somehow related to the `dynamic` type or "dynamic" is used with another meaning here?