### PR TITLE
Fix samples

### DIFF
--- a/standard/statements.md
+++ b/standard/statements.md
@@ -386,7 +386,7 @@ In an implicitly typed local variable declaration, the type of the local variabl
 
 > *Example*:
 >
-> <!-- Example: {template:"code-in-main", name:"LocalVariableDecls4", expectedWarnings:["CS0219","CS0219","CS0219"], additionalFiles:["Order.cs"]} -->
+> <!-- Example: {template:"code-in-main", name:"LocalVariableDecls4", expectedWarnings:["CS0219","CS0219"], additionalFiles:["Order.cs"]} -->
 > ```csharp
 > var i = 5;
 > var s = "Hello";
@@ -399,7 +399,7 @@ In an implicitly typed local variable declaration, the type of the local variabl
 >
 > The implicitly typed local variable declarations above are precisely equivalent to the following explicitly typed declarations:
 >
-> <!-- Example: {template:"code-in-main", name:"LocalVariableDecls5", expectedWarnings:["CS0219","CS0219","CS0219"], additionalFiles:["Order.cs"]} -->
+> <!-- Example: {template:"code-in-main", name:"LocalVariableDecls5", expectedWarnings:["CS0219","CS0219"], additionalFiles:["Order.cs"]} -->
 > ```csharp
 > int i = 5;
 > string s = "Hello";
@@ -407,7 +407,7 @@ In an implicitly typed local variable declaration, the type of the local variabl
 > int[] numbers = new int[] {1, 2, 3};
 > Dictionary<int,Order> orders = new Dictionary<int,Order>();
 > ref int j = ref i;
-> ref int var k = ref i;
+> ref readonly int k = ref i;
 > ```
 >
 > *end example*


### PR DESCRIPTION
The addition of `ref` variables reduced the number of warnings of CS0219 - "The variable 'variable' is assigned but its value is never used"; the second sample was simply broken in terms of the ref readonly change.