### PR TITLE
Fix path matching for example test action

### DIFF
--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - '/standard/*.md'
+      - "standard/*.md"
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
This now matches what we've got for markdownlint.yaml, which *is* being triggered.