### PR TITLE
Create word artifact when a PR is merged to the main branch

### DIFF
--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -68,6 +68,7 @@ jobs:
         body: 'renumber sections. Add grammar'
 
     - name: Run converter
+      id: run-converter
       run: |
         cd tools
         ./run-converter.sh

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -5,8 +5,9 @@ name: Update spec on merge
 on: 
   push:
     branches:
-      - draft-v6
-      - draft-v7
+      - standard-v6
+      - standard-v7
+      - draft-v8
   workflow_dispatch:
     inputs:
       reason:
@@ -65,3 +66,19 @@ jobs:
       with:
         title: 'Automated Section renumber and grammar extraction'
         body: 'renumber sections. Add grammar'
+
+    - name: Run converter
+      run: |
+        cd tools
+        ./run-converter.sh
+
+    - name: Upload Word artifact
+      uses: actions/upload-artifact@v3
+      if: > 
+        ${{ steps.renumber-sections.outputs.status }} == 'success' && 
+        ${{ steps.update-grammar.outputs.status }} == 'success' && 
+        ${{ steps.run-converter.outputs.status }} == 'success'
+      with:
+        name: standard.docx
+        path: ~/tools/tmp/standard.docx
+        retention-days: 15

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -64,8 +64,8 @@ jobs:
       uses: peter-evans/create-pull-request@v3.4.1
       if: ${{ steps.renumber-sections.outputs.status }} == 'success' && ${{ steps.update-grammar.outputs.status }} == 'success'
       with:
-        title: 'Automated Section renumber and grammar extraction'
-        body: 'renumber sections. Add grammar'
+        title: "Automated Section renumber and grammar extraction"
+        body: "renumber sections. Add grammar"
 
     - name: Run converter
       id: run-converter

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -60,13 +60,6 @@ jobs:
         ./update-grammar-annex.sh
       shell: bash
     
-    - name: Create pull request
-      uses: peter-evans/create-pull-request@v3.4.1
-      if: ${{ steps.renumber-sections.outputs.status }} == 'success' && ${{ steps.update-grammar.outputs.status }} == 'success'
-      with:
-        title: "Automated Section renumber and grammar extraction"
-        body: "renumber sections. Add grammar"
-
     - name: Run converter
       id: run-converter
       run: |
@@ -83,3 +76,10 @@ jobs:
         name: standard.docx
         path: ~/tools/tmp/standard.docx
         retention-days: 15
+
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v3.4.1
+      if: ${{ steps.renumber-sections.outputs.status }} == 'success' && ${{ steps.update-grammar.outputs.status }} == 'success'
+      with:
+        title: "Automated Section renumber and grammar extraction"
+        body: "renumber sections. Add grammar"

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -60,11 +60,19 @@ jobs:
         ./update-grammar-annex.sh
       shell: bash
     
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v3.4.1
+      if: ${{ steps.renumber-sections.outputs.status }} == 'success' && ${{ steps.update-grammar.outputs.status }} == 'success'
+      with:
+        title: "Automated Section renumber and grammar extraction"
+        body: "renumber sections. Add grammar"
+
     - name: Run converter
       id: run-converter
       run: |
         cd tools
         ./run-converter.sh
+      shell: bash
 
     - name: Upload Word artifact
       uses: actions/upload-artifact@v3
@@ -76,10 +84,3 @@ jobs:
         name: standard.docx
         path: ~/tools/tmp/standard.docx
         retention-days: 15
-
-    - name: Create pull request
-      uses: peter-evans/create-pull-request@v3.4.1
-      if: ${{ steps.renumber-sections.outputs.status }} == 'success' && ${{ steps.update-grammar.outputs.status }} == 'success'
-      with:
-        title: "Automated Section renumber and grammar extraction"
-        body: "renumber sections. Add grammar"

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -82,5 +82,5 @@ jobs:
         ${{ steps.run-converter.outputs.status }} == 'success'
       with:
         name: standard.docx
-        path: ~/tools/tmp/standard.docx
+        path: ./tools/tmp/standard.docx
         retention-days: 15

--- a/tools/run-converter.sh
+++ b/tools/run-converter.sh
@@ -21,3 +21,13 @@ dotnet run --project $CONVERTER_PROJECT -- \
   $SPEC_DIRECTORY/*.md $TEMPLATE \
   -o $OUTPUT_DIRECTORY/standard.docx
 
+if [ "$?" -eq "0" ]
+then
+    # Success: Write key/value for GitHub action to read:
+    echo "status=success" >> $GITHUB_OUTPUT 
+else
+    # Failed: report the error to the GitHub action:
+    echo "status=failed" >> $GITHUB_OUTPUT 
+fi
+
+

--- a/tools/run-converter.sh
+++ b/tools/run-converter.sh
@@ -29,5 +29,3 @@ else
     # Failed: report the error to the GitHub action:
     echo "status=failed" >> $GITHUB_OUTPUT 
 fi
-
-

--- a/tools/run-section-renumber.sh
+++ b/tools/run-section-renumber.sh
@@ -14,8 +14,8 @@ dotnet run --project $PROJECT -- $1
 if [ "$?" -eq "0" ]
 then
     # Success: Write key/value for GitHub action to read:
-    echo "::set-output name=status::success" 
+    echo "status=success" >> $GITHUB_OUTPUT 
 else
     # Failed: report the error to the GitHub action:
-    echo "::set-output name=status::failed" 
+    echo "status=failed" >> $GITHUB_OUTPUT 
 fi

--- a/tools/run-smarten.sh
+++ b/tools/run-smarten.sh
@@ -17,4 +17,4 @@ done
 rm -rf smarten
 
 # I think always success, but echo the success output anyway:
-echo "::set-output name=status::success" 
+echo "status=success" >> $GITHUB_OUTPUT

--- a/tools/update-grammar-annex.sh
+++ b/tools/update-grammar-annex.sh
@@ -49,4 +49,4 @@ echo Insert EOF Stuff
 cat $GRAMMAR_PROJECT/grammar-eof-insert.md >>$OUTPUT_FILE
 
 # I think always success, but echo the success output anyway:
-echo "::set-output name=status::success" 
+echo "status=success" >> $GITHUB_OUTPUT 

--- a/tools/validate-grammar.sh
+++ b/tools/validate-grammar.sh
@@ -3,28 +3,7 @@ set -eu -o pipefail
 
 declare -r SPEC_DIRECTORY=../standard
 
-declare -a SPEC_FILES=(
-    "lexical-structure.md" 
-    "basic-concepts.md" 
-    "types.md"
-    "variables.md"
-    "conversions.md"
-    "patterns.md"
-    "expressions.md"
-    "statements.md"
-    "namespaces.md"
-    "classes.md"
-    "structs.md"
-    "arrays.md"
-    "interfaces.md"
-    "enums.md"
-    "delegates.md"
-    "exceptions.md"
-    "attributes.md"
-    "unsafe-code.md"
-    )
-
-dotnet csharpgrammar ../test-grammar CSharp ../standard -m ../.github/workflows/dependencies/ReplaceAndAdd.md
+dotnet csharpgrammar ../test-grammar CSharp $SPEC_DIRECTORY -m ../.github/workflows/dependencies/ReplaceAndAdd.md
 
 # Now, validate it:
 curl -H "Accept: application/zip" https://repo1.maven.org/maven2/com/tunnelvisionlabs/antlr4/4.9.0/antlr4-4.9.0-complete.jar -o antlr-4.9.0-complete.jar


### PR DESCRIPTION
Update the workflow for "update on merge" to also run the word converter, and upload the generated *standard.docx* file to the actions output.

While doing this work, remove the outdated "::set-output" command. And, remove all but one of the hardcoded lists of spec files.

For an example output for uploading the action artifact, see [here](https://github.com/BillWagner/csharpstandard/actions/runs/6655931948) for a test run.

Fixes #745 
Fixes #953 

Contributes to #933 
