### PR TITLE
Make nameof section heading consistent with other named operators

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3223,7 +3223,7 @@ Except for the `stackalloc` operator, C# provides no predefined constructs for m
 > In the case of `span8`, `stackalloc` results in a `Span<int>`, which is converted by an implicit operator to `ReadOnlySpan<int>`. Similarly, for `span9`, the resulting `Span<double>` is converted to the user-defined type `Widget<double>` using the conversion, as shown.
 > *end example*
 
-### 12.8.22 Nameof expressions
+### 12.8.22 The nameof operator
 
 A *nameof_expression* is used to obtain the name of a program entity as a constant string.
 


### PR DESCRIPTION
This addresses Issue #1073.