### PR TITLE
Reverse some V7 edits w.r.t Indexers

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -4188,8 +4188,6 @@ An *indexer_declaration* may include a set of *attributes* ([§22](attributes.md
 
 Indexer declarations are subject to the same rules as method declarations ([§15.6](classes.md#156-methods)) with regard to valid combinations of modifiers, with the one exception being that the `static` modifier is not permitted on an indexer declaration.
 
-The modifiers `virtual`, `override`, and `abstract` are mutually exclusive except in one case. The `abstract` and `override` modifiers may be used together so that an abstract indexer can override a virtual one.
-
 The *type* of an indexer declaration specifies the element type of the indexer introduced by the declaration.
 
 > *Note*: As indexers are designed to be used in array element-like contexts, the term *element type* as defined for an array is also used with an indexer. *end note*

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -4188,11 +4188,11 @@ An *indexer_declaration* may include a set of *attributes* ([§22](attributes.md
 
 Indexer declarations are subject to the same rules as method declarations ([§15.6](classes.md#156-methods)) with regard to valid combinations of modifiers, with the one exception being that the `static` modifier is not permitted on an indexer declaration.
 
+The modifiers `virtual`, `override`, and `abstract` are mutually exclusive except in one case. The `abstract` and `override` modifiers may be used together so that an abstract indexer can override a virtual one.
+
 The *type* of an indexer declaration specifies the element type of the indexer introduced by the declaration.
 
 > *Note*: As indexers are designed to be used in array element-like contexts, the term *element type* as defined for an array is also used with an indexer. *end note*
-
-The *formal_parameter_list* specifies the parameters of the indexer. The formal parameter list of an indexer corresponds to that of a method ([§15.6.2](classes.md#1562-method-parameters)), except that at least one parameter shall be specified, and that the `this`, `out`, and `ref` parameter modifiers are not permitted.
 
 Unless the indexer is an explicit interface member implementation, the *type* is followed by the keyword `this`. For an explicit interface member implementation, the *type* is followed by an *interface_type*, a “`.`”, and the keyword `this`. Unlike other members, indexers do not have user-defined names.
 
@@ -4363,7 +4363,7 @@ Indexers and properties are very similar in concept, but differ in the following
 
 Aside from these differences, all rules defined in [§15.7.3](classes.md#1573-accessors), [§15.7.5](classes.md#1575-accessibility) and [§15.7.6](classes.md#1576-virtual-sealed-override-and-abstract-accessors) apply to indexer accessors as well as to property accessors.
 
-*Note*: This replacing of property/properties with indexer/indexers when reading [§15.7.3](classes.md#1573-accessors), [§15.7.5](classes.md#1575-accessibility) and [§15.7.6](classes.md#1576-virtual-sealed-override-and-abstract-accessors) applies to defined terms as well. For example *read-write property* becomes *read-write-indexer*. *end note*
+This replacing of property/properties with indexer/indexers when reading [§15.7.3](classes.md#1573-accessors), [§15.7.5](classes.md#1575-accessibility) and [§15.7.6](classes.md#1576-virtual-sealed-override-and-abstract-accessors) applies to defined terms as well. Specifically, *read-write property* becomes ***read-write indexer***, *read-only property* becomes ***read-only indexer***, and *write-only property* becomes ***write-only indexer***.
 
 ## 15.10 Operators
 


### PR DESCRIPTION
During the final integration of the ref-related feature text into draft-v7, 15.9, "Indexers" was broken into 15.9.1, "General" and 15.9.2 "Indexer and Property Differences," and some of the previous content was moved around, deleted, and/or edited.

A. The following para was deleted from 15.9.1:

> The modifiers `virtual`, `override`, and `abstract` are mutually exclusive except in one case. The `abstract` and `override` modifiers may be used together so that an abstract indexer can override a virtual one.

When I discussed this privately with Bill, he thought this might be true for *all* member functions, not just indexers. However, I couldn't find any such text under Methods. (And we don't have a general "member-function" section to state such things anyway.) So, I restored this para.

B. The following para was duplicated, and I removed the first occurrence:

> The *formal_parameter_list* specifies the parameters of the indexer. The formal parameter list of an indexer corresponds to that of a method ([§15.6.2](classes.md#1562-method-parameters)), except that at least one parameter shall be specified, and that the `this`, `ref`, and `out` parameter modifiers are not permitted.

C. V6 contained the following:

> Based on the presence or absence of get and set accessors, an indexer is classified as follows:

> - An indexer that includes both a get accessor and a set accessor is said to be a ***read-write indexer***.
> - An indexer that has only a get accessor is said to be a ***read-only indexer***. It is a compile-time error for a read-only indexer to be the target of an assignment.
> - An indexer that has only a set accessor is said to be a ***write-only indexer***. Except as the target of an assignment, it is a compile-time error to reference a write-only indexer in an expression.

This was removed and summarized in a Note in the (new) 15.9.1, as follows:

> *Note*: This replacing of property/properties with indexer/indexers when reading [§15.7.3](classes.md#1573-accessors), [§15.7.5](classes.md#1575-accessibility) and [§15.7.6](classes.md#1576-virtual-sealed-override-and-abstract-accessors) applies to defined terms as well. For example *read-write property* becomes *read-write-indexer*. *end note*

This introduced several problems: It made this informative, and it removed three term definitions (which we use throughout), while suggesting that a series of new-parallel terms existed, without normatively enumerating them.

After discussing this with Bill, I propose replacing that Note with the following normative text:

> This replacing of property/properties with indexer/indexers when reading [§15.7.3](classes.md#1573-accessors), [§15.7.5](classes.md#1575-accessibility) and [§15.7.6](classes.md#1576-virtual-sealed-override-and-abstract-accessors) applies to defined terms as well. Specifically, *read-write property* becomes ***read-write indexer***, *read-only property* becomes ***read-only indexer***, and *write-only property* becomes ***write-only indexer***.

FYI, the reason I stumbled on this was while writing the spec for init accessors in V9. This requires the addition of a 3rd flavor of terms:  ***read-init property/indexer*** and ***init-only property/indexer***.
