### PR TITLE
Fix Note formatting

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -239,7 +239,7 @@ For the production *global_attribute_target*, and in the text below, *identifier
 
 An attribute consists of an *attribute_name* and an optional list of positional and named arguments. The positional arguments (if any) precede the named arguments. A positional argument consists of an *attribute_argument_expression*; a named argument consists of a name, followed by an equal sign, followed by an *attribute_argument_expression*, which, together, are constrained by the same rules as simple assignment. The order of named arguments is not significant.
 
-> *Note*: For convenience, a trailing comma is allowed in a *global_attribute_section* and an *attribute_section*, just as one is allowed in an *array_initializer* ([§17.7](arrays.md#177-array-initializers)).
+> *Note*: For convenience, a trailing comma is allowed in a *global_attribute_section* and an *attribute_section*, just as one is allowed in an *array_initializer* ([§17.7](arrays.md#177-array-initializers)). *end note*
 
 The *attribute_name* identifies an attribute class.
 

--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -447,7 +447,7 @@ In addition to these forms of access, a derived class can access a protected ins
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
-> *Note:* The accessibility domain ([§7.5.3](basic-concepts.md#753-accessibility-domains)) of a protected member declared in a generic class includes the program text of all class declarations derived from any type constructed from that generic class. In the example:
+> *Note*: The accessibility domain ([§7.5.3](basic-concepts.md#753-accessibility-domains)) of a protected member declared in a generic class includes the program text of all class declarations derived from any type constructed from that generic class. In the example:
 >
 > <!-- Example: {template:"standalone-lib-without-using", name:"ProtectedAccess3"} -->
 > ```csharp

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2244,7 +2244,9 @@ Output parameters are typically used in methods that produce multiple return val
 A parameter declared with a `params` modifier is a parameter array. If a formal parameter list includes a parameter array, it shall be the last parameter in the list and it shall be of a single-dimensional array type.
 
 > *Example*: The types `string[]` and `string[][]` can be used as the type of a parameter array, but the type `string[,]` can not. *end example*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Note*: It is not possible to combine the `params` modifier with the modifiers `in`, `out`, or `ref`. *end note*
 
 A parameter array permits arguments to be specified in one of two ways in a method invocation:

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1953,7 +1953,7 @@ Grammar notes:
 - *unsafe_modifier* ([§23.2](unsafe-code.md#232-unsafe-contexts)) is only available in unsafe code ([§23](unsafe-code.md#23-unsafe-code)).
 - when recognising a *method_body* if both the *null_conditional_invocation_expression* and *expression* alternatives are applicable then the former shall be chosen.
 
-> *Note*: The overlapping of, and priority between, alternatives here is solely for descriptive convenience; the grammar rules could be elaborated to remove the overlap. ANTLR, and other grammar systems, adopt the same convenience and so *method_body* has the specified semantics automatically.
+> *Note*: The overlapping of, and priority between, alternatives here is solely for descriptive convenience; the grammar rules could be elaborated to remove the overlap. ANTLR, and other grammar systems, adopt the same convenience and so *method_body* has the specified semantics automatically. *end note*
 
 A *method_declaration* may include a set of *attributes* ([§22](attributes.md#22-attributes)) and one of the permitted kinds of declared accessibility ([§15.3.6](classes.md#1536-access-modifiers)), the `new` ([§15.3.5](classes.md#1535-the-new-modifier)), `static` ([§15.6.3](classes.md#1563-static-and-instance-methods)), `virtual` ([§15.6.4](classes.md#1564-virtual-methods)), `override` ([§15.6.5](classes.md#1565-override-methods)), `sealed` ([§15.6.6](classes.md#1566-sealed-methods)), `abstract` ([§15.6.7](classes.md#1567-abstract-methods)), `extern` ([§15.6.8](classes.md#1568-external-methods)) and `async` ([§15.15](classes.md#1515-async-functions)) modifiers.
 
@@ -2085,7 +2085,7 @@ The following kinds of formal parameters exist:
 - Reference parameters, which are declared with the `ref` modifier.
 - Parameter arrays, which are declared with the `params` modifier.
 
-> *Note*: As described in [§7.6](basic-concepts.md#76-signatures-and-overloading), the `in`, `out`, and `ref` modifiers are part of a method’s signature, but the `params` modifier is not.
+> *Note*: As described in [§7.6](basic-concepts.md#76-signatures-and-overloading), the `in`, `out`, and `ref` modifiers are part of a method’s signature, but the `params` modifier is not. *end note*
 
 #### 15.6.2.2 Value parameters
 
@@ -2099,7 +2099,7 @@ A method is permitted to assign new values to a value parameter. Such assignment
 
 A parameter declared with an `in` modifier is an input parameter. An input parameter is a local reference variable ([§9.7](variables.md#97-reference-variables-and-returns)) that gets its initial referent from the corresponding argument supplied in the method invocation. That argument is either a variable existing at the point of the method invocation, or one created by the implementation ([§12.6.2.3](expressions.md#12623-run-time-evaluation-of-argument-lists)) in the method invocation.
 
-*Note*: As with reference variables the referent of an input parameter can be changed using the ref assignment (`= ref`) operator, however the value stored in the referent itself cannot be changed.
+> *Note*: As with reference variables the referent of an input parameter can be changed using the ref assignment (`= ref`) operator, however the value stored in the referent itself cannot be changed. *end note*
 
 When a formal parameter is an input parameter, the corresponding argument in a method invocation shall consist of either the keyword `in` followed by a *variable_reference* ([§9.2.8](variables.md#928-input-parameters)) of the same type as the formal parameter, or an *expression* for which an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from that argument expression to the type of the corresponding parameter. A variable shall be definitely assigned before it can be passed as an input parameter.
 
@@ -2115,7 +2115,7 @@ In a method that takes input parameters, it is possible for multiple names to re
 
 A parameter declared with a `ref` modifier is a reference parameter. A reference parameter is a local reference variable ([§9.7](variables.md#97-reference-variables-and-returns)) that gets its initial referent from the corresponding argument supplied in the method invocation.
 
-*Note*: As with reference variables the referent of a reference parameter can be changed using the ref assignment (`= ref`) operator.
+> *Note*: As with reference variables the referent of a reference parameter can be changed using the ref assignment (`= ref`) operator. *end note*
 
 When a formal parameter is a reference parameter, the corresponding argument in a method invocation shall consist of the keyword `ref` followed by a *variable_reference* ([§9.5](variables.md#95-variable-references)) of the same type as the formal parameter. A variable shall be definitely assigned before it can be passed as a reference parameter.
 
@@ -4070,7 +4070,7 @@ The modifiers `virtual`, `override`, and `abstract` are mutually exclusive excep
 
 The *type* of an indexer declaration specifies the element type of the indexer introduced by the declaration.
 
-> *Note:* As indexers are designed to be used in array element-like contexts, the term *element type* as defined for an array is also used with an indexer. *end note*
+> *Note*: As indexers are designed to be used in array element-like contexts, the term *element type* as defined for an array is also used with an indexer. *end note*
 
 The *formal_parameter_list* specifies the parameters of the indexer. The formal parameter list of an indexer corresponds to that of a method ([§15.6.2](classes.md#1562-method-parameters)), except that at least one parameter shall be specified, and that the `this`, `out`, and `ref` parameter modifiers are not permitted.
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2245,7 +2245,7 @@ A parameter declared with a `params` modifier is a parameter array. If a formal 
 
 > *Example*: The types `string[]` and `string[][]` can be used as the type of a parameter array, but the type `string[,]` can not. *end example*
 
-*Note*: It is not possible to combine the `params` modifier with the modifiers `in`, `out`, or `ref`. *end note*
+> *Note*: It is not possible to combine the `params` modifier with the modifiers `in`, `out`, or `ref`. *end note*
 
 A parameter array permits arguments to be specified in one of two ways in a method invocation:
 
@@ -3119,7 +3119,7 @@ An expression body consisting of `=>` followed by an *expression* `E` and a semi
 
 A *property_initializer* may only be given for an automatically implemented property ([§15.7.4](classes.md#1574-automatically-implemented-properties)), and causes the initialization of the underlying field of such properties with the value given by the *expression*.
 
-*Note*: Even though the syntax for accessing a property is the same as that for a field, a property is not classified as a variable. Thus, it is not possible to pass a property as an `in`, `out`, or `ref` argument unless the property itself returns a reference ([§9.7](variables.md#97-reference-variables-and-returns)). *end note*
+> *Note*: Even though the syntax for accessing a property is the same as that for a field, a property is not classified as a variable. Thus, it is not possible to pass a property as an `in`, `out`, or `ref` argument unless the property itself returns a reference ([§9.7](variables.md#97-reference-variables-and-returns)). *end note*
 
 When a property declaration includes an `extern` modifier, the property is said to be an ***external property***. Because an external property declaration provides no actual implementation, each of its *accessor_declarations* consists of a semicolon.
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -421,7 +421,7 @@ The explicit numeric conversions possibly lose information or possibly cause exc
   - If the source value is NaN, the result is NaN if the decimal representation supports NaNs; otherwise a System.OverflowException is thrown.
 - For a conversion from `decimal` to `float` or `double`, the `decimal` value is rounded to the nearest `double` or `float` value. If the source value’s magnitude is too large to represent in the target type, or that value is infinity, the result is infinity preserving the sign of the original value. If the source value is NaN, the result is NaN. While this conversion may lose precision, it never causes an exception to be thrown.
 
-> *Note:* The `decimal` type is not required to support infinities or NaN values but may do so; its range may be smaller than the range of `float` and `double`, but is not guaranteed to be. For `decimal` representations without infinities or NaN values, and with a range smaller than `float`, the result of a conversion from `decimal` to either `float` or `double` will never be infinity or NaN. *end note*
+> *Note*: The `decimal` type is not required to support infinities or NaN values but may do so; its range may be smaller than the range of `float` and `double`, but is not guaranteed to be. For `decimal` representations without infinities or NaN values, and with a range smaller than `float`, the result of a conversion from `decimal` to either `float` or `double` will never be infinity or NaN. *end note*
 
 ### 10.3.3 Explicit enumeration conversions
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -425,99 +425,102 @@ Once a particular function member has been identified at binding-time, possibly 
 > *Note*: The following table summarizes the processing that takes place in constructs involving the six categories of function members that can be explicitly invoked. In the table, `e`, `x`, `y`, and `value` indicate expressions classified as variables or values, `T` indicates an expression classified as a type, `F` is the simple name of a method, and `P` is the simple name of a property.
 
 <!-- Custom Word conversion: function_members -->
-<table>
-  <tr>
-    <th>Construct</th>
-    <th>Example</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td rowspan="3">Method invocation</td>
-    <td><code>F(x, y)</code></td>
-    <td>Overload resolution is applied to select the best method <code>F</code> in the containing class or struct. The method is invoked with the argument list <code>(x, y)</code>. If the method is not <code>static</code>, the instance expression is <code>this</code>.</td>
-  </tr>
-  <tr>
-    <td><code>T.F(x, y)</code></td>
-    <td>Overload resolution is applied to select the best method <code>F</code> in the class or struct <code>T</code>. A binding-time error occurs if the method is not <code>static</code>. The method is invoked with the argument list <code>(x, y)</code>.</td>
-  </tr>
-  <tr>
-    <td><code>e.F(x, y)</code></td>
-    <td>Overload resolution is applied to select the best method <code>F</code> in the class, struct, or interface given by the type of <code>e</code>. A binding-time error occurs if the method is <code>static</code>. The method is invoked with the instance expression <code>e</code> and the argument list <code>(x, y)</code>.</td>
-  </tr>
-  <tr>
-    <td rowspan="6">Property access</td>
-    <td><code>P</code></td>
-    <td>The get accessor of the property <code>P</code> in the containing class or struct is invoked. A compile-time error occurs if <code>P</code> is write-only. If <code>P</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
-  </tr>
-  <tr>
-    <td><code>P = value</code></td>
-    <td>The set accessor of the property <code>P</code> in the containing class or struct is invoked with the argument list <code>(value)</code>. A compile-time error occurs if <code>P</code> is read-only. If <code>P</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
-  </tr>  
-  <tr>
-    <td><code>T.P</code></td>
-    <td>The get accessor of the property <code>P</code> in the class or struct <code>T</code> is invoked. A compile-time error occurs if <code>P</code> is not <code>static</code> or if <code>P</code> is write-only.</td>
-  </tr>  
-  <tr>
-    <td><code>T.P = value</code></td>
-    <td>The set accessor of the property <code>P</code> in the class or struct <code>T</code> is invoked with the argument list <code>(value)</code>. A compile-time error occurs if <code>P</code> is not <code>static</code> or if <code>P</code> is read-only.</td>
-  </tr>
-  <tr>
-    <td><code>e.P</code></td>
-    <td>The get accessor of the property <code>P</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code>. A binding-time error occurs if <code>P</code> is <code>static</code> or if <code>P</code> is write-only.</td>
-  </tr>
-  <tr>
-    <td><code>e.P = value</code></td>
-    <td>The set accessor of the property <code>P</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code> and the argument list <code>(value)</code>. A binding-time error occurs if <code>P</code> is <code>static</code> or if <code>P</code> is read-only.</td>
-  </tr>  
-  <tr>
-    <td rowspan="6">Event access</td>
-    <td><code>E += value</code></td>
-    <td>The add accessor of the event <code>E</code> in the containing class or struct is invoked. If <code>E</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
-  </tr>
-  <tr>
-    <td><code>E -= value</code></td>
-    <td>The remove accessor of the event <code>E</code> in the containing class or struct is invoked. If <code>E</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
-  </tr>
-  <tr>
-    <td><code>T.E += value</code></td>
-    <td>The add accessor of the event <code>E</code> in the class or struct <code>T</code> is invoked. A binding-time error occurs if <code>E</code> is not <code>static</code>.</td>
-  </tr>
-  <tr>
-    <td><code>T.E -= value</code></td>
-    <td>The remove accessor of the event <code>E</code> in the class or struct <code>T</code> is invoked. A binding-time error occurs if <code>E</code> is not <code>static</code>.</td>
-  </tr>
-  <tr>
-    <td><code>e.E += value</code></td>
-    <td>The add accessor of the event <code>E</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code>. A binding-time error occurs if <code>E</code> is <code>static</code>.</td>
-  </tr>
-  <tr>
-    <td><code>e.E -= value</code></td>
-    <td>The remove accessor of the event <code>E</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code>. A binding-time error occurs if <code>E</code> is <code>static</code>.</td>
-  </tr>
-  <tr>
-    <td rowspan="2">Indexer access</td>
-    <td><code>e[x, y]</code></td>
-    <td>Overload resolution is applied to select the best indexer in the class, struct, or interface given by the type of <code>e</code>. The get accessor of the indexer is invoked with the instance expression <code>e</code> and the argument list <code>(x, y)</code>. A binding-time error occurs if the indexer is write-only.</td>
-  </tr>
-  <tr>
-    <td><code>e[x, y] = value</code></td>
-    <td>Overload resolution is applied to select the best indexer in the class, struct, or interface given by the type of <code>e</code>. The set accessor of the indexer is invoked with the instance expression <code>e</code> and the argument list <code>(x, y, value)</code>. A binding-time error occurs if the indexer is read-only.</td>
-  </tr>
-  <tr>
-    <td rowspan="2">Operator invocation</td>
-    <td><code>-x</code></td>
-    <td>Overload resolution is applied to select the best unary operator in the class or struct given by the type of <code>x</code>. The selected operator is invoked with the argument list <code>(x)</code>.</td>
-  </tr>
-  <tr>
-    <td><code>x + y</code></td>
-    <td>Overload resolution is applied to select the best binary operator in the classes or structs given by the types of <code>x</code> and <code>y</code>. The selected operator is invoked with the argument list <code>(x, y)</code>.</td>
-  </tr>
-  <tr>
-    <td>Instance constructor invocation</td>
-    <td><code>new T(x, y)</code></td>
-    <td>Overload resolution is applied to select the best instance constructor in the class or struct <code>T</code>. The instance constructor is invoked with the argument list <code>(x, y)</code>.</td>
-  </tr>
-</table>
+> <table>
+>   <tr>
+>     <th>Construct</th>
+>     <th>Example</th>
+>     <th>Description</th>
+>   </tr>
+>   <tr>
+>     <td rowspan="3">Method invocation</td>
+>     <td><code>F(x, y)</code></td>
+>     <td>Overload resolution is applied to select the best method <code>F</code> in the containing class or struct. The method is invoked with the argument list <code>(x, y)</code>. If the method is not <code>static</code>, the instance expression is <code>this</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>T.F(x, y)</code></td>
+>     <td>Overload resolution is applied to select the best method <code>F</code> in the class or struct <code>T</code>. A binding-time error occurs if the method is not <code>static</code>. The method is invoked with the argument list <code>(x, y)</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>e.F(x, y)</code></td>
+>     <td>Overload resolution is applied to select the best method <code>F</code> in the class, struct, or interface given by the type of <code>e</code>. A binding-time error occurs if the method is <code>static</code>. The method is invoked with the instance expression <code>e</code> and the argument list <code>(x, y)</code>.</td>
+>   </tr>
+>   <tr>
+>     <td rowspan="6">Property access</td>
+>     <td><code>P</code></td>
+>     <td>The get accessor of the property <code>P</code> in the containing class or struct is invoked. A compile-time error occurs if <code>P</code> is write-only. If <code>P</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>P = value</code></td>
+>     <td>The set accessor of the property <code>P</code> in the containing class or struct is invoked with the argument list <code>(value)</code>. A compile-time error occurs if <code>P</code> is read-only. If <code>P</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
+>   </tr>  
+>   <tr>
+>     <td><code>T.P</code></td>
+>     <td>The get accessor of the property <code>P</code> in the class or struct <code>T</code> is invoked. A compile-time error occurs if <code>P</code> is not <code>static</code> or if <code>P</code> is write-only.</td>
+>   </tr>  
+>   <tr>
+>     <td><code>T.P = value</code></td>
+>     <td>The set accessor of the property <code>P</code> in the class or struct <code>T</code> is invoked with the argument list <code>(value)</code>. A compile-time error occurs if <code>P</code> is not <code>static</code> or if <code>P</code> is read-only.</td>
+>   </tr>
+>   <tr>
+>     <td><code>e.P</code></td>
+>     <td>The get accessor of the property <code>P</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code>. A binding-time error occurs if <code>P</code> is <code>static</code> or if <code>P</code> is write-only.</td>
+>   </tr>
+>   <tr>
+>     <td><code>e.P = value</code></td>
+>     <td>The set accessor of the property <code>P</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code> and the argument list <code>(value)</code>. A binding-time error occurs if <code>P</code> is <code>static</code> or if <code>P</code> is read-only.</td>
+>   </tr>  
+>   <tr>
+>     <td rowspan="6">Event access</td>
+>     <td><code>E += value</code></td>
+>     <td>The add accessor of the event <code>E</code> in the containing class or struct is invoked. If <code>E</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>E -= value</code></td>
+>     <td>The remove accessor of the event <code>E</code> in the containing class or struct is invoked. If <code>E</code> is not <code>static</code>, the instance expression is <code>this</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>T.E += value</code></td>
+>     <td>The add accessor of the event <code>E</code> in the class or struct <code>T</code> is invoked. A binding-time error occurs if <code>E</code> is not <code>static</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>T.E -= value</code></td>
+>     <td>The remove accessor of the event <code>E</code> in the class or struct <code>T</code> is invoked. A binding-time error occurs if <code>E</code> is not <code>static</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>e.E += value</code></td>
+>     <td>The add accessor of the event <code>E</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code>. A binding-time error occurs if <code>E</code> is <code>static</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>e.E -= value</code></td>
+>     <td>The remove accessor of the event <code>E</code> in the class, struct, or interface given by the type of <code>E</code> is invoked with the instance expression <code>e</code>. A binding-time error occurs if <code>E</code> is <code>static</code>.</td>
+>   </tr>
+>   <tr>
+>     <td rowspan="2">Indexer access</td>
+>     <td><code>e[x, y]</code></td>
+>     <td>Overload resolution is applied to select the best indexer in the class, struct, or interface given by the type of <code>e</code>. The get accessor of the indexer is invoked with the instance expression <code>e</code> and the argument list <code>(x, y)</code>. A binding-time error occurs if the indexer is write-only.</td>
+>   </tr>
+>   <tr>
+>     <td><code>e[x, y] = value</code></td>
+>     <td>Overload resolution is applied to select the best indexer in the class, struct, or interface given by the type of <code>e</code>. The set accessor of the indexer is invoked with the instance expression <code>e</code> and the argument list <code>(x, y, value)</code>. A binding-time error occurs if the indexer is read-only.
+> </td>
+>   </tr>
+>   <tr>
+>     <td rowspan="2">Operator invocation</td>
+>     <td><code>-x</code></td>
+>     <td>Overload resolution is applied to select the best unary operator in the class or struct given by the type of <code>x</code>. The selected operator is invoked with the argument list <code>(x)</code>.</td>
+>   </tr>
+>   <tr>
+>     <td><code>x + y</code></td>
+>     <td>Overload resolution is applied to select the best binary operator in the classes or structs given by the types of <code>x</code> and <code>y</code>. The selected operator is invoked with the argument list <code>(x, y)</code>.</td>
+>   </tr>
+>   <tr>
+>     <td>Instance constructor invocation</td>
+>     <td><code>new T(x, y)</code></td>
+>     <td>Overload resolution is applied to select the best instance constructor in the class or struct <code>T</code>. The instance constructor is invoked with the argument list <code>(x, y)</code>.</td>
+>   </tr>
+> </table>
+
+> *end note*
 
 ### 12.6.2 Argument lists
 
@@ -1294,7 +1297,7 @@ primary_no_array_creation_expression
     ;
 ```
 
-> *Note*: These grammar rules are not ANTLR-ready as they are part of a set of mutually left-recursive rules (`primary_expression`, `primary_no_array_creation_expression`, `member_access`, `invocation_expression`, `element_access`, `post_increment_expression`, `post_decrement_expression`, `pointer_member_access` and `pointer_element_access`) which ANTLR does not handle. Standard techniques can be used to transform the grammar to remove the mutual left-recursion. This has not been done as not all parsing strategies require it (e.g. an LALR parser would not) and doing so would obfuscate the structure and description.
+> *Note*: These grammar rules are not ANTLR-ready as they are part of a set of mutually left-recursive rules (`primary_expression`, `primary_no_array_creation_expression`, `member_access`, `invocation_expression`, `element_access`, `post_increment_expression`, `post_decrement_expression`, `pointer_member_access` and `pointer_element_access`) which ANTLR does not handle. Standard techniques can be used to transform the grammar to remove the mutual left-recursion. This has not been done as not all parsing strategies require it (e.g. an LALR parser would not) and doing so would obfuscate the structure and description. *end note*
 
 *pointer_member_access* ([§23.6.3](unsafe-code.md#2363-pointer-member-access)) and *pointer_element_access* ([§23.6.4](unsafe-code.md#2364-pointer-element-access)) are only available in unsafe code ([§23](unsafe-code.md#23-unsafe-code)).
 
@@ -4644,7 +4647,7 @@ A declaration expression shall only occur in the following syntactic contexts:
 - As a simple discard `_` comprising the left side of a simple assignment ([§12.21.2](expressions.md#12212-simple-assignment)).
 - As a *tuple_element* in one or more recursively nested *tuple_expression*s, the outermost of which comprises the left side of a deconstructing assignment. A *deconstruction_expression* gives rise to declaration expressions in this position, even though the declaration expressions are not syntactically present.
 
-> *Note:* This means that a declaration expression cannot be parenthesized. *end note*
+> *Note*: This means that a declaration expression cannot be parenthesized. *end note*
 
 It is an error for an implicitly typed variable declared with a *declaration_expression* to be referenced within the *argument_list* where it is declared.
 
@@ -4728,7 +4731,7 @@ If `ref` is present:
 - An identity conversion must exist between the types of the two *variable_reference*s, and type of the result can be either type. If either type is `dynamic`, type inference prefers `dynamic` ([§8.7](types.md#87-the-dynamic-type)).
 - The result is a variable reference, which is writeable if both *variable_reference*s  are writeable.
 
-> *Note:* When `ref` is present, the *conditional_expression* returns a variable reference, which can be assigned to a reference variable using the `= ref` operator or passed as a reference/input/output parameter. *end note*
+> *Note*: When `ref` is present, the *conditional_expression* returns a variable reference, which can be assigned to a reference variable using the `= ref` operator or passed as a reference/input/output parameter. *end note*
 
 If `ref` is not present, the second and third operands, `x` and `y`, of the `?:` operator control the type of the conditional expression:
 
@@ -4764,7 +4767,7 @@ The run-time processing of a conditional expression of the form `b ? x : y` 
 
 An ***anonymous function*** is an expression that represents an “in-line” method definition. An anonymous function does not have a value or type in and of itself, but is convertible to a compatible delegate or expression-tree type. The evaluation of an anonymous-function conversion depends on the target type of the conversion: If it is a delegate type, the conversion evaluates to a delegate value referencing the method that the anonymous function defines. If it is an expression-tree type, the conversion evaluates to an expression tree that represents the structure of the method as an object structure.
 
-> *Note*: For historical reasons, there are two syntactic flavors of anonymous functions, namely *lambda_expression*s and *anonymous_method_expression*s. For almost all purposes, *lambda_expression*s are more concise and expressive than *anonymous_method_expression*s, which remain in the language for backwards compatibility.
+> *Note*: For historical reasons, there are two syntactic flavors of anonymous functions, namely *lambda_expression*s and *anonymous_method_expression*s. For almost all purposes, *lambda_expression*s are more concise and expressive than *anonymous_method_expression*s, which remain in the language for backwards compatibility. *end note*
 
 ```ANTLR
 lambda_expression
@@ -4824,9 +4827,11 @@ anonymous_function_body
 When recognising an *anonymous_function_body* if both the *null_conditional_invocation_expression* and *expression* alternatives are applicable then the former shall be chosen.
 
 <!-- markdownlint-disable MD028 -->
-> *Note*: The overlapping of, and priority between, alternatives here is solely for descriptive convenience; the grammar rules could be elaborated to remove the overlap. ANTLR, and other grammar systems, adopt the same convenience and so *anonymous_function_body* has the specified semantics automatically.
+> *Note*: The overlapping of, and priority between, alternatives here is solely for descriptive convenience; the grammar rules could be elaborated to remove the overlap. ANTLR, and other grammar systems, adopt the same convenience and so *anonymous_function_body* has the specified semantics automatically. *end note*
+<!-- markdownlint-disable MD028 -->
 
-> *Note*: When treated as an *expression*, a syntactic form such as `x?.M()` would be an error if the result type of `M` is `void` ([§12.8.12](expressions.md#12812-null-conditional-element-access)). But when treated as a *null_conditional_invocation_expression*, the result type is permitted to be `void`.
+<!-- markdownlint-enable MD028 -->
+> *Note*: When treated as an *expression*, a syntactic form such as `x?.M()` would be an error if the result type of `M` is `void` ([§12.8.12](expressions.md#12812-null-conditional-element-access)). But when treated as a *null_conditional_invocation_expression*, the result type is permitted to be `void`. *end note*
 
 > *Example*: The result type of `List<T>.Reverse` is `void`.  In the following code, the body of the anonymous expression is a *null_conditional_invocation_expression*, so it is not an error.
 >

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -423,8 +423,8 @@ Invocations of methods, indexers, operators, and instance constructors employ ov
 Once a particular function member has been identified at binding-time, possibly through overload resolution, the actual run-time process of invoking the function member is described in [§12.6.6](expressions.md#1266-function-member-invocation).
 
 > *Note*: The following table summarizes the processing that takes place in constructs involving the six categories of function members that can be explicitly invoked. In the table, `e`, `x`, `y`, and `value` indicate expressions classified as variables or values, `T` indicates an expression classified as a type, `F` is the simple name of a method, and `P` is the simple name of a property.
-
-<!-- Custom Word conversion: function_members -->
+>
+> <!-- Custom Word conversion: function_members -->
 > <table>
 >   <tr>
 >     <th>Construct</th>

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -519,7 +519,7 @@ Once a particular function member has been identified at binding-time, possibly 
 >     <td>Overload resolution is applied to select the best instance constructor in the class or struct <code>T</code>. The instance constructor is invoked with the argument list <code>(x, y)</code>.</td>
 >   </tr>
 > </table>
-
+>
 > *end note*
 
 ### 12.6.2 Argument lists
@@ -4832,7 +4832,9 @@ When recognising an *anonymous_function_body* if both the *null_conditional_invo
 
 <!-- markdownlint-enable MD028 -->
 > *Note*: When treated as an *expression*, a syntactic form such as `x?.M()` would be an error if the result type of `M` is `void` ([§12.8.12](expressions.md#12812-null-conditional-element-access)). But when treated as a *null_conditional_invocation_expression*, the result type is permitted to be `void`. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*: The result type of `List<T>.Reverse` is `void`.  In the following code, the body of the anonymous expression is a *null_conditional_invocation_expression*, so it is not an error.
 >
 > <!-- Example: {template:"standalone-console", name:"AnonFunctExpressions"} -->

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -583,11 +583,11 @@ alphabetic character called the *format specifier*, and *xx* is an integer betwe
 of formatting applied to the value being represented as a string. The
 *precision specifier* controls the number of significant digits or decimal places in the string, if applicable.
 
-> *Note:* For the list of standard format specifiers, see the table below. Note that a given data type, such as `System.Int32`, might not support one or more of the standard format specifiers. *end note*
+> *Note*: For the list of standard format specifiers, see the table below. Note that a given data type, such as `System.Int32`, might not support one or more of the standard format specifiers. *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
-> *Note:* When a format includes symbols that vary by culture, such as the currencysymbol included by the ‘C’ and ‘c’ formats, a formatting object supplies the actual characters used in the string representation. A method might include a parameter to pass a `System.IFormatProvider` object that supplies a formatting object, or the method might use the default formatting object, which contains the symbol definitions for the current culture. The current culture typically uses the same set of symbols used system-wide by default. In the Base Class Library, the formatting object for system-supplied numeric types is a `System.Globalization.NumberFormatInfo` instance. For `System.DateTime` instances, a `System.Globalization.DateTimeFormatInfo` is used. *end note*
+> *Note*: When a format includes symbols that vary by culture, such as the currencysymbol included by the ‘C’ and ‘c’ formats, a formatting object supplies the actual characters used in the string representation. A method might include a parameter to pass a `System.IFormatProvider` object that supplies a formatting object, or the method might use the default formatting object, which contains the symbol definitions for the current culture. The current culture typically uses the same set of symbols used system-wide by default. In the Base Class Library, the formatting object for system-supplied numeric types is a `System.Globalization.NumberFormatInfo` instance. For `System.DateTime` instances, a `System.Globalization.DateTimeFormatInfo` is used. *end note*
 
 The following table describes the standard format specifiers and associated formatting
 object members that are used with numeric data types in the Base Class

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -923,7 +923,7 @@ Definite assignment for the body of each local function is defined separately fo
 
 Delegate conversions have a control flow path to the local function body. Captured variables are definitely assigned for the body if they are definitely assigned before the conversion. Variables assigned by the local function are not considered assigned after the conversion.
 
-> *Note:* the above implies that bodies are re-analyzed for definite assignment at every local function invocation or delegate conversion. Compilers are not required to re-analyze the body of a local function at each invocation or delegate conversion. The implementation must produce results equivalent to that description.
+> *Note*: the above implies that bodies are re-analyzed for definite assignment at every local function invocation or delegate conversion. Compilers are not required to re-analyze the body of a local function at each invocation or delegate conversion. The implementation must produce results equivalent to that description. *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
@@ -1214,7 +1214,7 @@ A property invocation and an indexer invocation (either `get` or `set`) is treat
 
 A value’s ref-safe-context is the nearest enclosing context.
 
-> *Note:* This occurs in an invocation such as `M(ref d.Length)` where `d` is of type `dynamic`. It is also consistent with arguments corresponding to `in` parameters.
+> *Note*: This occurs in an invocation such as `M(ref d.Length)` where `d` is of type `dynamic`. It is also consistent with arguments corresponding to `in` parameters. *end note*
 
 #### 9.7.2.7 Constructor invocations
 


### PR DESCRIPTION
@KalleOlaviNiemitalo, this addresses your Issue #853.

@jskeet. I think I broke the Word converter! At the end of 12.6.1, we have a very long "*Note*:" without an "*end note*", so I added one. However, the content of that Note is a multi-line table marked-up in HTML, which the Word converter needs to "recognize." The thing is that being inside a multi-line Note, I had to add a leading `>` to each table line, and my guess is the Word converter can't handle that.