### PR TITLE
Preprocessor symbols for nullable reference types: Define a single nullable context.

### DIFF
--- a/standard/basic-concepts.md
+++ b/standard/basic-concepts.md
@@ -1024,7 +1024,7 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 > {
 >     static void Main()
 >     {
->         B b = new B(new A());
+>         B? b = new B(new A());
 >         b = null;
 >         GC.Collect();
 >         GC.WaitForPendingFinalizers();
@@ -1069,19 +1069,19 @@ The behavior of the garbage collector can be controlled, to some degree, via sta
 >
 > class B
 > {
->     public A Ref;
+>     public A? Ref;
 >
 >     ~B()
 >     {
 >         Console.WriteLine("Finalize instance of B");
->         Ref.F();
+>         Ref?.F();
 >     }
 > }
 >
 > class Test
 > {
->     public static A RefA;
->     public static B RefB;
+>     public static A? RefA;
+>     public static B? RefB;
 >
 >     static void Main()
 >     {

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1529,19 +1529,17 @@ fragment PP_Nullable_Target
     ;
 ```
 
-A nullable directive sets the denoted nullable context for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The effect of each form of nullable directive is, as follows:
+A nullable directive sets the denoted nullable context for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The nullable context contains two flags: *annotations* and *warnings*. The effect of each form of nullable directive is, as follows:
 
-- `#nullable disable`: Sets the nullable context to “disabled”.
-- `#nullable enable`: Sets the nullable context to “enabled”.
-- `#nullable restore`: Restores the nullable context to the state specified by the external mechanism, if any.
-- `#nullable disable annotations`: Disables nullable annotations. Nullable warnings are unaffected.
-- `#nullable enable annotations`: Enables nullable annotations. Nullable warnings are unaffected.
-- `#nullable restore annotations`: Restores nullable annotations to the state specified by the external mechanism, if any. Warnings are unaffected.
-- `#nullable disable warnings`: Disables nullable warnings. Nullable annotations are unaffected.
-- `#nullable enable warnings`: Enables nullable warnings. Nullable annotations are unaffected.
-- `#nullable restore warnings`: Restores nullable warnings to the state specified by the external mechanism, if any. Nullable annotations are unaffected.
-
-Disabling the nullable context when it is already disabled has no effect. Likewise, enabling the nullable context when it is already enabled has no effect.
+- `#nullable disable`: Disables both nullable annotations and nullable warnings flags.
+- `#nullable enable`: Enables both nullable annotations and nullable warnings flags.
+- `#nullable restore`: Restores both the annotations and warnings flags to the state specified by the external mechanism, if any.
+- `#nullable disable annotations`: Disables the nullable annotations flag. The nullable warnings flag is unaffected.
+- `#nullable enable annotations`: Enables the nullable annotations flag. The nullable warnings flag is unaffected.
+- `#nullable restore annotations`: Restores the nullable annotations flag to the state specified by the external mechanism, if any. The nullable warnings flag is unaffected.
+- `#nullable disable warnings`: Disables the nullable warnings flag. The nullable annotations flag is unaffected.
+- `#nullable enable warnings`: Enables the nullable warnings flag. The nullable annotations flag is unaffected.
+- `#nullable restore warnings`: Restores the nullable warnings flag to the state specified by the external mechanism, if any. The nullable annotations flag is unaffected.
 
 ### 6.5.9 Pragma directives
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1529,7 +1529,7 @@ fragment PP_Nullable_Target
     ;
 ```
 
-A nullable directive sets the denoted nullable context for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The nullable context contains two flags: *annotations* and *warnings*. The effect of each form of nullable directive is, as follows:
+A nullable directive sets the available flags for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The nullable context contains two flags: *annotations* and *warnings*. The effect of each form of nullable directive is, as follows:
 
 - `#nullable disable`: Disables both nullable annotations and nullable warnings flags.
 - `#nullable enable`: Enables both nullable annotations and nullable warnings flags.
@@ -1540,6 +1540,24 @@ A nullable directive sets the denoted nullable context for subsequent lines of c
 - `#nullable disable warnings`: Disables the nullable warnings flag. The nullable annotations flag is unaffected.
 - `#nullable enable warnings`: Enables the nullable warnings flag. The nullable annotations flag is unaffected.
 - `#nullable restore warnings`: Restores the nullable warnings flag to the state specified by the external mechanism, if any. The nullable annotations flag is unaffected.
+
+The nullable state of expressions is tracked at all times. The state of the annotation flag determines the initial null state of a variable declaration. Warnings are only issued when the warnings flag is enabled.
+
+> *Example*: The example
+>
+> <!-- Example: {template:"standalone-console", name:"InitialWarning", ignoredWarnings:["CS8602"], expectedException:"NullReferenceException"}} -->
+> ```csharp
+> #nullable disable
+> string x = null;
+> string y = "";
+> #nullable enable
+> Console.WriteLine(x.Length); // Warning
+> Console.WriteLine(y.Length);
+> ```
+>
+> produces a compile-time warning (“dereference of a possible null reference”). The nullable state of `x` is tracked everywhere. A warning is issued when the warnings flag is enabled.
+>
+> *end example*
 
 ### 6.5.9 Pragma directives
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1026,7 +1026,7 @@ right_shift_assignment
 
 ### 6.5.1 General
 
-The pre-processing directives provide the ability to conditionally skip sections of compilation units, to report error and warning conditions, and to delineate distinct regions of source code.
+The pre-processing directives provide the ability to conditionally skip sections of compilation units, to report error and warning conditions, to delineate distinct regions of source code, and to set the nullable context.
 
 > *Note*: The term “pre-processing directives” is used only for consistency with the C and C++ programming languages. In C#, there is no separate pre-processing step; pre-processing directives are processed as part of the lexical analysis phase. *end note*
 
@@ -1042,6 +1042,7 @@ fragment PP_Kind
     | PP_Diagnostic
     | PP_Region
     | PP_Pragma
+    | PP_Nullable
     ;
 
 // Only recognised at the beginning of a line
@@ -1078,10 +1079,11 @@ The following pre-processing directives are available:
 - `#error`, which is used to issue errors ([§6.5.6](lexical-structure.md#656-diagnostic-directives)).
 - `#region` and `#endregion`, which are used to explicitly mark sections of source code ([§6.5.7](lexical-structure.md#657-region-directives)).
 - `#pragma`, which is used to specify optional contextual information to a compiler ([§6.5.9](lexical-structure.md#659-pragma-directives)).
+- `#nullable`, which is used to specify the nullable context (§Nullable-Directives).
 
 A pre-processing directive always occupies a separate line of source code and always begins with a `#` character and a pre-processing directive name. White space may occur before the `#` character and between the `#` character and the directive name.
 
-A source line containing a `#define`, `#undef`, `#if`, `#elif`, `#else`, `#endif`, `#line`, or `#endregion` directive can end with a single-line comment. Delimited comments (the `/* */` style of comments) are not permitted on source lines containing pre-processing directives.
+A source line containing a `#define`, `#undef`, `#if`, `#elif`, `#else`, `#endif`, `#line`, `#endregion`, or `#nullable` directive can end with a single-line comment. Delimited comments (the `/* */` style of comments) are not permitted on source lines containing pre-processing directives.
 
 Pre-processing directives are not part of the syntactic grammar of C#. However, pre-processing directives can be used to include or exclude sequences of tokens and can in that way affect the meaning of a C# program.
 
@@ -1506,6 +1508,40 @@ A `#line default` directive undoes the effect of all preceding `#line` directive
 A `#line hidden` directive has no effect on the compilation unit and line numbers reported in error messages, or produced by use of `CallerLineNumberAttribute` ([§22.5.6.2](attributes.md#22562-the-callerlinenumber-attribute)). It is intended to affect source-level debugging tools so that, when debugging, all lines between a `#line hidden` directive and the subsequent `#line` directive (that is not `#line hidden`) have no line number information, and are skipped entirely when stepping through code.
 
 > *Note*: Although a *PP_Compilation_Unit_Name* might contain text that looks like an escape sequence, such text is not an escape sequence; in this context a ‘`\`’ character simply designates an ordinary backslash character. *end note*
+
+### §Nullable-Directives Nullable directives
+
+Nullable directives control the nullable contexts (§Nullable-Contexts), as described below.
+
+```ANTLR
+fragment PP_Nullable
+    : PP_Whitespace? '#' PP_Whitespace? 'nullable' PP_Whitespace PP_Nullable_Action
+        (PP_Whitespace PP_Nullable_Target)? PP_New_Line
+    ;
+fragment PP_Nullable_Action
+    : 'disable'
+    | 'enable'
+    | 'restore'
+    ;
+fragment PP_Nullable_Target
+    : 'warnings'
+    | 'annotations'
+    ;
+```
+
+A nullable directive sets the denoted nullable context(s) for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The effect of each form of nullable directive is, as follows:
+
+- `#nullable disable`: Sets both nullable contexts to “disabled”
+- `#nullable enable`: Sets both nullable contexts to “enabled”
+- `#nullable restore`: Restores both nullable contexts to the states specified by the external mechanism, if any
+- `#nullable disable annotations`: Sets the nullable annotation context to “disabled”
+- `#nullable enable annotations`: Sets the nullable annotation context to “enabled”
+- `#nullable restore annotations`: Restores the nullable annotation context to the state specified by the external mechanism, if any
+- `#nullable disable warnings`: Sets the nullable warning context to “disabled”
+- `#nullable enable warnings`: Sets the nullable warning context to “enabled”
+- `#nullable restore warnings`: Restores the nullable warning context to the state specified by the external mechanism, if any
+
+Disabling a nullable context that is already disabled has no effect. Likewise, enabling a nullable context that is already enabled has no effect.
 
 ### 6.5.9 Pragma directives
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1509,9 +1509,9 @@ A `#line hidden` directive has no effect on the compilation unit and line number
 
 > *Note*: Although a *PP_Compilation_Unit_Name* might contain text that looks like an escape sequence, such text is not an escape sequence; in this context a ‘`\`’ character simply designates an ordinary backslash character. *end note*
 
-### §Nullable-Directives Nullable directives
+### §Nullable-Directives Nullable directive
 
-Nullable directives control the nullable contexts, as described below.
+The nullable directive controls the nullable context, as described below.
 
 ```ANTLR
 fragment PP_Nullable
@@ -1529,19 +1529,19 @@ fragment PP_Nullable_Target
     ;
 ```
 
-A nullable directive sets the denoted nullable context(s) for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The effect of each form of nullable directive is, as follows:
+A nullable directive sets the denoted nullable context for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The effect of each form of nullable directive is, as follows:
 
-- `#nullable disable`: Sets both nullable contexts to “disabled”
-- `#nullable enable`: Sets both nullable contexts to “enabled”
-- `#nullable restore`: Restores both nullable contexts to the states specified by the external mechanism, if any
-- `#nullable disable annotations`: Sets the nullable annotation context to “disabled”
-- `#nullable enable annotations`: Sets the nullable annotation context to “enabled”
-- `#nullable restore annotations`: Restores the nullable annotation context to the state specified by the external mechanism, if any
-- `#nullable disable warnings`: Sets the nullable warning context to “disabled”
-- `#nullable enable warnings`: Sets the nullable warning context to “enabled”
-- `#nullable restore warnings`: Restores the nullable warning context to the state specified by the external mechanism, if any
+- `#nullable disable`: Sets the nullable context to “disabled”.
+- `#nullable enable`: Sets the nullable context to “enabled”.
+- `#nullable restore`: Restores the nullable context to the state specified by the external mechanism, if any.
+- `#nullable disable annotations`: Disables nullable annotations. Nullable warnings are unaffected.
+- `#nullable enable annotations`: Enables nullable annotations. Nullable warnings are unaffected.
+- `#nullable restore annotations`: Restores nullable annotations to the state specified by the external mechanism, if any. Warnings are unaffected.
+- `#nullable disable warnings`: Disables nullable warnings. Nullable annotations are unaffected.
+- `#nullable enable warnings`: Enables nullable warnings. Nullable annotations are unaffected.
+- `#nullable restore warnings`: Restores nullable warnings to the state specified by the external mechanism, if any. Nullable annotations are unaffected.
 
-Disabling a nullable context that is already disabled has no effect. Likewise, enabling a nullable context that is already enabled has no effect.
+Disabling the nullable context when it is already disabled has no effect. Likewise, enabling the nullable context when it is already enabled has no effect.
 
 ### 6.5.9 Pragma directives
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1545,7 +1545,7 @@ The nullable state of expressions is tracked at all times. The state of the anno
 
 > *Example*: The example
 >
-> <!-- Example: {template:"standalone-console", name:"InitialWarning", ignoredWarnings:["CS8602"], expectedException:"NullReferenceException"}} -->
+> <!-- Example: {template:"standalone-console", name:"InitialWarning", ignoredWarnings:["CS8602"], expectedException:"NullReferenceException"} -->
 > ```csharp
 > #nullable disable
 > string x = null;

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1529,7 +1529,7 @@ fragment PP_Nullable_Target
     ;
 ```
 
-A nullable directive sets the available flags for subsequent lines of code, until another nullable directive overrides it, or until the end of the source code is reached. The nullable context contains two flags: *annotations* and *warnings*. The effect of each form of nullable directive is, as follows:
+A nullable directive sets the available flags for subsequent lines of code, until another nullable directive overrides it, or until the end of the *compilation _unit* is reached. The nullable context contains two flags: *annotations* and *warnings*. The effect of each form of nullable directive is, as follows:
 
 - `#nullable disable`: Disables both nullable annotations and nullable warnings flags.
 - `#nullable enable`: Enables both nullable annotations and nullable warnings flags.

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1511,7 +1511,7 @@ A `#line hidden` directive has no effect on the compilation unit and line number
 
 ### §Nullable-Directives Nullable directives
 
-Nullable directives control the nullable contexts (§Nullable-Contexts), as described below.
+Nullable directives control the nullable contexts, as described below.
 
 ```ANTLR
 fragment PP_Nullable

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -1541,7 +1541,7 @@ A nullable directive sets the available flags for subsequent lines of code, unti
 - `#nullable enable warnings`: Enables the nullable warnings flag. The nullable annotations flag is unaffected.
 - `#nullable restore warnings`: Restores the nullable warnings flag to the state specified by the external mechanism, if any. The nullable annotations flag is unaffected.
 
-The nullable state of expressions is tracked at all times. The state of the annotation flag determines the initial null state of a variable declaration. Warnings are only issued when the warnings flag is enabled.
+The nullable state of expressions is tracked at all times. The state of the annotation flag and the presence or absence of a nullable annotation, `?`, determines the initial null state of a variable declaration. Warnings are only issued when the warnings flag is enabled.
 
 > *Example*: The example
 >
@@ -1555,7 +1555,7 @@ The nullable state of expressions is tracked at all times. The state of the anno
 > Console.WriteLine(y.Length);
 > ```
 >
-> produces a compile-time warning (“dereference of a possible null reference”). The nullable state of `x` is tracked everywhere. A warning is issued when the warnings flag is enabled.
+> produces a compile-time warning (“as `x` is `null`”). The nullable state of `x` is tracked everywhere. A warning is issued when the warnings flag is enabled.
 >
 > *end example*
 

--- a/tools/example-templates/standalone-console/Project.csproj
+++ b/tools/example-templates/standalone-console/Project.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>annotations</Nullable>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>


### PR DESCRIPTION
Fixes #1088 

Alternative PR to #1108

This branch builds on the work in #1108. This is an alternative approach that defines a single `nullable` context. The nullable context has two properties: `annotations` and `warnings` that can be enabled or disabled separately.