### PR TITLE
`in dynamic` parameters with value arguments results in undefined behavior

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1004,7 +1004,7 @@ A function member is said to be an ***applicable function member*** with respect
   - for a value parameter or a parameter array, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter, or
   - for a `ref` or `out` parameter, there is an identity conversion between the type of the argument expression (if any) and the type of the corresponding parameter
   - for an `in` parameter when the corresponding argument has the `in` modifier, there is an identity conversion between the type of the argument expression (if any) and the type of the corresponding parameter
-  - for an `in` parameter when the corresponding argument omits the `in` modifier, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)), excluding dynamic implicit conversions ([§10.2.10](conversions.md#10210-implicit-dynamic-conversions)) exists from the argument expression to the type of the corresponding parameter.
+  - for an `in` parameter when the corresponding argument omits the `in` modifier, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)), excluding dynamic implicit conversions ([§10.2.10](conversions.md#10210-implicit-dynamic-conversions)) exists from the argument expression to the type of the corresponding parameter. When there exists a dynamic implicit conversion from the argument type to the parameter type, the results are undefined.
 
 For a function member that includes a parameter array, if the function member is applicable by the above rules, it is said to be applicable in its ***normal form***. If a function member that includes a parameter array is not applicable in its normal form, the function member might instead be applicable in its ***expanded form***:
 
@@ -1014,6 +1014,8 @@ For a function member that includes a parameter array, if the function member is
     - for a fixed value parameter or a value parameter created by the expansion, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter, or
     - for an `in`, `out`, or `ref` parameter, the type of the argument expression is identical to the type of the corresponding parameter.
   - the parameter-passing mode of the argument is value, and the parameter-passing mode of the corresponding parameter is input, and an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) excluding dynamic implicit conversions ([§10.2.10](conversions.md#10210-implicit-dynamic-conversions)) exists from the argument expression to the type of the corresponding parameter
+
+When there exists a dynamic implicit conversion from the argument type to the parameter type, the results are undefined.
 
 > *Example*: Given the following declarations and method calls:
 >

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1004,7 +1004,7 @@ A function member is said to be an ***applicable function member*** with respect
   - for a value parameter or a parameter array, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter, or
   - for a `ref` or `out` parameter, there is an identity conversion between the type of the argument expression (if any) and the type of the corresponding parameter
   - for an `in` parameter when the corresponding argument has the `in` modifier, there is an identity conversion between the type of the argument expression (if any) and the type of the corresponding parameter
-  - for an `in` parameter when the corresponding argument omits the `in` modifier, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)), excluding dynamic implicit conversions ([§10.2.10](conversions.md#10210-implicit-dynamic-conversions)) exists from the argument expression to the type of the corresponding parameter. When there exists a dynamic implicit conversion from the argument type to the parameter type, the results are undefined.
+  - for an `in` parameter when the corresponding argument omits the `in` modifier, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter.
 
 For a function member that includes a parameter array, if the function member is applicable by the above rules, it is said to be applicable in its ***normal form***. If a function member that includes a parameter array is not applicable in its normal form, the function member might instead be applicable in its ***expanded form***:
 
@@ -1013,9 +1013,9 @@ For a function member that includes a parameter array, if the function member is
   - the parameter-passing mode of the argument is identical to the parameter-passing mode of the corresponding parameter, and
     - for a fixed value parameter or a value parameter created by the expansion, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter, or
     - for an `in`, `out`, or `ref` parameter, the type of the argument expression is identical to the type of the corresponding parameter.
-  - the parameter-passing mode of the argument is value, and the parameter-passing mode of the corresponding parameter is input, and an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) excluding dynamic implicit conversions ([§10.2.10](conversions.md#10210-implicit-dynamic-conversions)) exists from the argument expression to the type of the corresponding parameter
+  - the parameter-passing mode of the argument is value, and the parameter-passing mode of the corresponding parameter is input, and an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter
 
-When there exists a dynamic implicit conversion from the argument type to the parameter type, the results are undefined.
+When the implicit conversion from the argument type to the parameter type of an `in` parameter is a dynamic implicit conversion ([§10.2.10](conversions.md#10210-implicit-dynamic-conversions)), the results are undefined.
 
 > *Example*: Given the following declarations and method calls:
 >

--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -17,7 +17,7 @@ The behavior is undefined in the following circumstances:
 1. When a pointer is subscripted to access an out-of-bounds element ([§23.6.4](unsafe-code.md#2364-pointer-element-access)).
 1. Modifying objects of managed type through fixed pointers ([§23.7](unsafe-code.md#237-the-fixed-statement)).
 1. The content of memory newly allocated by `stackalloc` ([§12.8.21](expressions.md#12821-stack-allocation)).
-1. Attempting to allocate a negative number of items using `stackalloc`([§12.8.21](expressions.md#12821-stack-allocation))
+1. Attempting to allocate a negative number of items using `stackalloc`([§12.8.21](expressions.md#12821-stack-allocation)).
 1. Implicit dynamic conversions (§10.2.10) of `in` parameters with value arguments (§12.6.4.2).
 
 ## B.3 Implementation-defined behavior

--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -17,7 +17,8 @@ The behavior is undefined in the following circumstances:
 1. When a pointer is subscripted to access an out-of-bounds element ([§23.6.4](unsafe-code.md#2364-pointer-element-access)).
 1. Modifying objects of managed type through fixed pointers ([§23.7](unsafe-code.md#237-the-fixed-statement)).
 1. The content of memory newly allocated by `stackalloc` ([§12.8.21](expressions.md#12821-stack-allocation)).
-1. Attempting to allocate a negative number of items using `stackalloc`([§12.8.21](expressions.md#12821-stack-allocation)).
+1. Attempting to allocate a negative number of items using `stackalloc`([§12.8.21](expressions.md#12821-stack-allocation))
+1. Implicit dynamic conversions (§10.2.10) of `in` parameters with value arguments (§12.6.4.2).
 
 ## B.3 Implementation-defined behavior
 


### PR DESCRIPTION
Fixes #802 

If an `in` parameter is matched with a value argument and the implicit conversion from the argument to the parameter type is a dynamic implicit conversion, the results are undefined.