### PR TITLE
Add status checks to the test runner

### DIFF
--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      pull-requests: write
     env:
       DOTNET_NOLOGO: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -16,8 +16,13 @@ on:
 jobs:
   test-extraction-and-runner:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     env:
       DOTNET_NOLOGO: true
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
     - name: Check out our repo

--- a/.github/workflows/word-converter.yaml
+++ b/.github/workflows/word-converter.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      pull-requests: write
     env:
       DOTNET_NOLOGO: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,6 @@ test-grammar/
 
 # don't checkin jar files:
 *.jar
+
+# don't checkin launchSettings:
+**/launchSettings.json

--- a/tools/ExampleTester/ExampleTester.csproj
+++ b/tools/ExampleTester/ExampleTester.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ExampleExtractor\ExampleExtractor.csproj" />
+    <ProjectReference Include="..\Utilities\Utilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/ExampleTester/GeneratedExample.cs
+++ b/tools/ExampleTester/GeneratedExample.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 using Newtonsoft.Json;
 using System.Reflection;
 using System.Text;
+using Utilities;
 
 namespace ExampleTester;
 
@@ -33,9 +34,9 @@ internal class GeneratedExample
         return new GeneratedExample(directory);
     }
 
-    internal async Task<bool> Test(TesterConfiguration configuration)
+    internal async Task<bool> Test(TesterConfiguration configuration, StatusCheckLogger logger)
     {
-        var outputLines = new List<string> { $"Testing {Metadata.Name} from {Metadata.Source}" };
+        logger.ConsoleOnlyLog(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"Testing {Metadata.Name} from {Metadata.Source}", "ExampleTester"));
 
         // Explicitly do a release build, to avoid implicitly defining DEBUG.
         var properties = new Dictionary<string, string> { { "Configuration", "Release" } };
@@ -52,21 +53,16 @@ internal class GeneratedExample
         }
 
         bool ret = true;
-        ret &= ValidateDiagnostics("errors", DiagnosticSeverity.Error, Metadata.ExpectedErrors);
-        ret &= ValidateDiagnostics("warnings", DiagnosticSeverity.Warning, Metadata.ExpectedWarnings, Metadata.IgnoredWarnings);
+        ret &= ValidateDiagnostics("errors", DiagnosticSeverity.Error, Metadata.ExpectedErrors, logger);
+        ret &= ValidateDiagnostics("warnings", DiagnosticSeverity.Warning, Metadata.ExpectedWarnings, logger, Metadata.IgnoredWarnings);
         // Don't try to validate output if we've already failed in terms of errors and warnings, or if we expect errors.
         if (ret && Metadata.ExpectedErrors is null)
         {
             ret &= ValidateOutput();
         }
-
-        if (!ret || !configuration.Quiet)
-        {
-            outputLines.ForEach(Console.WriteLine);
-        }
         return ret;
 
-        bool ValidateDiagnostics(string type, DiagnosticSeverity severity, List<string> expected, List<string>? ignored = null)
+        bool ValidateDiagnostics(string type, DiagnosticSeverity severity, List<string> expected, StatusCheckLogger logger, List<string>? ignored = null)
         {
             expected ??= new List<string>();
             ignored ??= new List<string>();
@@ -81,10 +77,12 @@ internal class GeneratedExample
             bool ret = ValidateExpectedAgainstActual(type, expected, actualIds);
             if (!ret)
             {
-                outputLines.Add($"  Details of actual {type}:");
+                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Details of actual {type}:", "ExampleTester"));
                 foreach (var diagnostic in actualDiagnostics)
                 {
-                    outputLines.Add($"    Line {diagnostic.Location.GetLineSpan().StartLinePosition.Line + 1}: {diagnostic.Id}: {diagnostic.GetMessage()}");
+                    logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine,
+                        $"    Line {diagnostic.Location.GetLineSpan().StartLinePosition.Line + 1}: {diagnostic.Id}: {diagnostic.GetMessage()}",
+                        "ExampleTester"));
                 }
             }
             return ret;
@@ -97,7 +95,7 @@ internal class GeneratedExample
             {
                 if (Metadata.ExpectedOutput != null)
                 {
-                    outputLines.Add("  Output expected, but project has no entry point.");
+                    logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, "  Output expected, but project has no entry point.", "ExampleTester"));
                     return false;
                 }
                 return true;
@@ -114,7 +112,7 @@ internal class GeneratedExample
             var emitResult = compilation.Emit(ms);
             if (!emitResult.Success)
             {
-                outputLines.Add("  Failed to emit assembly");
+                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, "  Failed to emit assembly", "ExampleTester"));
                 return false;
             }
 
@@ -122,13 +120,13 @@ internal class GeneratedExample
             var type = generatedAssembly.GetType(typeName);
             if (type is null)
             {
-                outputLines.Add($"  Failed to find entry point type {typeName}");
+                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Failed to find entry point type {typeName}", "ExampleTester"));
                 return false;
             }
             var method = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (method is null)
             {
-                outputLines.Add($"  Failed to find entry point method {typeName}.{methodName}");
+                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Failed to find entry point method {typeName}.{methodName}", "ExampleTester"));
                 return false;
             }
             var arguments = method.GetParameters().Any()
@@ -197,7 +195,7 @@ internal class GeneratedExample
             {
                 if (!result)
                 {
-                    outputLines.Add(message);
+                    logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, message, "ExampleTester"));
                 }
                 return result;
             }
@@ -207,7 +205,8 @@ internal class GeneratedExample
         {
             if (!expected.SequenceEqual(actual))
             {
-                outputLines.Add($"  Mismatched {type}: Expected {string.Join(", ", expected)}; Was {string.Join(", ", actual)}");
+                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine,
+                    $"  Mismatched {type}: Expected {string.Join(", ", expected)}; Was {string.Join(", ", actual)}", "ExampleTester"));
                 return false;
             }
             return true;

--- a/tools/ExampleTester/GeneratedExample.cs
+++ b/tools/ExampleTester/GeneratedExample.cs
@@ -36,7 +36,7 @@ internal class GeneratedExample
 
     internal async Task<bool> Test(TesterConfiguration configuration, StatusCheckLogger logger)
     {
-        logger.ConsoleOnlyLog(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"Testing {Metadata.Name} from {Metadata.Source}", "ExampleTester"));
+        logger.ConsoleOnlyLog(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"Testing {Metadata.Name} from {Metadata.Source}", "ExampleTester");
 
         // Explicitly do a release build, to avoid implicitly defining DEBUG.
         var properties = new Dictionary<string, string> { { "Configuration", "Release" } };
@@ -77,12 +77,12 @@ internal class GeneratedExample
             bool ret = ValidateExpectedAgainstActual(type, expected, actualIds);
             if (!ret)
             {
-                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Details of actual {type}:", "ExampleTester"));
+                logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Details of actual {type}:", "ExampleTester");
                 foreach (var diagnostic in actualDiagnostics)
                 {
-                    logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine,
+                    logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine,
                         $"    Line {diagnostic.Location.GetLineSpan().StartLinePosition.Line + 1}: {diagnostic.Id}: {diagnostic.GetMessage()}",
-                        "ExampleTester"));
+                        "ExampleTester");
                 }
             }
             return ret;
@@ -95,7 +95,7 @@ internal class GeneratedExample
             {
                 if (Metadata.ExpectedOutput != null)
                 {
-                    logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, "  Output expected, but project has no entry point.", "ExampleTester"));
+                    logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine, "  Output expected, but project has no entry point.", "ExampleTester");
                     return false;
                 }
                 return true;
@@ -112,7 +112,7 @@ internal class GeneratedExample
             var emitResult = compilation.Emit(ms);
             if (!emitResult.Success)
             {
-                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, "  Failed to emit assembly", "ExampleTester"));
+                logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine, "  Failed to emit assembly", "ExampleTester");
                 return false;
             }
 
@@ -120,13 +120,13 @@ internal class GeneratedExample
             var type = generatedAssembly.GetType(typeName);
             if (type is null)
             {
-                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Failed to find entry point type {typeName}", "ExampleTester"));
+                logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Failed to find entry point type {typeName}", "ExampleTester");
                 return false;
             }
             var method = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (method is null)
             {
-                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Failed to find entry point method {typeName}.{methodName}", "ExampleTester"));
+                logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine, $"  Failed to find entry point method {typeName}.{methodName}", "ExampleTester");
                 return false;
             }
             var arguments = method.GetParameters().Any()
@@ -195,7 +195,7 @@ internal class GeneratedExample
             {
                 if (!result)
                 {
-                    logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine, message, "ExampleTester"));
+                    logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine, message, "ExampleTester");
                 }
                 return result;
             }
@@ -205,8 +205,8 @@ internal class GeneratedExample
         {
             if (!expected.SequenceEqual(actual))
             {
-                logger.LogFailure(new StatusCheckMessage(Metadata.Source, Metadata.StartLine, Metadata.EndLine,
-                    $"  Mismatched {type}: Expected {string.Join(", ", expected)}; Was {string.Join(", ", actual)}", "ExampleTester"));
+                logger.LogFailure(Metadata.Source, Metadata.StartLine, Metadata.EndLine,
+                    $"  Mismatched {type}: Expected {string.Join(", ", expected)}; Was {string.Join(", ", actual)}", "ExampleTester");
                 return false;
             }
             return true;

--- a/tools/MarkdownConverter/Spec/Reporter.cs
+++ b/tools/MarkdownConverter/Spec/Reporter.cs
@@ -59,14 +59,14 @@ public class Reporter
     {
         loc = loc ?? Location;
         IncrementErrors();
-        githubLogger.LogFailure(new Diagnostic(loc.File ?? "mdspec2docx", loc.StartLine, loc.EndLine, msg, code));
+        githubLogger.LogFailure(new StatusCheckMessage(loc.File ?? "mdspec2docx", loc.StartLine, loc.EndLine, msg, code));
     }
 
     public void Warning(string code, string msg, SourceLocation? loc = null, int lineOffset = 0)
     {
         loc = loc ?? Location;
         IncrementWarnings();
-        githubLogger.LogWarning(new Diagnostic(loc.File ?? "mdspec2docx", loc.StartLine+lineOffset, loc.EndLine+lineOffset, msg, code));
+        githubLogger.LogWarning(new StatusCheckMessage(loc.File ?? "mdspec2docx", loc.StartLine+lineOffset, loc.EndLine+lineOffset, msg, code));
     }
 
     public void Log(string code, string msg, SourceLocation? loc = null)

--- a/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
+++ b/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
@@ -62,7 +62,7 @@ internal class ReferenceUpdateProcessor
             if ((referenceText.Length > 1) &&
                 (!linkMap.ContainsKey(referenceText)))
             {
-                var diagnostic = new Diagnostic(path, lineNumber, lineNumber, $"`{referenceText}` not found", DiagnosticIDs.TOC002);
+                var diagnostic = new StatusCheckMessage(path, lineNumber, lineNumber, $"`{referenceText}` not found", DiagnosticIDs.TOC002);
                 logger.LogFailure(diagnostic);
             } else
             {

--- a/tools/StandardAnchorTags/TocSectionNumberBuilder.cs
+++ b/tools/StandardAnchorTags/TocSectionNumberBuilder.cs
@@ -69,7 +69,7 @@ public class TocSectionNumberBuilder
             return;
         }
         // Getting here means this file doesn't have an H1. That's an error:
-        var diagnostic = new Diagnostic(path, 1, 1, "File doesn't have an H1 tag as its first line.", DiagnosticIDs.TOC001);
+        var diagnostic = new StatusCheckMessage(path, 1, 1, "File doesn't have an H1 tag as its first line.", DiagnosticIDs.TOC001);
         logger.LogFailure(diagnostic);
     }
 

--- a/tools/Utilities/StatusCheckLogger.cs
+++ b/tools/Utilities/StatusCheckLogger.cs
@@ -43,11 +43,6 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
     public void ConsoleOnlyLog(StatusCheckMessage d)
     {
         WriteMessageToConsole("", d);
-        annotations.Add(
-            new(FormatPath(d.file),
-            d.StartLine, d.EndLine,
-            CheckAnnotationLevel.Notice, $"{d.Id}::{d.Message}")
-        );
     }
 
     /// <summary>

--- a/tools/Utilities/StatusCheckLogger.cs
+++ b/tools/Utilities/StatusCheckLogger.cs
@@ -40,10 +40,8 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
     /// Log the diagnostic information to console. These will only appear in the console window, not
     /// as annotations on the changes in the PR. 
     /// </remarks>
-    public void ConsoleOnlyLog(StatusCheckMessage d)
-    {
+    public void ConsoleOnlyLog(StatusCheckMessage d) =>
         WriteMessageToConsole("", d);
-    }
 
     /// <summary>
     /// Log a notice from the status check

--- a/tools/Utilities/StatusCheckLogger.cs
+++ b/tools/Utilities/StatusCheckLogger.cs
@@ -35,12 +35,27 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
     /// <summary>
     /// Log a notice from the status check to the console only
     /// </summary>
+    /// <param name="source">source file</param>
+    /// <param name="startLine">start line</param>
+    /// <param name="endLine">end line</param>
+    /// <param name="message">The error message</param>
+    /// <param name="id">The error ID</param>
+    /// <remarks>
+    /// Log the diagnostic information to console. These will only appear in the console window, not
+    /// as annotations on the changes in the PR. 
+    /// </remarks>
+    public void ConsoleOnlyLog(string source, int startLine, int endLine, string message, string id) =>
+        ConsoleOnlyLog(source, new StatusCheckMessage(source, startLine, endLine, message, id));
+
+    /// <summary>
+    /// Log a notice from the status check to the console only
+    /// </summary>
     /// <param name="d">The diagnostic</param>
     /// <remarks>
     /// Log the diagnostic information to console. These will only appear in the console window, not
     /// as annotations on the changes in the PR. 
     /// </remarks>
-    public void ConsoleOnlyLog(StatusCheckMessage d) =>
+    public void ConsoleOnlyLog(string source, StatusCheckMessage d) =>
         WriteMessageToConsole("", d);
 
     /// <summary>
@@ -79,6 +94,18 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
             CheckAnnotationLevel.Warning, $"{d.Id}::{d.Message}")
         );
     }
+
+    /// <summary>
+    /// Log a failure from the status check
+    /// </summary>
+    /// <param name="source">The source file</param>
+    /// <param name="startLine">Start line in source</param>
+    /// <param name="endLine">End line in source</param>
+    /// <param name="message">The error message</param>
+    /// <param name="id">The string ID for the error</param>
+    public void LogFailure(string source, int startLine, int endLine, string message, string id) =>
+        LogFailure(new(source, startLine, endLine, message, id));
+
 
     /// <summary>
     /// Log a failure from the status check

--- a/tools/tools.sln
+++ b/tools/tools.sln
@@ -14,6 +14,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleExtractor", "ExampleExtractor\ExampleExtractor.csproj", "{571E69B9-07A3-4682-B692-876B016315CD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleTester", "ExampleTester\ExampleTester.csproj", "{829FE7D6-B7E7-48DF-923A-73A79921E997}"
+	ProjectSection(ProjectDependencies) = postProject
+		{835C6333-BDB5-4DEC-B3BE-4300E3F948AF} = {835C6333-BDB5-4DEC-B3BE-4300E3F948AF}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleFormatter", "ExampleFormatter\ExampleFormatter.csproj", "{82D1A159-5637-48C4-845D-CC1390995CC2}"
 EndProject


### PR DESCRIPTION
Contributes to #1125

Replace the existing logging code with the utility class that writes to the console, and adds a status check record.

Log failures as status checks, but status is only to the output console.