### PR TITLE
Fix of possible mistake in documentation-comments.md

### DIFF
--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -553,7 +553,7 @@ public class Point
 
 ### D.3.16 \<summary\>
 
-This tag can be used to describe a type or a member of a type. Use `<remarks>` ([§D.3.12](documentation-comments.md#d312-remarks)) to specify extra information about a type.
+This tag can be used to describe a type or a member of a type. Use `<remarks>` ([§D.3.12](documentation-comments.md#d312-remarks)) to specify extra information about the type or member.
 
 **Syntax:**
 

--- a/standard/documentation-comments.md
+++ b/standard/documentation-comments.md
@@ -553,7 +553,7 @@ public class Point
 
 ### D.3.16 \<summary\>
 
-This tag can be used to describe a type or a member of a type. Use `<remarks>` ([§D.3.12](documentation-comments.md#d312-remarks)) to describe the type itself.
+This tag can be used to describe a type or a member of a type. Use `<remarks>` ([§D.3.12](documentation-comments.md#d312-remarks)) to specify extra information about a type.
 
 **Syntax:**
 


### PR DESCRIPTION
In [D.3.16 \<summary\>](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments#d316-summary) is written:
"This tag can be used to describe a type or a member of a type. Use \<remarks\> (§D.3.12) to describe the type itself."

And in [D.3.12 \<remarks\>](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments#d312-remarks) is written:
"This tag is used to specify extra information about a type. Use \<summary\> (§D.3.16) to describe the type itself and the members of a type."

The description of the `<summary>` in both parts is OK. However in case of `<remarks>` the description in D.3.16 doesn't seem right when compared to the description in D.3.12.