### PR TITLE
Correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The branch `draft-v9` has Draft PRs and Issues for C# 9.
 
 The branch `draft-v8` has the evolving draft text for C# 8.
 
-### C# 7 draft (the most-recently published version)
+### C# 7 standard
 
 The branch `standard-v7` has the ECMA C# 7 standard text, in Markdown format. For the official standard, see the [ECMA site](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/).
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ More broadly, *no* comments should be regarded as being part of the standard its
 
 ## Admin folder
 
-A home for adminstrative files.
+A home for administrative files.
 
 For now, it contains separate logs for past (V6, V7), present (V8), and future (V9) work going on to add new features.
 

--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 
 ## C# Language Specification
 
-### C# 9.0 draft
+### C# 9 draft
 
-The branch `draft-v9` has Draft PRs and Issues for C# 9.0.
+The branch `draft-v9` has Draft PRs and Issues for C# 9.
 
-### C# 8.0 draft
+### C# 8 draft
 
-The branch `draft-v8` has the evolving draft text for C# 8.0.
+The branch `draft-v8` has the evolving draft text for C# 8.
 
-### C# 7.0 draft
+### C# 7 draft (the most-recently published version)
 
-The branch `standard-v7` has the text for C# 7.0. It has been submitted for consideration as a formal standard to ECMA.
+The branch `standard-v7` has the ECMA C# 7 standard text, in Markdown format. For the official standard, see the [ECMA site](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/).
 
-### C# 6.0 standard
+### C# 6 standard
 
-The branch `standard-v6` has the ECMA C# 6.0 standard text, in Markdown format. For the official standard, see the [ECMA site](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/).
+The branch `standard-v6` has the ECMA C# 6 standard text, in Markdown format. For the official standard, see the [ECMA site](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/).
 
-### C# 5.0 standard
+### C# 5 standard
 
-The branch `standard-v5` has the ECMA C# 5.0 standard text, converted to Markdown. For the official standard, see the [ECMA site](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/).
+The branch `standard-v5` has the ECMA C# 5 standard text, converted to Markdown. For the official standard, see the [ECMA site](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/).
 
 This version is stored in this branch as a base markdown version to compare with future updated standard texts.
 
@@ -39,15 +39,15 @@ This version is stored in this branch as a base markdown version to compare with
 
 There are HTML comments (`<!-- comment -->`) within the standard for the sake of tooling. Some help in the process of converting the standard to Word, and others are for automated testing purposes.
 
-Some automated test comments refer to error codes that are specific to the Microsoft C# compiler (e.g. "CS0509") to test that compilation fails as expected, where an example presents deliberately-invalid code. These error codes are not part of the standard, and should not be viewed as any kind of compliance check for other compilers.
+Some automated test comments refer to error codes that are specific to the Microsoft C# compiler (e.g., "CS0509") to test that compilation fails as expected, where an example presents deliberately-invalid code. These error codes are not part of the standard, and should not be viewed as any kind of compliance check for other compilers.
 
 More broadly, *no* comments should be regarded as being part of the standard itself.
 
 ## Admin folder
 
-A home for adminstrative files (such as [eventually] meeting agendas and minutes).
+A home for adminstrative files.
 
-For now, it contains separate logs for past (v6, v7), present (v8), and future (v9) work going on to add new features.
+For now, it contains separate logs for past (V6, V7), present (V8), and future (V9) work going on to add new features.
 
 ## Tools folder
 


### PR DESCRIPTION
Correct/bring up to date. Removed all .x from version numbers, as Ecma hasn't published any dot versions; besides, 7.0 might have confused readers with MS's V7.0, when Ecma V7 actually matches MS V7.3.