### PR TITLE
Update quest-config.json

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -5,5 +5,12 @@
         "AreaPath": "Production\\Digital and App Innovation\\DotNet and more\\dotnet"
     },
     "ImportTriggerLabel": "reQUEST",
-    "ImportedLabel": "seQUESTered"
+    "ImportedLabel": "seQUESTered",
+    "DefaultParentNode": 227484,
+    "WorkItemTags": [
+        {
+            "Label": ":label: content-curation",
+            "Tag": "content-curation"
+        }
+    ]
 }


### PR DESCRIPTION
- Add the content curation tag for quest items.
- Set the default parent node to C# work item

The actual github label used to trigger the quest tag is something you can change. I used `🏷️ content-curation` but feel free to edit this PR to change it to what you want.

You'll need to add this label to this repo and then use it for curation items.