### PR TITLE
State that the set of ValueTuple types provided is implementation-defined

### DIFF
--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -39,6 +39,7 @@ A conforming implementation is required to document its choice of behavior in ea
 1. The behavior of the `fixed` statement if the array expression is `null` or if the array has zero elements ([§23.7](unsafe-code.md#237-the-fixed-statement)).
 1. The behavior of the `fixed` statement if the string expression is `null` ([§23.7](unsafe-code.md#237-the-fixed-statement)).
 1. The value returned when a stack allocation of size zero is made ([§23.9](unsafe-code.md#239-stack-allocation)).
+1. The set of `System.ValueTuple<...>` types available for tuple types ([8.3.11](types.md#8311-tuple-types))
 
 ## B.4 Unspecified behavior
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -389,7 +389,7 @@ An enumeration type is a distinct type with named constants. Every enumeration t
 
 ### 8.3.11 Tuple types
 
-A tuple type represents an ordered, fixed-length sequence of values with optional names and individual types. The number of elements in a tuple type is referred to as its ***arity***. A tuple type is written `(T1 I1, ..., Tn In)` with n ≥ 2, where the identifiers `I1...In` are optional ***tuple element names***. This syntax is shorthand for a type constructed with the types `T1...Tn` from `System.ValueTuple<...>`, which shall be a set of generic struct types capable of expressing tuple types of any arity greater than one.
+A tuple type represents an ordered, fixed-length sequence of values with optional names and individual types. The number of elements in a tuple type is referred to as its ***arity***. A tuple type is written `(T1 I1, ..., Tn In)` with n ≥ 2, where the identifiers `I1...In` are optional ***tuple element names***. This syntax is shorthand for a type constructed with the types `T1...Tn` from `System.ValueTuple<...>`, which shall be a set of generic struct types capable of expressing tuple types of any arity greater than one. The precise set of `System.ValueTuple<...>` types provided is implementation-defined.
 
 > *Note*: There does not need to exist a `System.ValueTuple<...>` declaration that directly matches the arity of any tuple type with a corresponding number of type parameters. Instead, larger tuples can be represented with a special overload `System.ValueTuple<..., TRest>` that in addition to tuple elements has a `Rest` field containing a nested tuple value of the remaining elements. Such nesting may be observable in various ways, e.g. via the presence of a `Rest` field. *end note*
 


### PR DESCRIPTION
Part of #768.

@Nigel-Ecma I'm not sure this fully addresses your concern of "Do we need to say anything about how one implementation handles tuple values created by another with a different m?" from #664, but I couldn't think of a simple way of stating that. I'm hoping you'll agree that saying that the set of types available is implementation-defined implies that you shouldn't expect to be able to use code compiled for one implementation on another implementation, but other suggestions are welcome :)