### PR TITLE
V7.3 stack allocation hack

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3091,16 +3091,25 @@ stackalloc_element_initializer
     : expression
     ;
 ```
+A *stackalloc_expression* is only permitted in two contexts:
 
-The *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)) indicates the type of the items that will be stored in the newly allocated location, and the *expression* indicates the number of these items. Taken together, these specify the required allocation size. As the size of a stack allocation cannot be negative, it is a compile-time error to specify the number of items as a *constant_expression* that evaluates to a negative value.
+1. The *expression* of a *local_variable_initializer* of a *local_variable_declaration* ([§13.6.2](statements.md#1362-local-variable-declarations)); and
+2. The right operand *expression* of a simple assignment ([$12.21.2](expressions.md#12212-simple-assignment)) which itself occurs as a *expression_statement* ([§13.7](statements.md#137-expression-statements))
+
+In both contexts the *stackalloc_expression* is only permitted to be:
+
+1. The whole of the *expression*; or
+2. As the second and/or third operands of a *conditional_expression* ([§12.18](expressions.md#1218-conditional-operator)) which is itself the whole of the *expression*.
+
+The *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)) indicates the type of the items that will be stored in the newly allocated location, and the *expression* indicates the number of these items. Taken together, these specify the required allocation size. The type of *expression* must be implicitly convertible to the type `int`. As the size of a stack allocation cannot be negative, it is a compile-time error to specify the number of items as a *constant_expression* that evaluates to a negative value.
 
 If *unmanaged_type* is omitted, it is inferred from the corresponding *stackalloc_initializer*. If *expression* is omitted from *stackalloc_expression*, it is inferred to be the number of *stackalloc_element_initializer*s in the corresponding *stackalloc_initializer* following the rules for best common type ([§12.6.3.15](expressions.md#126315-finding-the-best-common-type-of-a-set-of-expressions)) of the *stackalloc_initializer_element_list*.
 
 When a *stackalloc_expression* includes both *expression* and *stackalloc_initializer*, the *expression* shall be a *constant_expression* and the number of elements in that *stackalloc_initializer* shall match the value of *expression*.
 
-A stack allocation initializer of the form `stackalloc T[E]` requires `T` to be an *unmanaged_type* and `E` to be an expression implicitly convertible to type `int`. The operator allocates `E * sizeof(T)` bytes from the call stack. The result is a pointer, of type `T*`, to the newly allocated block. For use in safe contexts, a *stackalloc_expression* has an implicit conversion from `T*` to `Span<T>`. As pointer contexts require unsafe code, see [§12.8.21](expressions.md#12821-stack-allocation) for more information.
+A *stackalloc_expression* allocates `E * sizeof(T)` bytes from the execution stack; where `T` is the given or inferred *unmanaged_type*, and `E` is the given or inferred *expression*. The result is a pointer, of type `T*`, to the newly allocated block. For use in safe contexts, a *stackalloc_expression* has an implicit conversion from `T*` to `Span<T>`. As pointer contexts require unsafe code, see [§12.8.21](expressions.md#12821-stack-allocation) for more information.
 
-If `E` is a negative value, then the behavior is undefined. If `E` is zero, then no allocation is made, and the value returned is implementation-defined. If there is not enough memory available to allocate a block of the given size, a `System.StackOverflowException` is thrown.
+At runtime if `E` is a negative value, then the behavior is undefined. If `E` is zero, then no allocation is made, and the value returned is implementation-defined. If there is not enough memory available to allocate a block of the given size, a `System.StackOverflowException` is thrown.
 
 When *stackalloc_initializer* is present, the *stackalloc_initializer_element_list* shall consist of a sequence of expressions, each having an implicit conversion to *unmanaged_type* ([§10.2](conversions.md#102-implicit-conversions)). The expressions initialize elements in the allocated memory in increasing order, starting with the element at index zero. In the absence of a *stackalloc_initializer*, the content of the newly allocated memory is undefined.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3113,7 +3113,7 @@ At runtime if the number of items to be allocated is a negative value then the b
 When a *stackalloc_initializer* is present:
 
 - If *unmanaged_type* is omitted, it is inferred following the rules for best common type ([§12.6.3.15](expressions.md#126315-finding-the-best-common-type-of-a-set-of-expressions)) for the set of *stackalloc_element_initializer*s.
-- If *constant_expression* is omitted it is inferred to be the number of *stackalloc_element_initializer*s. 
+- If *constant_expression* is omitted it is inferred to be the number of *stackalloc_element_initializer*s.
 - If *constant_expression* is present it must equal the number of *stackalloc_element_initializer*s.
 
 Each *stackalloc_element_initializer* shall have an implicit conversion to *unmanaged_type* ([§10.2](conversions.md#102-implicit-conversions)). The *stackalloc_element_initializer*s initialize elements in the allocated memory in increasing order, starting with the element at index zero. In the absence of a *stackalloc_initializer*, the content of the newly allocated memory is undefined.


### PR DESCRIPTION
This is a replacement for PR #840 (as this bear of little brain was thwarted by Github in making the changes as comments/review on the PR, I expect there is a way to do it…)

The purpose, as identified by @RexJaeschke, is impose the C# 7.3 restrictions on `stackalloc` as the existing text applied to C# 8. However when I came to read the clause I found there was duplication of material, I'm guessing from moving stuff from the unsafe section, so I (foolishly?) took on cleaning it up, but just as much as necessary to be correct.

I have inserted markdown (HTML) comments around the bit which covers the C# 7.3, if we’re luck just deleting that in C# 8 should do – but someone should check when the time comes!

The discussion on #840 covered more concerns, such as C# 7.3 doesn't allow (pointless) casts. None of these are addressed as I don’t believe they are intended for C# 7.3, and C# 8 will allow them automatically without adding verbiage – but opinions may vary of that!