### PR TITLE
Correct the used term

### DIFF
--- a/standard/variables.md
+++ b/standard/variables.md
@@ -1052,7 +1052,7 @@ All reference variables obey safety rules that ensure the ref-safe-context of th
 
 For any variable, the ***ref-safe-context*** of that variable is the context where a *variable_reference* ([§9.5](variables.md#95-variable-references)) to that variable is valid. The referent of a reference variable must have a ref-safe-context that is at least as wide as the ref-safe-context of the reference variable itself.
 
-> *Note*: The compiler determines the safe context through a static analysis of the program text. The safe context reflects the lifetime of a variable at runtime. *end note*
+> *Note*: The compiler determines the ref-safe-context through a static analysis of the program text. The ref-safe-context reflects the lifetime of a variable at runtime. *end note*
 
 There are three ref-safe-contexts:
 


### PR DESCRIPTION
The whole section is about and uses the term "ref-safe-context". Is that note exception (that is, "safe context" is something different) or this PR does the right thing?