### PR TITLE
Restrict usage of stack allocation expression

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3097,8 +3097,8 @@ A stack allocation initializer of the form `stackalloc T[E]` requires `T` to be 
 
 Apart from being used as the initializer of a local variable, a *stackalloc_expression* shall be used in the following contexts only:
 
- - The right operand of an *assignment_operator* that is not embedded in some larger expression.
- - The second and third operands in a *conditional_expression*.
+- The right operand of an *assignment_operator* that is not embedded in some larger expression.
+- The second and third operands in a *conditional_expression*.
 
 If `E` is a negative value, then the behavior is undefined. If `E` is zero, then no allocation is made, and the value returned is implementation-defined. If there is not enough memory available to allocate a block of the given size, a `System.StackOverflowException` is thrown.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3095,6 +3095,11 @@ When a *stackalloc_expression* includes both *expression* and *stackalloc_initia
 
 A stack allocation initializer of the form `stackalloc T[E]` requires `T` to be an *unmanaged_type* and `E` to be an expression implicitly convertible to type `int`. The operator allocates `E * sizeof(T)` bytes from the call stack. The result is a pointer, of type `T*`, to the newly allocated block. For use in safe contexts, a *stackalloc_expression* has an implicit conversion from `T*` to `Span<T>`. As pointer contexts require unsafe code, see [§12.8.21](expressions.md#12821-stack-allocation) for more information.
 
+Apart from being used as the initializer of a local variable, a *stackalloc_expression* shall be used in the following contexts only:
+
+ - The right operand of an *assignment_operator* that is not embedded in some larger expression.
+ - The second and third operands in a *conditional_expression*.
+
 If `E` is a negative value, then the behavior is undefined. If `E` is zero, then no allocation is made, and the value returned is implementation-defined. If there is not enough memory available to allocate a block of the given size, a `System.StackOverflowException` is thrown.
 
 When *stackalloc_initializer* is present, the *stackalloc_initializer_element_list* shall consist of a sequence of expressions, each having an implicit conversion to *unmanaged_type* ([§10.2](conversions.md#102-implicit-conversions)). The expressions initialize elements in the allocated memory in increasing order, starting with the element at index zero. In the absence of a *stackalloc_initializer*, the content of the newly allocated memory is undefined.


### PR DESCRIPTION
V7 restricts the contexts in which a *stackalloc_expression* may appear. However, these restrictions were inadvertently lost during the review of that feature's PR.

**As it happens, V8 removes those restrictions.**

In order for V7 to actually track the V7 implementation, this PR adds those restrictions. The committee can decide if it wishes to do this or to abandon this PR.
