### PR TITLE
Improve `attribute_argument` grammar

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -209,8 +209,8 @@ attribute_name
     ;
 
 attribute_arguments
-    : '(' positional_argument_list? ')'
-    | '(' positional_argument_list ',' named_argument_list ')'
+    : '(' ')'
+    | '(' positional_argument_list (',' named_argument_list)? ')'
     | '(' named_argument_list ')'
     ;
 
@@ -231,7 +231,7 @@ named_argument
     ;
 
 attribute_argument_expression
-    : expression
+    : non_assignment_expression
     ;
 ```
 


### PR DESCRIPTION
- Change `attribute_argument_expression` to be `non_assignment_expression` instead of just `expression`. This causes the three alternatives in `attribute_argument` to be distinguishable rather than all accepting the same sentences (based on syntax only). This is sufficient for ANTLR to recognise both `named_argument` and `positional_argument`, rather than just the latter as with the original grammar.
- Restructure `attribute_argument` so it is both more readable, which is nice, and LL(3) rather and LL(N), which helps out ANTLR.

Neither change is *required* for a compiler to be able to distinguish the argument kinds using the semantic rules – other parsing approaches (non-LL) wouldn't struggle with the grammar as was; hand-written parsers, such as Roslyn’s, could
also obviously cope as they can just rewrite the grammar as they see fit! However the first change improves the ANTLR parse tree significantly, the second just makes things nicer for people and ANTLR alike :-)