### PR TITLE
Minor nit: make sentence a new para

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -4490,6 +4490,7 @@ The following rules apply to binary operator declarations, where `T` denotes the
 
 - A binary non-shift operator shall take two parameters, at least one of which shall have type `T` or `T?`, and can return any type.
 - A binary `<<` or `>>` operator ([§12.11](expressions.md#1211-shift-operators)) shall take two parameters, the first of which shall have type `T` or T? and the second of which shall have type `int` or `int?`, and can return any type.
+
 The signature of a binary operator consists of the operator token (`+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, `>>`, `==`, `!=`, `>`, `<`, `>=`, or `<=`) and the types of the two formal parameters. The return type and the names of the formal parameters are not part of a binary operator’s signature.
 
 Certain binary operators require pair-wise declaration. For every declaration of either operator of a pair, there shall be a matching declaration of the other operator of the pair. Two operator declarations match if identity conversions exist between their return types and their corresponding parameter types. The following operators require pair-wise declaration:


### PR DESCRIPTION
We have a para following the final bullet in a list incorrectly being considered part of that bullet. It was a separate para in V5, but was (presumably accidentally) made incorrect in V6.