### PR TITLE
enable nullable annotations

### DIFF
--- a/tools/example-templates/code-in-class-lib-without-using/Project.csproj
+++ b/tools/example-templates/code-in-class-lib-without-using/Project.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/code-in-class-lib/Project.csproj
+++ b/tools/example-templates/code-in-class-lib/Project.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/code-in-main-without-using/Project.csproj
+++ b/tools/example-templates/code-in-main-without-using/Project.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>annotations</Nullable>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/tools/example-templates/code-in-main/Project.csproj
+++ b/tools/example-templates/code-in-main/Project.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>annotations</Nullable>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/tools/example-templates/code-in-partial-class/Project.csproj
+++ b/tools/example-templates/code-in-partial-class/Project.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/extern-lib/ExampleProject.csproj
+++ b/tools/example-templates/extern-lib/ExampleProject.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <NoWarn>CS0169</NoWarn>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternN2.csproj
+++ b/tools/example-templates/extern-lib/ExternN2.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternR1.csproj
+++ b/tools/example-templates/extern-lib/ExternR1.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternX.csproj
+++ b/tools/example-templates/extern-lib/ExternX.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternY.csproj
+++ b/tools/example-templates/extern-lib/ExternY.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/standalone-console-without-using/Project.csproj
+++ b/tools/example-templates/standalone-console-without-using/Project.csproj
@@ -7,6 +7,7 @@
     <Nullable>disable</Nullable>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
+    <Nullable>annotations</Nullable>
+</PropertyGroup>
 
 </Project>

--- a/tools/example-templates/standalone-console/Project.csproj
+++ b/tools/example-templates/standalone-console/Project.csproj
@@ -7,6 +7,7 @@
     <Nullable>disable</Nullable>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/standalone-lib-without-using/Project.csproj
+++ b/tools/example-templates/standalone-lib-without-using/Project.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/standalone-lib/Project.csproj
+++ b/tools/example-templates/standalone-lib/Project.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Change nullable behavior from `disable` to `annotations`.

This may make it easier to break up the nullable normative language in multiple PRs.