### PR TITLE
Fix local variable usage terms in variables.md

### DIFF
--- a/standard/variables.md
+++ b/standard/variables.md
@@ -135,7 +135,7 @@ The lifetime of a local variable is the portion of program execution during whic
 
 A local variable introduced by a *local_variable_declaration* or *declaration_expression* is not automatically initialized and thus has no default value. Such a local variable is considered initially unassigned.
 
-> *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). Using a variable before its *local_variable_initializer* has been executed; e.g., within the initializer expression itself or by using a *goto_statement* which bypasses the initializer; is a complie-time error:
+> *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). Using a variable before its *local_variable_initializer* has been executed; e.g., within the initializer expression itself or by using a *goto_statement* which bypasses the initializer; is a compile-time error:
 >
 > <!-- Example: {template:"code-in-main-without-using", name:"LocalVariables", expectedErrors:["CS0165"], expectedWarnings:["CS0162"]} -->
 > ```csharp

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -135,7 +135,7 @@ The lifetime of a local variable is the portion of program execution during whic
 
 A local variable introduced by a *local_variable_declaration* or *declaration_expression* is not automatically initialized and thus has no default value. Such a local variable is considered initially unassigned.
 
-> *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). It is impossible to use a variable without executing its *local_variable_initializer*; e.g., within the initializer expression itself or by using a *goto_statement* to bypass the initialization:
+> *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). Using a variable before its *local_variable_initializer* has been executed; e.g., within the initializer expression itself or by using a *goto_statement* which bypasses the initializer; is a complie-time error:
 >
 > <!-- Example: {template:"code-in-main-without-using", name:"LocalVariables", expectedErrors:["CS0165"], expectedWarnings:["CS0162"]} -->
 > ```csharp

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -135,7 +135,7 @@ The lifetime of a local variable is the portion of program execution during whic
 
 A local variable introduced by a *local_variable_declaration* or *declaration_expression* is not automatically initialized and thus has no default value. Such a local variable is considered initially unassigned.
 
-> *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). It is possible to use a variable without executing its *local_variable_initializer*; e.g., within the initializer expression itself or by using a *goto_statement* to bypass the initialization:
+> *Note*: A *local_variable_declaration* that includes a *local_variable_initializer* is still initially unassigned. Execution of the declaration behaves exactly like an assignment to the variable ([§9.4.4.5](variables.md#9445-declaration-statements)). It is impossible to use a variable without executing its *local_variable_initializer*; e.g., within the initializer expression itself or by using a *goto_statement* to bypass the initialization:
 >
 > <!-- Example: {template:"code-in-main-without-using", name:"LocalVariables", expectedErrors:["CS0165"], expectedWarnings:["CS0162"]} -->
 > ```csharp


### PR DESCRIPTION
I think it was meant to be `impossible` there instead of `possible` because otherwise there's a conflict between the note and the following statement: `A variable shall be *definitely assigned* ([§9.4](variables.md#94-definite-assignment)) before its value can be obtained."`
Also, there's the following example which uses variable `a` in its own initializer, which should be possible according to the note.
```
int a = a + 2;
```
