### PR TITLE
Reserve operator method names

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1390,7 +1390,7 @@ The following method names are reserved. While many have corresponding operators
 
 | **Method Name** | **C# Operator** |
 |--------------|----------------------|
-| `op_Addition` | `+` (binary) | 
+| `op_Addition` | `+` (binary) |
 | `op_AdditionAssignment` | (reserved) |
 | `op_AddressOf` | (reserved) |
 | `op_Assign` | (reserved) |
@@ -1433,7 +1433,7 @@ The following method names are reserved. While many have corresponding operators
 | `op_MultiplicationAssignment` | (reserved) |
 | `op_Multiply` | `*` (binary) |
 | `op_OnesComplement` | `~` |
-| `op_PointerDereference` | (reserved)
+| `op_PointerDereference` | (reserved) |
 | `op_PointerToMemberSelection` | (reserved) |
 | `op_RightShift` | `>>` |
 | `op_RightShiftAssignment` | (reserved) |
@@ -1443,7 +1443,7 @@ The following method names are reserved. While many have corresponding operators
 | `op_True` | `true` |
 | `op_UnaryNegation` | `-` (unary) |
 | `op_UnaryPlus` | `+` (unary) |
-| `op_UnsignedRightShift ` | (reserved for future use) |
+| `op_UnsignedRightShift` | (reserved for future use) |
 | `op_UnsignedRightShiftAssignment` | (reserved) |
 
 ## 15.4 Constants

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1296,6 +1296,8 @@ The reserved names do not introduce declarations, thus they do not participate i
 
 The declaration of a finalizer ([§15.13](classes.md#1513-finalizers)) also causes a signature to be reserved ([§15.3.10.5](classes.md#153105-member-names-reserved-for-finalizers)).
 
+Certain names are reserved for use as operator method names (§Names-Reserved-For-Ops).
+
 #### 15.3.10.2 Member names reserved for properties
 
 For a property `P` ([§15.7](classes.md#157-properties)) of type `T`, the following signatures are reserved:
@@ -1381,6 +1383,68 @@ For a class containing a finalizer ([§15.13](classes.md#1513-finalizers)), the 
 ```csharp
 void Finalize();
 ```
+
+#### §Names-Reserved-For-Ops Member names reserved for operators
+
+The following method names are reserved. While many have corresponding operators in this specification, some are reserved for use by future versions, while some are reserved for interop with other languages.
+
+| **Method Name** | **C# Operator** |
+|--------------|----------------------|
+| `op_Addition` | `+` (binary) | 
+| `op_AdditionAssignment` | (reserved) |
+| `op_AddressOf` | (reserved) |
+| `op_Assign` | (reserved) |
+| `op_BitwiseAnd` | `&` (binary) |
+| `op_BitwiseAndAssignment` | (reserved) |
+| `op_BitwiseOr` | `\|` |
+| `op_BitwiseOrAssignment` | (reserved) |
+| `op_CheckedAddition` | (reserved for future use) |
+| `op_CheckedDecrement` | (reserved for future use) |
+| `op_CheckedDivision` | (reserved for future use) |
+| `op_CheckedExplicit` | (reserved for future use) |
+| `op_CheckedIncrement` | (reserved for future use) |
+| `op_CheckedMultiply` | (reserved for future use) |
+| `op_CheckedSubtraction` | (reserved for future use) |
+| `op_CheckedUnaryNegation` | (reserved for future use) |
+| `op_Comma` | (reserved) |
+| `op_Decrement` | `--` (prefix and postfix) |
+| `op_Division` | `/` |
+| `op_DivisionAssignment` | (reserved) |
+| `op_Equality` | `==` |
+| `op_ExclusiveOr` | `^` |
+| `op_ExclusiveOrAssignment` | (reserved) |
+| `op_Explicit` | explicit (narrowing) coercion |
+| `op_False` | `false` |
+| `op_GreaterThan` | `>` |
+| `op_GreaterThanOrEqual` | `>=` |
+| `op_Implicit` | implicit (widening) coercion |
+| `op_Increment` | `++` (prefix and postfix) |
+| `op_Inequality` | `!=` |
+| `op_LeftShift` | `<<` |
+| `op_LeftShiftAssignment` | (reserved) |
+| `op_LessThan` | `<` |
+| `op_LessThanOrEqual` | `<=` |
+| `op_LogicalAnd` | (reserved) |
+| `op_LogicalNot` | `!` |
+| `op_LogicalOr` | (reserved) |
+| `op_MemberSelection` | (reserved) |
+| `op_Modulus` | `%` |
+| `op_ModulusAssignment` | (reserved) |
+| `op_MultiplicationAssignment` | (reserved) |
+| `op_Multiply` | `*` (binary) |
+| `op_OnesComplement` | `~` |
+| `op_PointerDereference` | (reserved)
+| `op_PointerToMemberSelection` | (reserved) |
+| `op_RightShift` | `>>` |
+| `op_RightShiftAssignment` | (reserved) |
+| `op_SignedRightShift` | (reserved) |
+| `op_Subtraction` | `-` (binary) |
+| `op_SubtractionAssignment` | (reserved) |
+| `op_True` | `true` |
+| `op_UnaryNegation` | `-` (unary) |
+| `op_UnaryPlus` | `+` (unary) |
+| `op_UnsignedRightShift ` | (reserved for future use) |
+| `op_UnsignedRightShiftAssignment` | (reserved) |
 
 ## 15.4 Constants
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -1384,7 +1384,7 @@ For a class containing a finalizer ([§15.13](classes.md#1513-finalizers)), the 
 void Finalize();
 ```
 
-#### §Names-Reserved-For-Ops Member names reserved for operators
+#### §Names-Reserved-For-Ops Method names reserved for operators
 
 The following method names are reserved. While many have corresponding operators in this specification, some are reserved for use by future versions, while some are reserved for interop with other languages.
 


### PR DESCRIPTION
While the mapping of C# operators to compiler-generated method names is *not* stated in the C# spec, it *is* in the CLI spec. (Partition I, Table I.4 [I.10.3.1 Unary operators] and Table I.5 [I.10.3.2 Binary operators].) Unfortunately, this is insufficient, for the following reasons:

1. The C# spec normatively references Partition IV only: ISO/IEC 23271:2012, Common Language Infrastructure (CLI), Partition IV: Base Class Library (BCL), Extended Numerics Library, and Extended Array Library. In the C# spec Introduction we say, “Although Microsoft’s implementation of C# relies on CLI for library and run-time support, other implementations of C# need not, provided they support an alternate way of getting at the minimum CLI features required by this C# standard (see Annex C).” And Annex C is all about the library in Partition IV. So, we can’t simply defer to Partition I without making it a Normative Reference (which I’m sure we don’t want to do).
1. In any event, those tables do *not* actually show the C# mapping! Instead, their right-most columns imply a mapping to C++ and are marked as *informative*.
1. Even if we could defer to the CLI for this information, we’d still have to augment it for the new operator function names resulting from V11’s “Checked user-defined operators” as well as `>>>`.

This PR replicates the tables from the CLI spec, replacing C++ with C# in the (now normative) right column, and puts them in a new section, 15.3.10.6, “Member names reserved for operators.” And as we already know the extra names that V11 uses, I’ve put those in the current spec, but tagged with “reserved for future use” to warn people to stay away from defining methods with those names.
