### PR TITLE
Update quest-config.json

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -6,11 +6,5 @@
     },
     "ImportTriggerLabel": "reQUEST",
     "ImportedLabel": "seQUESTered",
-    "DefaultParentNode": 227484,
-    "WorkItemTags": [
-        {
-            "Label": ":label: content-curation",
-            "Tag": "content-curation"
-        }
-    ]
+    "DefaultParentNode": 227484
 }


### PR DESCRIPTION
After reviewing the purpose of the curation tag/parent, it doesn't really apply in this repo. The default parent still applies.