### PR TITLE
Correction to the local function grammar

### DIFF
--- a/standard/statements.md
+++ b/standard/statements.md
@@ -451,7 +451,7 @@ local_function_declaration
 
 local_function_header
     : local_function_modifier* ('ref' 'readonly'?)? return_type identifier type_parameter_list?
-        ( formal_parameter_list? ) type_parameter_constraints_clause*
+        '(' formal_parameter_list? ')' type_parameter_constraints_clause*
     ;
 local_function_modifier
     : 'async'


### PR DESCRIPTION
I took this grammar from the MS proposal, which unfortunately contains an error that I only just spotted today. The parens are *required* tokens, but currently are interpreted as (redundant) ANTLR grouping parens. This correction makes the local function header match that for a method.