### PR TITLE
Specify temporary for `this` as an input parameter

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1211,7 +1211,11 @@ The run-time processing of a function member invocation consists of the followin
   - `M` is invoked.
 - Otherwise, if the type of `E` is a value-type `V`, and `M` is declared or overridden in `V`:
   - `E` is evaluated. If this evaluation causes an exception, then no further steps are executed. For an instance constructor, this evaluation consists of allocating storage (typically from an execution stack) for the new object. In this case `E` is classified as a variable.
-  - If `E` is not classified as a variable, or if `E` is an input parameter (§15.6.2.3) and `V` is not a readonly struct type (§16.2.2), then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` is a true variable is it possible for the caller to observe the changes that `M` makes to `this`.
+  - If `E` is not classified as a variable, or if `V` is not a readonly struct type (§16.2.2), and `E` is one of:
+    - an input parameter (§15.6.2.3), or
+    - a `readonly` field (§15.5.3), or
+    - a `readonly` reference variable or return (§9.7),
+    then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` is a true variable is it possible for the caller to observe the changes that `M` makes to `this`.
   - The argument list is evaluated as described in [§12.6.2](expressions.md#1262-argument-lists).
   - `M` is invoked. The variable referenced by `E` becomes the variable referenced by `this`.
 - Otherwise:

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1216,7 +1216,7 @@ The run-time processing of a function member invocation consists of the followin
     - a `readonly` field (§15.5.3), or
     - a `readonly` reference variable or return (§9.7),
 
-  then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` is a true variable is it possible for the caller to observe the changes that `M` makes to `this`.
+  then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` can be written is it possible for the caller to observe the changes that `M` makes to `this`.
   - The argument list is evaluated as described in [§12.6.2](expressions.md#1262-argument-lists).
   - `M` is invoked. The variable referenced by `E` becomes the variable referenced by `this`.
 - Otherwise:

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1211,7 +1211,7 @@ The run-time processing of a function member invocation consists of the followin
   - `M` is invoked.
 - Otherwise, if the type of `E` is a value-type `V`, and `M` is declared or overridden in `V`:
   - `E` is evaluated. If this evaluation causes an exception, then no further steps are executed. For an instance constructor, this evaluation consists of allocating storage (typically from an execution stack) for the new object. In this case `E` is classified as a variable.
-  - If `E` is not classified as a variable, then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` is a true variable is it possible for the caller to observe the changes that `M` makes to `this`.
+  - If `E` is not classified as a variable, or if `E` is an input parameter (§15.6.2.3) and `V` is not a readonly struct type (§16.2.2), then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` is a true variable is it possible for the caller to observe the changes that `M` makes to `this`.
   - The argument list is evaluated as described in [§12.6.2](expressions.md#1262-argument-lists).
   - `M` is invoked. The variable referenced by `E` becomes the variable referenced by `this`.
 - Otherwise:

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1215,7 +1215,8 @@ The run-time processing of a function member invocation consists of the followin
     - an input parameter (§15.6.2.3), or
     - a `readonly` field (§15.5.3), or
     - a `readonly` reference variable or return (§9.7),
-    then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` is a true variable is it possible for the caller to observe the changes that `M` makes to `this`.
+
+  then a temporary local variable of `E`’s type is created and the value of `E` is assigned to that variable. `E` is then reclassified as a reference to that temporary local variable. The temporary variable is accessible as `this` within `M`, but not in any other way. Thus, only when `E` is a true variable is it possible for the caller to observe the changes that `M` makes to `this`.
   - The argument list is evaluated as described in [§12.6.2](expressions.md#1262-argument-lists).
   - `M` is invoked. The variable referenced by `E` becomes the variable referenced by `this`.
 - Otherwise:


### PR DESCRIPTION
Fixes #894 

Issue #894 has several comments that describe different possible concerns. To help reviewers (and to keep my head around each different scenario). Each commit will fix one of the concerns.

The first commit fixes the concern in the description: 

If a method takes an `in` parameter of a struct type that is not a `readonly struct`, then the compiler creates a temporary to invoke a (non-readonly) member of that type. Note that for C# 8.0, this will need to be revisited again to note that a copy needn't be created to invoke a `readonly` member of a non-readonly struct.