### PR TITLE
conversions.md: indent final 2-entry bullet 1 level

### DIFF
--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -1001,5 +1001,5 @@ the target object of the delegate is determined from the instance expression ass
   - If the instance expression is of a *value_type*, a boxing operation ([§10.2.9](conversions.md#1029-boxing-conversions)) is performed to convert the value to an object, and this object becomes the target object.
 - Otherwise, the selected method is part of a static method call, and the target object of the delegate is `null`.
 - A delegate instance of delegate type `D` is obtained with a reference to the method that was determined at compile-time and a reference to the target object computed above, as follows:
-- The conversion is permitted (but not required) to use an existing delegate instance that already contains these references.
-- If an existing instance was not reused, a new one is created ([§20.5](delegates.md#205-delegate-instantiation)). If there is not enough memory available to allocate the new instance, a `System.OutOfMemoryException` is thrown. Otherwise the instance is initialized with the given references.
+  - The conversion is permitted (but not required) to use an existing delegate instance that already contains these references.
+  - If an existing instance was not reused, a new one is created ([§20.5](delegates.md#205-delegate-instantiation)). If there is not enough memory available to allocate the new instance, a `System.OutOfMemoryException` is thrown. Otherwise the instance is initialized with the given references.


### PR DESCRIPTION
The 3rd-to-last bullet ends in "as follows:" which sure sounds like what follows should be in a subordinate list. And that is indeed what we had in V5. However, I just noticed that in V6 and subsequent versions, that extra indent level has been removed, which I'm thinking was probably an editorial error introduced during the big conversion from Word to md.

Interestingly, I discovered this as I was researching the claim that in V11, the 2nd-to-last bullet had just been added, but when I looked at the spec, it had been there for many years. So either the V11 MS [What's New in V11 text](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-11#improved-method-group-conversion-to-delegate) is wrong, or we jumped the gun a long time ago by adding text that wasn't yet true.