### PR TITLE
Update dependencies, plus merge fix

### DIFF
--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -50,7 +50,7 @@ jobs:
       id: renumber-sections
       run: |
         cd tools
-        ./run-section-renumber.sh
+        ./run-section-renumber-update.sh
       shell: bash
 
     - name: Create pull request

--- a/tools/ExampleTester/ExampleTester.csproj
+++ b/tools/ExampleTester/ExampleTester.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/tools/MarkdownConverter/MarkdownConverter.csproj
+++ b/tools/MarkdownConverter/MarkdownConverter.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="csharp2colorized" Version="1.0.3" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.1" />
-    <PackageReference Include="FSharp.Core" Version="8.0.101" />
-    <PackageReference Include="FSharp.Formatting" Version="19.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="FSharp.Core" Version="8.0.300" />
+    <PackageReference Include="FSharp.Formatting" Version="20.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.10.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/Utilities/Utilities.csproj
+++ b/tools/Utilities/Utilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="11.0.1" />
+    <PackageReference Include="Octokit" Version="12.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 

--- a/tools/run-section-renumber-update.sh
+++ b/tools/run-section-renumber-update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+declare -r PROJECT=StandardAnchorTags
+
+dotnet run --project $PROJECT -- --owner dotnet --repo csharpstandard
+
+if [ -n "$GITHUB_OUTPUT" ]
+then
+    echo "status=success" >> $GITHUB_OUTPUT 
+fi


### PR DESCRIPTION
Two distinct changes here.

First, update all dependencies. Dependabot should have updated these, but that PR is failing the build. It appears that some updates weren't correctly applied.

Second, a quick work-around for the "update on merge" action so that it runs correctly. It's block, so I just copied the shell script and made mods. I'll take a bit longer to create a single script that reports errors and warnings correctly when the actions run not as part of a PR validation. I need to do some research there, and this is blocking us.