### PR TITLE
Redirect link to normative text

### DIFF
--- a/standard/variables.md
+++ b/standard/variables.md
@@ -226,7 +226,8 @@ The definite-assignment states of instance variables of a *struct_type* variable
 Definite assignment is a requirement in the following contexts:
 
 - A variable shall be definitely assigned at each location where its value is obtained.
-  > *Note*: This ensures that undefined values never occur. *end note*  
+  > *Note*: This ensures that undefined values never occur. *end note*
+
   The occurrence of a variable in an expression is considered to obtain the value of the variable, except when
   - the variable is the left operand of a simple assignment,
   - the variable is passed as an output parameter, or

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -218,7 +218,7 @@ At a given location in the executable code of a function member or an anonymous 
 >
 > *end note*
 
-The definite-assignment states of instance variables of a *struct_type* variable are tracked individually as well as collectively. In additional to the rules above, the following rules apply to *struct_type* variables and their instance variables:
+The definite-assignment states of instance variables of a *struct_type* variable are tracked individually as well as collectively. In additional to the rules described in [§9.4.2](variables.md#942-initially-assigned-variables), [§9.4.3](variables.md#943-initially-unassigned-variables), and [§9.4.4](variables.md#944-precise-rules-for-determining-definite-assignment), the following rules apply to *struct_type* variables and their instance variables:
 
 - An instance variable is considered definitely assigned if its containing *struct_type* variable is considered definitely assigned.
 - A *struct_type* variable is considered definitely assigned if each of its instance variables is considered definitely assigned.


### PR DESCRIPTION
[This a trivial, nit-picking edit!]

In draft-v8 [§9.4.1 Definite assignment|General](variables.md#941-general) we have:

> ...
>
> > *Note*: Informally stated, the rules of definite assignment are:
> >
> > ...
> >
> > The formal specification underlying the above informal rules is described in [§9.4.2](variables.md#942-initially-assigned-variables), [§9.4.3](variables.md#943-initially-unassigned-variables), and [§9.4.4](variables.md#944-precise-rules-for-determining-definite-assignment).
> >
> > *end note*
>
> The definite-assignment states of instance variables of a *struct_type* variable are tracked individually as well as collectively. ***In additional to the rules above***, the following rules apply to *struct_type* variables and their instance variables:
>
> - ...
> - ...

In V1, the Note content was normative, so the list of rules it contains was normative. However, in V2, the Note bracketing was introduced, making the contents informative. However, the phrase marked in ***bold/italic*** was not adjusted accordioning. As a result, that phrase in normative text relies on so-called rules in informative text (which, in turn, point to a normative set of rules). 

My solution is simple: Have the the phrase marked in ***bold/italic*** point directly to the normative set of rules. 