### PR TITLE
Consolidate parameter-kinds text w.r.t Variables and Classes clauses

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2192,7 +2192,7 @@ The following kinds of parameters exist:
 - Input parameters ([§15.6.2.3.2](classes.md#156232-input-parameters)).
 - Output parameters ([§15.6.2.3.4](classes.md#156234-output-parameters)).
 - Reference parameters ([§15.6.2.3.3](classes.md#156233-reference-parameters)).
-- Parameter arrays ([§15.6.2.](classes.md#15624-parameter-arrays)).
+- Parameter arrays ([§15.6.2.4](classes.md#15624-parameter-arrays)).
 
 > *Note*: As described in [§7.6](basic-concepts.md#76-signatures-and-overloading), the `in`, `out`, and `ref` modifiers are part of a method’s signature, but the `params` modifier is not. *end note*
 
@@ -2222,7 +2222,7 @@ In a method that takes multiple by-reference parameters, it is possible for mult
 
 ##### 15.6.2.3.2 Input parameters
 
-A parameter declared with an `in` modifier is an ***input parameter***. The argument corresponding to an `in` parameter is either a variable existing at the point of the method invocation, or one created by the implementation ([§12.6.2.3](expressions.md#12623-run-time-evaluation-of-argument-lists)) in the method invocation. For definite-assignment rules, see [§9.2.8](variables.md#928-input-parameters).
+A parameter declared with an `in` modifier is an ***input parameter***. The argument corresponding to an input parameter is either a variable existing at the point of the method invocation, or one created by the implementation ([§12.6.2.3](expressions.md#12623-run-time-evaluation-of-argument-lists)) in the method invocation. For definite-assignment rules, see [§9.2.8](variables.md#928-input-parameters).
 
 It is a compile-time error to modify the value of an input parameter.
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2188,19 +2188,21 @@ A method invocation ([§12.8.9.2](expressions.md#12892-method-invocations)) crea
 
 The following kinds of parameters exist:
 
-- Value parameters, which are declared without any modifiers.
-- Input parameters, which are declared with the `in` modifier.
-- Output parameters, which are declared with the `out` modifier.
-- Reference parameters, which are declared with the `ref` modifier.
-- Parameter arrays, which are declared with the `params` modifier.
+- Value parameters ([§15.6.2.2](classes.md#15622-value-parameters)).
+- Input parameters ([§15.6.2.3.2](classes.md#156232-input-parameters)).
+- Output parameters ([§15.6.2.3.4](classes.md#156234-output-parameters)).
+- Reference parameters ([§15.6.2.3.3](classes.md#156233-reference-parameters)).
+- Parameter arrays ([§15.6.2.](classes.md#15624-parameter-arrays)).
 
 > *Note*: As described in [§7.6](basic-concepts.md#76-signatures-and-overloading), the `in`, `out`, and `ref` modifiers are part of a method’s signature, but the `params` modifier is not. *end note*
 
 #### 15.6.2.2 Value parameters
 
-A parameter declared with no modifiers is a value parameter. A value parameter is a local variable that gets its initial value from the corresponding argument supplied in the method invocation.
+A parameter declared with no modifiers is a ***value parameter***. A value parameter is a local variable that gets its initial value from the corresponding argument supplied in the method invocation.
 
-When a parameter is a value parameter, the corresponding argument in a method invocation shall be an expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the parameter type.
+For definite-assignment rules, see [§9.2.5](variables.md#925-value-parameters).
+
+The corresponding argument in a method invocation shall be an expression that is implicitly convertible ([§10.2](conversions.md#102-implicit-conversions)) to the parameter type.
 
 A method is permitted to assign new values to a value parameter. Such assignments only affect the local storage location represented by the value parameter—they have no effect on the actual argument given in the method invocation.
 
@@ -2220,7 +2222,7 @@ In a method that takes multiple by-reference parameters, it is possible for mult
 
 ##### 15.6.2.3.2 Input parameters
 
-A parameter declared with an `in` modifier is a input parameter. The argument corresponding to an `in` parameter is either a variable existing at the point of the method invocation, or one created by the implementation ([§12.6.2.3](expressions.md#12623-run-time-evaluation-of-argument-lists)) in the method invocation. A variable shall be definitely assigned before it can be passed as an argument for an input parameter. Within a method, an input parameter is always considered definitely assigned.
+A parameter declared with an `in` modifier is an ***input parameter***. The argument corresponding to an `in` parameter is either a variable existing at the point of the method invocation, or one created by the implementation ([§12.6.2.3](expressions.md#12623-run-time-evaluation-of-argument-lists)) in the method invocation. For definite-assignment rules, see [§9.2.8](variables.md#928-input-parameters).
 
 It is a compile-time error to modify the value of an input parameter.
 
@@ -2228,7 +2230,7 @@ It is a compile-time error to modify the value of an input parameter.
 
 ##### 15.6.2.3.3 Reference parameters
 
-A parameter declared with a `ref` modifier is a reference parameter. A variable shall be definitely assigned before it can be passed as an argument for a reference parameter. Within a method, a reference parameter is always considered definitely assigned.
+A parameter declared with a `ref` modifier is a ***reference parameter***. For definite-assignment rules, see [§9.2.6](variables.md#926-reference-parameters).
 
 > *Example*: The example
 >
@@ -2289,9 +2291,11 @@ A parameter declared with a `ref` modifier is a reference parameter. A variable 
 >
 > *end example*
 
+For a `struct` type, within an instance method, instance accessor ([§12.2.1](expressions.md#1221-general)), or instance constructor with a constructor initializer, the `this` keyword behaves exactly as a reference parameter of the struct type ([§12.8.13](expressions.md#12813-this-access)).
+
 ##### 15.6.2.3.4 Output parameters
 
-A parameter declared with an `out` modifier is an output parameter. Within a method, just like a local variable, an output parameter is initially considered unassigned and shall be definitely assigned before its value is used. Every output parameter of a method shall be definitely assigned before the method returns.
+A parameter declared with an `out` modifier is an ***output parameter***. For definite-assignment rules, see [§9.2.7](variables.md#927-output-parameters).
 
 A method declared as a partial method ([§15.6.9](classes.md#1569-partial-methods)) shall not have output parameters.
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -71,15 +71,13 @@ For the purpose of definite-assignment checking, an array element is considered 
 
 ### 9.2.5 Value parameters
 
-A parameter declared without an `in`, `out`, or `ref` modifier is a ***value parameter***.
-
 A value parameter comes into existence upon invocation of the function member (method, instance constructor, accessor, or operator) or anonymous function to which the parameter belongs, and is initialized with the value of the argument given in the invocation. A value parameter normally ceases to exist when execution of the function body completes. However, if the value parameter is captured by an anonymous function ([§12.19.6.2](expressions.md#121962-captured-outer-variables)), its lifetime extends at least until the delegate or expression tree created from that anonymous function is eligible for garbage collection.
 
 For the purpose of definite-assignment checking, a value parameter is considered initially assigned.
 
-### 9.2.6 Reference parameters
+Value parameters are discussed further in [§15.6.2.2](classes.md#15622-value-parameters).
 
-A parameter declared with a `ref` modifier is a ***reference parameter***.
+### 9.2.6 Reference parameters
 
 A reference parameter is a reference variable ([§9.7](variables.md#97-reference-variables-and-returns)) which comes into existence upon invocation of the function member, delegate, anonymous function, or local function and its referent is initialized to the variable given as the argument in that invocation. A reference parameter ceases to exist when execution of the function body completes. Unlike value parameters a reference parameter shall not be captured ([§9.7.2.9](variables.md#9729-limitations-on-reference-variables)).
 
@@ -90,11 +88,9 @@ The following definite-assignment rules apply to reference parameters.
 - A variable shall be definitely assigned ([§9.4](variables.md#94-definite-assignment)) before it can be passed as a reference parameter in a function member or delegate invocation.
 - Within a function member or anonymous function, a reference parameter is considered initially assigned.
 
-For a `struct` type, within an instance method or instance accessor ([§12.2.1](expressions.md#1221-general)) or instance constructor with a constructor initializer, the `this` keyword behaves exactly as a reference parameter of the struct type ([§12.8.13](expressions.md#12813-this-access)).
+Reference parameters are discussed further in [§15.6.2.3.3](classes.md#156233-reference-parameters).
 
 ### 9.2.7 Output parameters
-
-A parameter declared with an `out` modifier is an ***output parameter***.
 
 An output parameter is a reference variable ([§9.7](variables.md#97-reference-variables-and-returns)) which comes into existence upon invocation of the function member, delegate, anonymous function, or local function and its referent is initialized to the variable given as the argument in that invocation. An output parameter ceases to exist when execution of the function body completes. Unlike value parameters an output parameter shall not be captured ([§9.7.2.9](variables.md#9729-limitations-on-reference-variables)).
 
@@ -107,9 +103,9 @@ The following definite-assignment rules apply to output parameters.
 - Within a function member or anonymous function, an output parameter is considered initially unassigned.
 - Every output parameter of a function member, anonymous function, or local function shall be definitely assigned ([§9.4](variables.md#94-definite-assignment)) before the function member, anonymous function, or local function returns normally.
 
-### 9.2.8 Input parameters
+Output parameters are discussed further in [§15.6.2.3.4](classes.md#156234-output-parameters)).
 
-A parameter declared with an `in` modifier is an ***input parameter***.
+### 9.2.8 Input parameters
 
 An input parameter is a reference variable ([§9.7](variables.md#97-reference-variables-and-returns)) which comes into existence upon invocation of the function member, delegate, anonymous function, or local function and its referent is initialized to the *variable_reference* given as the argument in that invocation. An input parameter ceases to exist when execution of the function body completes. Unlike value parameters an input parameter shall not be captured ([§9.7.2.9](variables.md#9729-limitations-on-reference-variables)).
 
@@ -117,6 +113,8 @@ The following definite assignment rules apply to input parameters.
 
 - A variable shall be definitely assigned ([§9.4](variables.md#94-definite-assignment)) before it can be passed as an input parameter in a function member or delegate invocation.
 - Within a function member, anonymous function, or local function an input parameter is considered initially assigned.
+
+Input parameters are discussed further in [§15.6.2.3.2](classes.md#156232-input-parameters).
 
 ### 9.2.9 Local variables
 
@@ -1081,8 +1079,8 @@ There are three ref-safe-contexts:
 
 - ***function-member***: Within a function a *variable_reference* to any of the following has a ref-safe-context of function-member:
 
-  - Value parameters ([§9.2.5](variables.md#925-value-parameters)) on a function member declaration, including the implicit `this` of class member functions; and
-  - The implicit reference (`ref`) parameter ([§9.2.6](variables.md#926-reference-parameters)) `this` of a struct member function, along with its fields.
+  - Value parameters ([§15.6.2.2](classes.md#15622-value-parameters)) on a function member declaration, including the implicit `this` of class member functions; and
+  - The implicit reference (`ref`) parameter ([§15.6.2.3.3](classes.md#156233-reference-parameters)) `this` of a struct member function, along with its fields.
 
    A *variable_reference* with ref-safe-context of function-member is a valid referent only if the reference variable is declared in the same function member.
 

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -103,7 +103,7 @@ The following definite-assignment rules apply to output parameters.
 - Within a function member or anonymous function, an output parameter is considered initially unassigned.
 - Every output parameter of a function member, anonymous function, or local function shall be definitely assigned ([§9.4](variables.md#94-definite-assignment)) before the function member, anonymous function, or local function returns normally.
 
-Output parameters are discussed further in [§15.6.2.3.4](classes.md#156234-output-parameters)).
+Output parameters are discussed further in [§15.6.2.3.4](classes.md#156234-output-parameters).
 
 ### 9.2.8 Input parameters
 


### PR DESCRIPTION
Instead of starting with only one of the 4 parameter kinds, the solution was found to be much simpler than first thought, so I addressed all 4.

This PR address all the concerns of Issue #1160.

1. Variables subclauses 9.x cover lifetime, (sometimes) initialization, and definite assignment. All other text was moved to the Classes 15.x counterpart places with forward pointers to them, including the definitions of the terms value/input/output/reference parameters.
2.  Classes subclauses 15.x now point back to their 9.x counterpart places w.r.t definite assignment.
3. Various links were updated due to the 9.x-->15.x move.
