### PR TITLE
enhance trace-back message when exception thrown by StandardAnchorTags tool

### DIFF
--- a/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
+++ b/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
@@ -124,7 +124,7 @@ internal class ReferenceUpdateProcessor
 
         // Start and the end of the range, look for "](", then ']'. 
         int endIndex = range.End.Value;
-        if (line.Substring(endIndex, 2) != "](") throw new InvalidOperationException("Unexpected link text");
+        if (line.Substring(endIndex, 2) != "](") throw new InvalidOperationException($"Unexpected link text >{line.Substring(endIndex, 2)}< in line >{line}<");
 
         endIndex += 2;
         while (line[endIndex] != ')') endIndex++;


### PR DESCRIPTION
Now displays the source line and the text that could not be found there.