### PR TITLE
Define SpanT

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3122,7 +3122,7 @@ The result of a *stackalloc_expression* is an instance of type `Span<T>`, where 
 
 - `Span<T>` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)) is a ref struct type ([§16.2.3](structs.md#1623-ref-modifier)), which presents a block of memory, here the block allocated by the *stackalloc_expression*, as an indexable collection of typed (`T`) items.
 - The result’s `Length` property returns the number of items allocated.
-- The result’s indexer ([§15.9](classes.md#159_indexers)) returns a *variable_reference* ([§9.5](variables.md#95-variable-references)) to an item of the allocated block and is range checked.
+- The result’s indexer ([§15.9](classes.md#159-indexers)) returns a *variable_reference* ([§9.5](variables.md#95-variable-references)) to an item of the allocated block and is range checked.
 
 > *Note*: When occurring in unsafe code the result of a *stackalloc_expression* may be of a different type, see ([§23.9](unsafe-code.md#239-stack-allocation)). *end note*
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3118,11 +3118,13 @@ When a *stackalloc_initializer* is present:
 
 Each *stackalloc_element_initializer* shall have an implicit conversion to *unmanaged_type* ([§10.2](conversions.md#102-implicit-conversions)). The *stackalloc_element_initializer*s initialize elements in the allocated memory in increasing order, starting with the element at index zero. In the absence of a *stackalloc_initializer*, the content of the newly allocated memory is undefined.
 
-The result of a *stackalloc_expression* is an instance of type `Span<T>`, where `T` is the *unmanaged_type* and the instance’s `Length` property returns the number of items allocated.
+The result of a *stackalloc_expression* is an instance of type `Span<T>`, where `T` is the *unmanaged_type*:
+
+- `Span<T>` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)) is a ref struct type ([§16.2.3](structs.md#1623-ref-modifier)), which presents a block of memory, here the block allocated by the *stackalloc_expression*, as an indexable collection of typed (`T`) items.
+- The result’s `Length` property returns the number of items allocated.
+- The result’s indexer ([§15.9](classes.md#159_indexers)) returns a *variable_reference* ([§9.5](variables.md#95-variable-references)) to an item of the allocated block and is range checked.
 
 > *Note*: When occurring in unsafe code the result of a *stackalloc_expression* may be of a different type, see ([§23.9](unsafe-code.md#239-stack-allocation)). *end note*
-
-Access via an instance of `Span<T>` to the elements of an allocated block is range checked.
 
 Stack allocation initializers are not permitted in `catch` or `finally` blocks ([§13.11](statements.md#1311-the-try-statement)).
 

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -558,12 +558,13 @@ namespace System
 {
     public ref struct ReadOnlySpan<T>
     {
+        public int Length { get; }
+        public ref readonly T this[int index] { get; }
     }
-}
-namespace System
-{
     public ref struct Span<T>
     {
+        public int Length { get; }
+        public ref T this[int index] { get; }
         public static implicit operator ReadOnlySpan<T>(Span<T> span);
     }
 }


### PR DESCRIPTION
Working on stackalloc turned up that Span<T> was used but what it is wasn't defined, and in the library (§C.3) the used members (indexer and the just used Length) not mentioned.

So here is a draft PR which squeezes what Span<T> is into stackalloc’s description, as it is the only place (currently) using it, and adds just the used members to Span<T>, and also ReadOnlySpan<T> as that was in §C.3 presumably as it is used in the example.

Is this sufficient? Should more members be included? Is defining it in stackalloc’s description OK? Etc.

Depending on feedback I'll remove draft status, edit, or kill.