### PR TITLE
Add example annotation to 3 new examples

### DIFF
--- a/standard/patterns.md
+++ b/standard/patterns.md
@@ -22,20 +22,22 @@ A *declaration_pattern* and a *var_pattern* can result in the declaration of a l
 
 Each pattern form defines the set of types for input values that the pattern may be applied to. A pattern `P` is *applicable to* a type `T` if `T` is among the types whose values the pattern may match. It is a compile-time error if a pattern `P` appears in a program to match a pattern input value ([§11.1](patterns.md#111-general)) of type `T` if `P` is not applicable to `T`.
 
-> *Example*: The following example generates a compile-time error because the compile-time type of `v` is `Stream`. A variable of type `Stream` can never have a value that is reference compatible with `string`:
+> *Example*: The following example generates a compile-time error because the compile-time type of `v` is `TextReader`. A variable of type `TextReader` can never have a value that is reference-compatible with `string`:
 >
+> <!-- Example: {template:"standalone-console", name:"PatternFormGen1", expectedWarnings:["CS0184"]} -->
 > ```csharp
-> Stream v = OpenDataFile(); // compile-time type of 'v' is 'Stream'
+> TextReader v = Console.In; // compile-time type of 'v' is 'TextReader'
 > if (v is string) // compile-time error
 > {
 >     // code assuming v is a string
 > }
 > ```
 >
-> However, the following doesn’t generate a compile-time error because the compile-time type of `v` is `object`. A variable of type `object` could have a value that is reference compatible with `string`:
+> However, the following doesn’t generate a compile-time error because the compile-time type of `v` is `object`. A variable of type `object` could have a value that is reference-compatible with `string`:
 >
+> <!-- Example: {template:"standalone-console", name:"PatternFormGen2"} -->
 > ```csharp
-> object v = OpenDataFile();
+> object v = Console.In;
 > if (v is string s)
 > {
 >     // code assuming v is a string

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -335,6 +335,7 @@ The definite-assignment state of *v* at the beginning of a case’s guard clause
 
 > *Example*: The second rule eliminates the need for the compiler to issue an error if an unassigned variable is accessed in unreachable code. The state of *b* is “definitely assigned” in the unreachable switch label `case 2 when b`.
 >
+> <!-- Example: {template:"standalone-console-without-using", name:"DefAssignSwitch", expectedWarnings:["CS0162"]} -->
 > ```csharp
 > bool b;
 > switch (1) 


### PR DESCRIPTION
@BillWagner, I changed the 2 examples in patterns.md, so they don't need any non-standard supporting types/methods. I believe I have preserved your original intent.

BTW, should you want to add annotations to examples in the future, add the following line right before the line starting the source code, and then replace/delete options as you need (according to https://github.com/dotnet/csharpstandard/blob/standard-v7/tools/ExampleExtractor/ExtractorAndTesterUsersGuide.md):

`> <!-- Example: {template:"xxx", name:"xxx", replaceEllipsis:true, customEllipsisReplacements: ["xxx", "xxx"], expectedErrors:["CSxxx"], expectedWarnings:["CSxxx"], ignoredWarnings:["CSxxx"], inferOutput:true, expectedOutput:["xxx"], ignoreOutput:true, expectedException:"xxx", additionalFiles:["xxx.cs"]} -->`

The leading `> ` is only needed if the example is inside an Example or Note.