### PR TITLE
Correct 2 x grammar rules for compilation unit name in #line

### DIFF
--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1488,12 +1488,12 @@ fragment PP_Line_Indicator
     ;
     
 fragment PP_Compilation_Unit_Name
-    : '"' PP_Compilation_Unit_Name_Character+ '"'
+    : '"' PP_Compilation_Unit_Name_Character* '"'
     ;
     
 fragment PP_Compilation_Unit_Name_Character
     // Any Input_Character except "
-    : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029' | '#')
+    : ~('\u000D' | '\u000A'   | '\u0085' | '\u2028' | '\u2029' | '"')
     ;
 ```
 


### PR DESCRIPTION
Good catch, @logeshkumars0604!

This PR fixes dotnet/roslyn#1118.

The " vs. # error was introduced in V6 when we converted to the ANTLR grammar notation.

The ability to have an empty filename was never tested, but as you point out, it does work, so I have made the name contents zero-or-more characters, instead of one-or-more. I tested this using `#line 300 ""` along with `CallerFilePathAttribute`.