### PR TITLE
Make AsyncMethodBuilder a reserved attribute

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -523,6 +523,7 @@ A small number of attributes affect the language in some way. These attributes i
 - `System.AttributeUsageAttribute` ([§22.5.2](attributes.md#2252-the-attributeusage-attribute)), which is used to describe the ways in which an attribute class can be used.
 - `System.Diagnostics.ConditionalAttribute` ([§22.5.3](attributes.md#2253-the-conditional-attribute)), is a multi-use attribute class which is used to define conditional methods and conditional attribute classes. This attribute indicates a condition by testing a conditional compilation symbol.
 - `System.ObsoleteAttribute` ([§22.5.4](attributes.md#2254-the-obsolete-attribute)), which is used to mark a member as obsolete.
+- `System.Runtime.CompilerServices.AsyncMethodBuilderAttribute` (§AsyncMethodBuilderAttribute), which is used to establish a task builder for an async method.
 - `System.Runtime.CompilerServices.CallerLineNumberAttribute` ([§22.5.5.2](attributes.md#22552-the-callerlinenumber-attribute)), `System.Runtime.CompilerServices.CallerFilePathAttribute` ([§22.5.5.3](attributes.md#22553-the-callerfilepath-attribute)), and `System.Runtime.CompilerServices.CallerMemberNameAttribute` ([§22.5.5.4](attributes.md#22554-the-callermembername-attribute)), which are used to supply information about the calling context to optional parameters.
 
 An execution environment may provide additional implementation-specific attributes that affect the execution of a C# program.
@@ -767,6 +768,10 @@ If a program uses a type or member that is decorated with the `Obsolete` attribu
 > the class `A` is decorated with the `Obsolete` attribute. Each use of `A` in `Main` results in a warning that includes the specified message, “This class is obsolete; use class `B` instead”.
 >
 > *end example*
+
+### §AsyncMethodBuilder The AsyncMethodBuilder attribute
+
+This attribute is discussed in [§15.15.1](classes.md#15151-general).
 
 ### 22.5.5 Caller-info attributes
 

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -771,7 +771,7 @@ If a program uses a type or member that is decorated with the `Obsolete` attribu
 
 ### §AsyncMethodBuilderAttribute The AsyncMethodBuilder attribute
 
-This attribute is discussed in [§15.15.1](classes.md#15151-general).
+This attribute is described in [§15.15.1](classes.md#15151-general).
 
 ### 22.5.5 Caller-info attributes
 

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -769,7 +769,7 @@ If a program uses a type or member that is decorated with the `Obsolete` attribu
 >
 > *end example*
 
-### §AsyncMethodBuilder The AsyncMethodBuilder attribute
+### §AsyncMethodBuilderAttribute The AsyncMethodBuilder attribute
 
 This attribute is discussed in [§15.15.1](classes.md#15151-general).
 


### PR DESCRIPTION
This addresses Issue #1031.

Jon/Bill, as this fix is trivial, let's merge it without further TG2 discussion.