### PR TITLE
Make preamble text a new General section

### DIFF
--- a/standard/variables.md
+++ b/standard/variables.md
@@ -1048,6 +1048,8 @@ A ***reference return*** is the *variable_reference* returned from a returns-by-
 
 ### 9.7.2 Ref safe contexts
 
+#### §ref-safe-contexts-general General
+
 All reference variables obey safety rules that ensure the ref-safe-context of the reference variable is not greater than the ref-safe-context of its referent.
 
 For any variable, the ***ref-safe-context*** of that variable is the context where a *variable_reference* ([§9.5](variables.md#95-variable-references)) to that variable is valid. The referent of a reference variable must have a ref-safe-context that is at least as wide as the ref-safe-context of the reference variable itself.


### PR DESCRIPTION
@KalleOlaviNiemitalo, 

Fixes Issue #860.

I resolved this by putting all the 9.7.2 preamble text into a new section 9.7.2.1 General. Although there were a number of existing xref links to 9.7.2, I left them alone, as they really do mean 9.7.2.*, as a group, not just the new 9.7.2.1 section.