### PR TITLE
Clarify the representation of Boolean value true

### DIFF
--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -44,6 +44,7 @@ A conforming implementation is required to document its choice of behavior in ea
 ## B.4 Unspecified behavior
 
 1. The time at which the finalizer (if any) for an object is run, once that object has become eligible for finalization ([§7.9](basic-concepts.md#79-automatic-memory-management)).
+1. The representation of `true` ([§8.3.9](types.md#839-the-bool-type)).
 1. The value of the result when converting out-of-range values from `float` or `double` values to an integral type in an `unchecked` context ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)).
 1. The exact target object and target method of the delegate produced from an *anonymous_method_expression* contains ([§10.7.2](conversions.md#1072-evaluation-of-anonymous-function-conversions-to-delegate-types)).
 1. The layout of arrays, except in an unsafe context ([§12.8.16.5](expressions.md#128165-array-creation-expressions)).

--- a/standard/types.md
+++ b/standard/types.md
@@ -377,7 +377,7 @@ The `decimal` type has greater precision but may have a smaller range than the f
 
 ### 8.3.9 The Bool type
 
-The `bool` type represents Boolean logical quantities. The possible values of type `bool` are `true` and `false`.
+The `bool` type represents Boolean logical quantities. The possible values of type `bool` are `true` and `false`. The representation of `false` is described in [§8.3.3](types.md#833-default-constructors). Although the representation of `true` is unspecified, it shall be different from that of `false`.
 
 No standard conversions exist between `bool` and other value types. In particular, the `bool` type is distinct and separate from the integral types, a `bool` value cannot be used in place of an integral value, and vice versa.
 


### PR DESCRIPTION
In [§8.3.3](types.md#833-default-constructors) of the current spec (draft-v7), we say that `false` is all-bits zero. And as we say nothing about the representation of `true` that is **implicitly unspecified**. That is problematic, as we should at least say that the two values need to be distinct. In fact, the CLI spec states the following:

> The System.Boolean value type represents the logical values true and false. The size of this type is 8 bits, the representation of false is all-bits-zero, and the representation of true is unspecified except that it shall have at least one bit set.

I'm thinking that VB might use -1/255 for true. In any event, the CLI doesn't exclude a CLS-compliant language having true be 2, 3, 4, 5, ....

This PR makes the representation **explicitly** unspecified, and requires the two values to differ.

@BillWagner https://learn.microsoft.com/en-us/dotnet/api/system.boolean?view=net-7.0#Binary states

> The byte's low-order bit is used to represent its value. A value of 1 represents true; a value of 0 represents false.

This doesn't sound right for *all* possible conforming implementations. If in a C# method that is passing a bool to/from some other language, more than 1 bit could be used for the representation of true, allowing the low bit to be zero for both true and false, for example if true were any even number.