### PR TITLE
Fix formatting

### DIFF
--- a/standard/variables.md
+++ b/standard/variables.md
@@ -1072,6 +1072,7 @@ There are three ref-safe-contexts:
   - Member fields and elements of such parameters;
   - Member fields of parameters of class type; and
   - Elements of parameters of array type.
+  
   A *variable_reference* with ref-safe-context of caller-context can be the referent of a reference return.
 
 These values form a nesting relationship from narrowest (declaration-block) to widest (caller-context). Each nested block represents a different context.


### PR DESCRIPTION
Currently, it renders as follows:
![image](https://github.com/dotnet/csharpstandard/assets/15279990/6a49b7d6-dbb8-4ddd-8b07-6718938ffb56)
