### PR TITLE
Add the missing word

### DIFF
--- a/standard/variables.md
+++ b/standard/variables.md
@@ -1115,7 +1115,7 @@ These values form a nesting relationship from narrowest (declaration-block) to w
 >         // context of r3 is declaration-block, ref safe context of v3 is declaration-block
 >         ref int r3 = ref v3;
 >
->         // context of r4 is block, ref safe context of arr[v3] is caller-context
+>         // context of r4 is declaration-block, ref safe context of arr[v3] is caller-context
 >         ref int r4 = ref arr[v3]; 
 >     }
 > }


### PR DESCRIPTION
Is that correct change, given other two examples:
![image](https://github.com/dotnet/csharpstandard/assets/15279990/df9f46d2-8358-40a8-8a7b-7e3a7f0a0529)
