### PR TITLE
allow `unsafe` and `ref` in grammar

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1930,7 +1930,6 @@ method_header
 method_modifier
     : ref_method_modifier
     | 'async'
-    | unsafe_modifier   // unsafe code support
     ;
 
 ref_method_modifier
@@ -1945,6 +1944,7 @@ ref_method_modifier
     | 'override'
     | 'abstract'
     | 'extern'
+    | unsafe_modifier   // unsafe code support
     ;
 
 return_type

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -13,7 +13,7 @@ A *delegate_declaration* is a *type_declaration* ([§14.7](namespaces.md#147-typ
 ```ANTLR
 delegate_declaration
     : attributes? delegate_modifier* 'delegate' return_type delegate_header
-    | attributes? ref_delegate_modifier* 'delegate' ref_kind ref_return_type delegate_header
+    | attributes? delegate_modifier* 'delegate' ref_kind ref_return_type delegate_header
     ;
 
 delegate_header
@@ -22,16 +22,12 @@ delegate_header
     ;
     
 delegate_modifier
-    : ref_delegate_modifier
-    | unsafe_modifier   // unsafe code support
-    ;
-
-ref_delegate_modifier
     : 'new'
     | 'public'
     | 'protected'
     | 'internal'
     | 'private'
+    | unsafe_modifier   // unsafe code support
     ;
 ```
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -447,7 +447,7 @@ A *local_function_declaration* declares a local function.
 ```ANTLR
 local_function_declaration
     : local_function_modifier* return_type local_function_header local_function_body
-    | ref_kind ref_return_type local_function_header ref_local_function_body
+    | ref_local_function_modifier* ref_kind ref_return_type local_function_header ref_local_function_body
     ;
 
 local_function_header
@@ -456,8 +456,12 @@ local_function_header
     ;
 
 local_function_modifier
-    : 'async'
-    | unsafe_modifier   // unsafe code support
+    : ref_local_function_modifier
+    | 'async'
+    ;
+
+ref_local_function_modifier
+    : unsafe_modifier   // unsafe code support
     ;
 
 local_function_body

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -180,7 +180,7 @@ An expression with a pointer type cannot be used to provide the value in a *memb
 
 The default value ([§9.3](variables.md#93-default-values)) for any pointer type is `null`.
 
-> *Note*: Although pointers can be passed as `ref` or `out` parameters, doing so can cause undefined behavior, since the pointer might well be set to point to a local variable that no longer exists when the called method returns, or the fixed object to which it used to point, is no longer fixed. For example:
+> *Note*: Although pointers can be passed as `in`, `ref` or `out` parameters, doing so can cause undefined behavior, since the pointer might well be set to point to a local variable that no longer exists when the called method returns, or the fixed object to which it used to point, is no longer fixed. For example:
 >
 > <!-- Example: {template:"standalone-console-without-using", name:"PointerTypes1", replaceEllipsis:true} -->
 > <!-- Note: the behavior of this example is undefined. -->


### PR DESCRIPTION
`unsafe` and ref returns are allowed for delegates, local functions, and methods. Update the grammar for that part.

Fixes #886

See https://github.com/dotnet/csharpstandard/pull/941#pullrequestreview-1634196517