### PR TITLE
Annotate New Examples from Recently Closed V7-Feature PRs

### DIFF
--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -323,10 +323,11 @@ If an element name in the tuple expression does not match a corresponding elemen
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-console-without-using", name:"ImplicitTupleConversions", ignoredWarnings:["CS0219","CS8123"], expectedErrors:["CS0037"]} -->
 > ```csharp
 > (int, string) t1 = (1, "One");
 > (byte, string) t2 = (2, null);
-> (int, string) t3 = (null, null); // Error: No conversion
+> (int, string) t3 = (null, null);        // Error: No conversion
 > (int i, string s) t4 = (i: 4, "Four");
 > (int i, string) t5 = (x: 5, s: "Five"); // Warning: Names are ignored
 > ```

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1546,11 +1546,12 @@ A tuple value can be obtained from a tuple expression by converting it to a tupl
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-console-without-using", name:"TupleExpressions1", expectedErrors:["CS0815"], ignoredWarnings:["CS0219"]} -->
 > ```csharp
 > (int i, string) t1 = (i: 1, "One");
 > (long l, string) t2 = (l: 2, null);
-> var t3 = (i: 3, "Three"); // (int i, string)
-> var t4 = (i: 4, null); // Error: no type
+> var t3 = (i: 3, "Three");          // (int i, string)
+> var t4 = (i: 4, null);             // Error: no type
 > ```
 >
 > In this example, all four tuple expressions are valid. The first two, `t1` and `t2`, do not use the type of the tuple expression, but instead apply an implicit tuple conversion. In the case of `t2`, the implicit tuple conversion relies on the implicit conversions from `2` to `long` and from `null` to `string`. The third tuple expression has a type `(int i, string)`, and can therefore be reclassified as a value of that type. The declaration of `t4`, on the other hand, is an error: The tuple expression has no type because its second element has no type.
@@ -4508,6 +4509,7 @@ A declaration expression with the identifier `_` is a discard ([§9.2.8.1](varia
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-console-without-using", name:"DeclarationExpressions1", replaceEllipsis:true, customEllipsisReplacements:["i = 10; b = true; return \"abc\";"], expectedErrors:["CS8196"], ignoredWarnings:["CS0219"]} -->
 > ```csharp
 > string M(out int i, string s, out bool b) { ... }
 >
@@ -4523,19 +4525,21 @@ A declaration expression with the identifier `_` is a discard ([§9.2.8.1](varia
 >
 > The declaration of `s3` shows the use of both implicitly and explicitly typed declaration expressions that are discards. Because discards do not declare a named variable, the multiple occurrences of the identifier `_` are allowed.
 >
+> <!-- Example: {template:"standalone-console-without-using", name:"DeclarationExpressions2"} -->
 > ```csharp
 > (int i1, int _, (var i2, var _), _) = (1, 2, (3, 4), 5);
 > ```
 >
 > This example shows the use of implicitly and explicitly typed declaration expressions for both variables and discards in a deconstructing assignment. The *simple_name* `_` is equivalent to `var _` when no declaration of `_` is found.
 >
+> <!-- Example: {template:"standalone-console-without-using", name:"DeclarationExpressions3", replaceEllipsis:true, customEllipsisReplacements:["i = 10;"], expectedErrors:["CS1503"], ignoredWarnings:["CS8321"]} -->
 > ```csharp
 > void M1(out int i) { ... }
 >
 > void M2(string _)
 > {
->     M1(out _); // Error: `_` is a string
->     M1(out var _); // 
+>     M1(out _);      // Error: `_` is a string
+>     M1(out var _);
 > }
 > ```
 >

--- a/standard/types.md
+++ b/standard/types.md
@@ -406,6 +406,7 @@ Tuple elements are public fields with the names `Item1`, `Item2`, etc., and can 
 <!-- markdownlint-enable MD028 -->
 > *Example*: Given the following examples:
 >
+> <!-- Example: {template:"standalone-console", name:"TupleTypes1", ignoredWarnings:["CS0219"], expectedErrors:["CS8125","CS8125"]} -->
 > ```csharp
 > (int, string) pair1 = (1, "One");
 > (int, string word) pair2 = (2, "Two");

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -870,6 +870,7 @@ A `char*` value produced by fixing a string instance always points to a null-ter
 <!-- markdownlint-enable MD028 -->
 > *Example*: The following code shows a *fixed_pointer_initializer* with an expression of type other than *array_type* or `string`:
 >
+> <!-- Example: {template:"standalone-console", name:"FixedStatement5"} -->
 > ```csharp
 > public class C
 > {
@@ -880,7 +881,7 @@ A `char*` value produced by fixing a string instance always points to a null-ter
 >
 > public class Test
 > {
->     unsafe private static void M()
+>     unsafe private static void Main()
 >     {
 >         C c = new C(10);
 >         fixed (int* p = c)

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -164,6 +164,7 @@ A discard is not initially assigned, so it is always an error to access its valu
 
 > *Example*:
 >
+> <!-- Example: {template:"standalone-console", name:"Discards1", replaceEllipsis:true, customEllipsisReplacements: ["i1 = 0; i2 = 0; i3 = 0; return (0,0,0);"]} -->
 > ```csharp
 > _ = "Hello".Length;
 > (int, int, int) M(out int i1, out int i2, out int i3) { ... }


### PR DESCRIPTION
I looked for all V7-feature PRs that were closed since I finished annotating all chapters back in January. I found 4: 240, 664, 239, and 244. However, only 240 and 664 added new examples, which I have annotated here.

As more V7-feature PRs get closed, I'll do likewise for them.