### PR TITLE
Small tweaks to "Local variable declarations"

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -453,7 +453,7 @@
       - [§13.6.2.1](statements.md#13621-general)  General
       - [§13.6.2.2](statements.md#13622-implicitly-typed-local-variable-declarations)  Implicitly typed local variable declarations
       - [§13.6.2.3](statements.md#13623-explicitly-typed-local-variable-declarations)  Explicitly typed local variable declarations
-      - [§13.6.2.4](statements.md#13624-ref-local-variable-declarations)  Ref local variable declarations
+      - [§13.6.2.4](statements.md#13624-explicitly-typed-ref-local-variable-declarations)  Explicitly typed ref local variable declarations
     - [§13.6.3](statements.md#1363-local-constant-declarations)  Local constant declarations
     - [§13.6.4](statements.md#1364-local-function-declarations)  Local function declarations
   - [§13.7](statements.md#137-expression-statements)  Expression statements

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -438,7 +438,7 @@ explicitly_typed_ref_local_variable_declaration
     : ref_kind type ref_local_variable_declarators
     ;
 
-explicitly_typed_ref_local_variable_declarators
+ref_local_variable_declarators
     : ref_local_variable_declarator (',' ref_local_variable_declarator)*
     ;
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -435,7 +435,7 @@ If a *local_variable_initializer* is present then its type shall be appropriate 
 
 ```ANTLR
 explicitly_typed_ref_local_variable_declaration
-    : ref_kind type explicitly_typed_ref_local_variable_declarators
+    : ref_kind type ref_local_variable_declarators
     ;
 
 explicitly_typed_ref_local_variable_declarators

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -302,11 +302,9 @@ A *local_variable_declaration* declares one or more local variables.
 local_variable_declaration
     : implicitly_typed_local_variable_declaration
     | explicitly_typed_local_variable_declaration
-    | ref_local_variable_declaration
+    | explicitly_typed_ref_local_variable_declaration
     ;
 ```
-
-Local variable declarations fall into one of the three categories: implicitly typed, explicitly typed, and ref local.
 
 Implicitly typed declarations contain the contextual keyword ([§6.4.4](lexical-structure.md#644-keywords)) `var` resulting in a syntactic ambiguity between the three categories which is resolved as follows:
 
@@ -366,7 +364,7 @@ implicitly_typed_local_variable_declarator
     ;
 ```
 
-An *implicity_typed_local_variable_declaration* introduces a single local variable, *identifier*. The *expression* or *variable_reference* shall have a compile-time type, `T`. The first alternative declares a variable with an initial value of *expression*; its type is `T?` when `T` is a non-nullable reference type, otherwise its type is `T`. The second alternative declares a ref variable with an initial value of `ref` *variable_reference*; its type is `ref T?` when `T` is a non-nullable reference type, otherwise its type is `ref T`.
+An *implicity_typed_local_variable_declaration* introduces a single local variable, *identifier*. The *expression* or *variable_reference* shall have a compile-time type, `T`. The first alternative declares a variable with an initial value of *expression*; its type is `T?` when `T` is a non-nullable reference type, otherwise its type is `T`. The second alternative declares a ref variable with an initial value of `ref` *variable_reference*; its type is `ref T?` when `T` is a non-nullable reference type, otherwise its type is `ref T`. (`ref_kind` is described in [§15.6.1](classes.md#1561-general).)
 
 > *Example*:
 >
@@ -433,14 +431,14 @@ An *explicity_typed_local_variable_declaration* introduces one or more local var
 
 If a *local_variable_initializer* is present then its type shall be appropriate according to the rules of simple assignment ([§12.21.2](expressions.md#12212-simple-assignment)) or array initialization ([§17.7](arrays.md#177-array-initializers)) and its value is assigned as the initial value of the variable.
 
-#### 13.6.2.4 Ref local variable declarations
+#### 13.6.2.4 Explicitly typed ref local variable declarations
 
 ```ANTLR
-ref_local_variable_declaration
-    : ref_kind type ref_local_variable_declarators
+explicitly_typed_ref_local_variable_declaration
+    : explicitly_typed_ref_kind type ref_local_variable_declarators
     ;
 
-ref_local_variable_declarators
+explicitly_typed_ref_local_variable_declarators
     : ref_local_variable_declarator (',' ref_local_variable_declarator)*
     ;
 

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -364,7 +364,7 @@ implicitly_typed_local_variable_declarator
     ;
 ```
 
-An *implicity_typed_local_variable_declaration* introduces a single local variable, *identifier*. The *expression* or *variable_reference* shall have a compile-time type, `T`. The first alternative declares a variable with an initial value of *expression*; its type is `T?` when `T` is a non-nullable reference type, otherwise its type is `T`. The second alternative declares a ref variable with an initial value of `ref` *variable_reference*; its type is `ref T?` when `T` is a non-nullable reference type, otherwise its type is `ref T`. (`ref_kind` is described in [§15.6.1](classes.md#1561-general).)
+An *implicitly_typed_local_variable_declaration* introduces a single local variable, *identifier*. The *expression* or *variable_reference* shall have a compile-time type, `T`. The first alternative declares a variable with an initial value of *expression*; its type is `T?` when `T` is a non-nullable reference type, otherwise its type is `T`. The second alternative declares a ref variable with an initial value of `ref` *variable_reference*; its type is `ref T?` when `T` is a non-nullable reference type, otherwise its type is `ref T`. (*ref_kind* is described in [§15.6.1](classes.md#1561-general).)
 
 > *Example*:
 >

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -435,7 +435,7 @@ If a *local_variable_initializer* is present then its type shall be appropriate 
 
 ```ANTLR
 explicitly_typed_ref_local_variable_declaration
-    : explicitly_typed_ref_kind type ref_local_variable_declarators
+    : ref_kind type explicitly_typed_ref_local_variable_declarators
     ;
 
 explicitly_typed_ref_local_variable_declarators


### PR DESCRIPTION
[This proposal is the result of a private conversation I had with Nigel, and is intended to reflect our final agreement.]

I’m working on the spec for a future feature that involves changes to [§13.6.2.1 General](statements.md#13621-general), in the grammar that starts with rule *local_variable_declaration*. However, once I started reading the draft V8 spec of that section, I got confused. **I think some text, a grammar rule name, and a section name are misleading**, and I’d like to change them before I continue with the other task.

In V6 (prior to the addition of ref/ref-readonly on locals), this section was simple, but as the grammar allowed all kinds of invalid constructs w.r.t implicitly typed local variable declarations, there was a non-trivial bullet list of constraints expressed in text. My original proposal for the V7 feature ref/ref-readonly locals involved light edits to that section. However, it appears that during TG2’s integration of that feature, the grammar was completely rewritten to incorporate all the previous text constraints, and broken into 3 subparts, each of which got its own new section (along with a General intro), as follows: 

- 13.6.2 Local variable declarations 
  - 13.6.2.1 General 
  - 13.6.2.2 Implicitly typed local variable declarations 
  - 13.6.2.3 Explicitly typed local variable declarations 
  - 13.6.2.4 Ref local variable declarations

§13.6.2.1 General starts by saying

> Local variable declarations fall into one of the three categories: implicitly typed, explicitly typed, and ref local. 

My interpretation was that this implied the three categories are mutually exclusive, when they are not! (A ref local could be implicit or explicit.) In any event, Nigel and I agreed to disagree on that interpretation, but we agreed this para adds no value and should be removed.

We agreed to rename rule *ref_local_variable_declaration* to *explicitly_typed_ref_local_variable_declaration*, which requires Section “13.6.2.4 Ref local variable declarations” to be renamed “13.6.2.4 Explicitly typed ref local variable declarations” with any links to that section being updated.
 
The grammar in “13.6.2.2 Implicitly typed local variable declarations” contains *ref_kind*, but doesn’t explain that, so a pointer to “13.6.2.4 Ref local variable declarations,” which does explain that, should be added.
