### PR TITLE
add org -level app keys

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -29,6 +29,8 @@ jobs:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
           ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+          ImportOptions__ApiKeys__SequesterPrivateKey: ${{ secrets.SEQUESTER_PRIVATEKEY }}
+          ImportOptions__ApiKeys__SequesterAppID: ${{ secrets.SEQUESTER_APPID }}
         with:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -38,6 +38,8 @@ jobs:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
           ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+          ImportOptions__ApiKeys__SequesterPrivateKey: ${{ secrets.SEQUESTER_PRIVATEKEY }}
+          ImportOptions__ApiKeys__SequesterAppID: ${{ secrets.SEQUESTER_APPID }}
         with:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
@@ -53,6 +55,8 @@ jobs:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
           ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+          ImportOptions__ApiKeys__SequesterPrivateKey: ${{ secrets.SEQUESTER_PRIVATEKEY }}
+          ImportOptions__ApiKeys__SequesterAppID: ${{ secrets.SEQUESTER_APPID }}
         with:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}


### PR DESCRIPTION
The sequester app uses org-level permissions to read org level projects.

I've already configured the keys in the secrets section for this repo. Once this is merged, the overnight bulk run will update internal job boards based on GH projects.