### PR TITLE
Learn publishing issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -7,7 +7,7 @@ body:
       value: "## Issue information"
   - type: markdown
     attributes:
-      value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue. Make sure to include the relevant section number.
+      value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue. Make sure to include the relevant section number. The committee is working on C# 8 currently. Don't write issues about features added after that version.
   - type: dropdown
     id: issue-type
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -28,7 +28,7 @@ body:
       label: Description
   - type: markdown
     attributes:
-      value: "## 🚧 Article information 🚧"
+      value: "## 🚧 Document information 🚧"
   - type: markdown
     attributes:
       value: "*Don't modify the following fields*. They are automatically filled in for you. Doing so will disconnect your issue from the affected article. *Don't edit them*."

--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -1,0 +1,46 @@
+name: Learn feedback control.
+description: |
+  ⛔ This template is hooked into the feedback control on the bottom of every page on the learn.microsoft.com site. It automatically fills in several fields for you. Don't use for other purposes. ⛔
+body:
+  - type: markdown
+    attributes:
+      value: "## Issue information"
+  - type: markdown
+    attributes:
+      value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue. Make sure to include the relevant section number.
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of issue
+      options:
+        - Typo
+        - Spec incorrect
+        - Spec incomplete
+        - xref missing
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    validations:
+      required: true
+    attributes:
+      label: Description
+  - type: markdown
+    attributes:
+      value: "## 🚧 Article information 🚧"
+  - type: markdown
+    attributes:
+      value: "*Don't modify the following fields*. They are automatically filled in for you. Doing so will disconnect your issue from the affected article. *Don't edit them*."
+  - type: input
+    id: pageUrl
+    validations:
+      required: true
+    attributes:
+      label: Page URL
+  - type: input
+    id: contentSourceUrl
+    validations:
+      required: true
+    attributes:
+      label: Content source URL


### PR DESCRIPTION
Add the issue template for feedback from customers that read the specification on the docs.microsoft.com site.

Once this is merged, I can update the config to use this spec.