### PR TITLE
Fix misdescribed example of input argument

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -615,7 +615,7 @@ During the run-time processing of a function member invocation ([§12.6.6](expre
      > M1(i + 5);     // transformed to a temporary input argument
      > ```
      >
-     > In each method call, an unnamed `int` variable is created, initialized with the argument’s value, and then passed as an input argument. See [§12.6.4.2](expressions.md#12642-applicable-function-member) and [§12.6.4.4](expressions.md#12644-better-parameter-passing-mode).
+     > In the `M1(i)` method call, `i` itself is passed as an input argument, because it is classified as a variable and has the same type `int` as the input parameter. In the `M1(i + 5)` method call, an unnamed `int` variable is created, initialized with the argument’s value, and then passed as an input argument. See [§12.6.4.2](expressions.md#12642-applicable-function-member) and [§12.6.4.4](expressions.md#12644-better-parameter-passing-mode).
      >
      > *end example*
 


### PR DESCRIPTION
Fixes #911 (as described there)

cc @KalleOlaviNiemitalo

@BillWagner: This looks pretty simple and correct to me. The wording was taken from the issue.