### PR TITLE
Add support for static local functions (#869)

### DIFF
--- a/standard/statements.md
+++ b/standard/statements.md
@@ -507,7 +507,8 @@ local_function_modifier
     ;
 
 ref_local_function_modifier
-    : unsafe_modifier   // unsafe code support
+    : 'static'
+    | unsafe_modifier   // unsafe code support
     ;
 
 local_function_body
@@ -563,9 +564,9 @@ Unless specified otherwise below, the semantics of all grammar elements is the s
 
 The *identifier* of a *local_function_declaration* shall be unique in its declared block scope, including any enclosing local variable declaration spaces. One consequence of this is that overloaded *local_function_declaration*s are not allowed.
 
-A *local_function_declaration* may include one `async` ([§15.15](classes.md#1515-async-functions)) modifier and one `unsafe` ([§23.1](unsafe-code.md#231-general)) modifier. If the declaration includes the `async` modifier then the return type shall be `void` or a `«TaskType»` type ([§15.15.1](classes.md#15151-general)). The `unsafe` modifier uses the containing lexical scope. The `async` modifier does not use the containing lexical scope. It is a compile-time error for *type_parameter_list* or *formal_parameter_list* to contain *attributes*.
+A *local_function_declaration* may include one `async` ([§15.15](classes.md#1515-async-functions)) modifier and one `unsafe` ([§23.1](unsafe-code.md#231-general)) modifier. If the declaration includes the `async` modifier then the return type shall be `void` or a `«TaskType»` type ([§15.15.1](classes.md#15151-general)). If the declaration includes the `static` modifier, the function is a ***static local function***; otherwise, it is a ***non-static local function***. It is a compile-time error for *type_parameter_list* or *formal_parameter_list* to contain *attributes*. If the local function is declared in an unsafe context (§23.2), the local function may include unsafe code, even if the local function declaration doesn't include the `unsafe` modifier.
 
-A local function is declared at block scope, and that function may capture variables from the enclosing scopes. It is a compile-time error if a captured variable is read by the body of the local function but is not definitely assigned before each call to the function. The compiler shall determine which variables are definitely assigned on return ([§9.4.4.33](variables.md#94433-rules-for-variables-in-local-functions)).
+A local function is declared at block scope. A non-static local function may capture variables from the enclosing scope while a static local function shall not (so it has no access to enclosing locals, parameters, non-static local functions, or `this`). It is a compile-time error if a captured variable is read by the body of a non-static local function but is not definitely assigned before each call to the function. The compiler shall determine which variables are definitely assigned on return ([§9.4.4.33](variables.md#94433-rules-for-variables-in-local-functions)).
 
 When the type of `this` is a struct type, it is a compile-time error for the body of a local function to access `this`. This is true whether the access is explicit (as in `this.x`) or implicit (as in `x` where `x` is an instance member of the struct). This rule only prohibits such access and does not affect whether member lookup results in a member of the struct.
 
@@ -605,6 +606,13 @@ Local function bodies are always reachable. The endpoint of a local function dec
 > In other words, the location of a local function declaration doesn’t affect the reachability of any statements in the containing function. *end example*
 
 If the type of the argument to a local function is `dynamic`, the function to be called shall be resolved at compile time, not runtime.
+
+A local function shall not be used in an expression tree.
+
+A static local function
+
+- May reference static members, type parameters, constant definitions and static local functions from the enclosing scope.
+- Shall not reference `this` or `base` nor instance members from an implicit `this` reference, nor local variables, parameters, or non-static local functions from the enclosing scope. However, all these are permitted in a `nameof()` expression.
 
 ## 13.7 Expression statements
 


### PR DESCRIPTION
This PR ports the changes in #869, which was mistakenly merged into `standard-v7` rather than `draft-v8`.

I cherry-picked the squashed commit. No other edits were made. This matches the edits the committee approved on 3/27