### PR TITLE
Add examples for nullability and null states

### DIFF
--- a/standard/types.md
+++ b/standard/types.md
@@ -863,8 +863,98 @@ The ***default null state*** of an expression is determined by its type, and the
 
 A diagnostic can be produced when a variable ([§9.2.1](variables.md#921-general)) of a non-nullable reference type is initialized or assigned to an expression that is maybe null when that variable is declared in text where the annotation flag is enabled.
 
+> *Example*: Consider the following method where a parameter is nullable and that value is assigned to a non-nullable type:
+>
+> <!-- Example: {template:"code-in-class-lib", name:"NullableAssignment"} -->
+> ```csharp
+> #nullable enable
+> public class C
+> {
+>     public void M(string? p)
+>     {
+>         // Assignment to maybe null
+>         string s = p;
+>     }
+> }
+> ```
+>
+> The compiler may issue a warning where the parameter that might be null is assigned to a variable that should not be null. If the parameter is null-checked before assignment, the compiler won't issue a warning:
+>
+> <!-- Example: {template:"code-in-class-lib", name:"NullChecked"} -->
+> ```csharp
+> #nullable enable
+> public class C
+> {
+>     public void M(string? p)
+>     {
+>         string s = p ?? ""; // null check
+>     }
+> }
+> ```
+>
+> *end example*
+
 The compiler can update the null state of a variable as part of its analysis.
 
-> *Note*: The compiler can treat a property ([§15.7](classes.md#157-properties)) as either a variable with state, or as independent get and set accessors ([§15.7.3](classes.md#1573-accessors)). In other words, a compiler can choose if writing to a property changes the null state of reading the property.
+> *Example*: The compiler may choose to update the state based on any statements in your program:
+>
+> <!-- Example: {template:"code-in-class-lib", name:"UpdateStates"} -->
+> ```csharp
+> #nullable enable
+> public void M(string? p)
+> {
+>     // p is maybe-null
+>     int length = p.Length;
+>
+>     // p is not null.
+>     string s = p;
+> 
+>     if (s != null)
+>     {
+>         int l2 = s.Length;
+>     }
+>     // s is maybe null
+>     int l3 = s.Length;
+> }
+> ```
+>
+> In the previous example, the compiler may decide that after the statement `int length = p.Length;`, the null-state of `p` is not-null. If it were null, that statement would have thrown a `NullReferenceException`. Later in the method, the code checks that `s` is not a null reference. The null-state of `s` can change to maybe null after the null-checked block closes. The compiler can infer that `s` is maybe null because the code was written to assume that it might have been null. *end example*
+<!-- markdownlint-disable MD028 -->
+
+<!-- markdownlint-enable MD028 -->
+> *Example*: The compiler can treat a property ([§15.7](classes.md#157-properties)) as either a variable with state, or as independent get and set accessors ([§15.7.3](classes.md#1573-accessors)). In other words, a compiler can choose if writing to a property changes the null state of reading the property, or if reading a property changes the null state of that property.
+>
+> <!-- Example: {template:"standalone-console", name:"VolatileFields", inferOutput:true} -->
+> ```csharp
+> class Test
+> {
+>     private string? _field;
+>     public string? DisappearingProperty
+>     {
+>         get
+>         {
+>                string tmp = _field;
+>                _field = null;
+>                return tmp;
+>         }
+>         set
+>         {
+>              _field = value;
+>         }
+>     }
+>
+>     static void Main()
+>     {
+>         var t = new Test();
+>         if (t.DisappearingProperty != null)
+>         {
+>             int len = t.DisappearingProperty.Length;
+>         }
+>     }
+> }
+>
+> ```
+>
+> In the previous example, the backing field for the `DisappearingProperty` is set to null when it is read. However, a compiler may assume that reading a property doesn't change the null state of that expression. *end example*
 
 ***End of conditionally normative text***

--- a/standard/types.md
+++ b/standard/types.md
@@ -924,7 +924,7 @@ The compiler can update the null state of a variable as part of its analysis.
 <!-- markdownlint-enable MD028 -->
 > *Example*: The compiler can treat a property ([§15.7](classes.md#157-properties)) as either a variable with state, or as independent get and set accessors ([§15.7.3](classes.md#1573-accessors)). In other words, a compiler can choose if writing to a property changes the null state of reading the property, or if reading a property changes the null state of that property.
 >
-> <!-- Example: {template:"standalone-console", name:"VolatileFields", inferOutput:true} -->
+> <!-- Example: {template:"standalone-console", name:"NullPropertyAnalysis"} -->
 > ```csharp
 > class Test
 > {
@@ -952,7 +952,6 @@ The compiler can update the null state of a variable as part of its analysis.
 >         }
 >     }
 > }
->
 > ```
 >
 > In the previous example, the backing field for the `DisappearingProperty` is set to null when it is read. However, a compiler may assume that reading a property doesn't change the null state of that expression. *end example*

--- a/standard/types.md
+++ b/standard/types.md
@@ -922,7 +922,9 @@ The compiler can update the null state of a variable as part of its analysis.
 > }
 > ```
 >
-> In the previous example, the compiler may decide that after the statement `int length = p.Length;`, the null-state of `p` is not-null. If it were null, that statement would have thrown a `NullReferenceException`. Later in the method, the code checks that `s` is not a null reference. The null-state of `s` can change to maybe null after the null-checked block closes. The compiler can infer that `s` is maybe null because the code was written to assume that it might have been null. *end example*
+> In the previous example, the compiler may decide that after the statement `int length = p.Length;`, the null-state of `p` is not-null. If it were null, that statement would have thrown a `NullReferenceException`. This is similar to the behavior if the code had been preceded by `if (p == null) throw NullReferenceException();` except that the code as written may produce a warning, the purpose of which is to warn that an exception may be thrown implicitly.
+
+Later in the method, the code checks that `s` is not a null reference. The null-state of `s` can change to maybe null after the null-checked block closes. The compiler can infer that `s` is maybe null because the code was written to assume that it might have been null. Generally, when the code contains a null check, the compiler may infer that the value might have been null.*end example*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->

--- a/standard/types.md
+++ b/standard/types.md
@@ -865,7 +865,7 @@ A diagnostic can be produced when a variable ([§9.2.1](variables.md#921-general
 
 > *Example*: Consider the following method where a parameter is nullable and that value is assigned to a non-nullable type:
 >
-> <!-- Example: {template:"code-in-class-lib", name:"NullableAssignment"} -->
+> <!-- Example: {template:"code-in-class-lib", name:"NullableAssignment", expectedErrors:["CS8600"]} -->
 > ```csharp
 > #nullable enable
 > public class C
@@ -898,7 +898,7 @@ The compiler can update the null state of a variable as part of its analysis.
 
 > *Example*: The compiler may choose to update the state based on any statements in your program:
 >
-> <!-- Example: {template:"code-in-class-lib", name:"UpdateStates"} -->
+> <!-- Example: {template:"code-in-class-lib", name:"UpdateStates", expectedErrors:["8602","CS8602"]} -->
 > ```csharp
 > #nullable enable
 > public void M(string? p)

--- a/standard/types.md
+++ b/standard/types.md
@@ -902,7 +902,7 @@ The compiler can update the null state of a variable as part of its analysis.
 
 > *Example*: The compiler may choose to update the state based on any statements in your program:
 >
-> <!-- Example: {template:"code-in-class-lib", name:"UpdateStates", expectedWarnings:["8602","CS8602"]} -->
+> <!-- Example: {template:"code-in-class-lib", name:"UpdateStates", expectedWarnings:["CS8602","CS8602"]} -->
 > ```csharp
 > #nullable enable
 > public void M(string? p)

--- a/standard/types.md
+++ b/standard/types.md
@@ -865,7 +865,7 @@ A diagnostic can be produced when a variable ([§9.2.1](variables.md#921-general
 
 > *Example*: Consider the following method where a parameter is nullable and that value is assigned to a non-nullable type:
 >
-> <!-- Example: {template:"code-in-class-lib", name:"NullableAssignment", expectedErrors:["CS8600"]} -->
+> <!-- Example: {template:"code-in-class-lib", name:"NullableAssignment", expectedWarnings:["CS8600"]} -->
 > ```csharp
 > #nullable enable
 > public class C
@@ -887,7 +887,7 @@ A diagnostic can be produced when a variable ([§9.2.1](variables.md#921-general
 > {
 >     public void M(string? p)
 >     {
->         if (p is not null)
+>         if (p != null)
 >         {
 >             string s = p;
 >             // Use s
@@ -902,7 +902,7 @@ The compiler can update the null state of a variable as part of its analysis.
 
 > *Example*: The compiler may choose to update the state based on any statements in your program:
 >
-> <!-- Example: {template:"code-in-class-lib", name:"UpdateStates", expectedErrors:["8602","CS8602"]} -->
+> <!-- Example: {template:"code-in-class-lib", name:"UpdateStates", expectedWarnings:["8602","CS8602"]} -->
 > ```csharp
 > #nullable enable
 > public void M(string? p)

--- a/standard/types.md
+++ b/standard/types.md
@@ -878,7 +878,7 @@ A diagnostic can be produced when a variable ([§9.2.1](variables.md#921-general
 > }
 > ```
 >
-> The compiler may issue a warning where the parameter that might be null is assigned to a variable that should not be null. If the parameter is null-checked before assignment, the compiler won't issue a warning:
+> The compiler may issue a warning where the parameter that might be null is assigned to a variable that should not be null. If the parameter is null-checked before assignment, the compiler may use that in its nullable state analysis and not issue a warning:
 >
 > <!-- Example: {template:"code-in-class-lib", name:"NullChecked"} -->
 > ```csharp

--- a/standard/types.md
+++ b/standard/types.md
@@ -872,7 +872,7 @@ A diagnostic can be produced when a variable ([§9.2.1](variables.md#921-general
 > {
 >     public void M(string? p)
 >     {
->         // Assignment to maybe null
+>         // Assignment of maybe null value to non-nullable variable
 >         string s = p;
 >     }
 > }
@@ -887,7 +887,11 @@ A diagnostic can be produced when a variable ([§9.2.1](variables.md#921-general
 > {
 >     public void M(string? p)
 >     {
->         string s = p ?? ""; // null check
+>         if (p is not null)
+>         {
+>             string s = p;
+>             // Use s
+>         }
 >     }
 > }
 > ```
@@ -922,7 +926,7 @@ The compiler can update the null state of a variable as part of its analysis.
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
-> *Example*: The compiler can treat a property ([§15.7](classes.md#157-properties)) as either a variable with state, or as independent get and set accessors ([§15.7.3](classes.md#1573-accessors)). In other words, a compiler can choose if writing to a property changes the null state of reading the property, or if reading a property changes the null state of that property.
+> *Example*: The compiler can treat a property ([§15.7](classes.md#157-properties)) as either a variable with state, or as independent get and set accessors ([§15.7.3](classes.md#1573-accessors)). In other words, a compiler can choose whether writing to a property changes the null state of reading the property, or if reading a property changes the null state of that property.
 >
 > <!-- Example: {template:"standalone-console", name:"NullPropertyAnalysis"} -->
 > ```csharp


### PR DESCRIPTION
Fixes #1094 

In the section on nullability and null states, add examples to the notes and text to illustrate possible null analysis results.