### PR TITLE
Grammar rule *parameter_modifier* disallows valid V7 constructs

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2130,7 +2130,7 @@ default_argument
 
 parameter_modifier
     : parameter_mode_modifier
-    | 'this'
+    | 'this' parameter_mode_modifier?
     ;
 
 parameter_mode_modifier
@@ -3056,6 +3056,7 @@ When the first parameter of a method includes the `this` modifier, that method i
 
 - It may only be an input parameter if it has a value type
 - It may only be a reference parameter if it has a value type or has a generic type constrained to struct
+- It shall not be an output parameter.
 - It shall not be a pointer type.
 
 > *Example*: The following is an example of a static class that declares two extension methods:

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2131,6 +2131,7 @@ default_argument
 parameter_modifier
     : parameter_mode_modifier
     | 'this' parameter_mode_modifier?
+    | parameter_mode_modifier? 'this'
     ;
 
 parameter_mode_modifier

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3055,8 +3055,8 @@ class Customer
 
 When the first parameter of a method includes the `this` modifier, that method is said to be an ***extension method***. Extension methods shall only be declared in non-generic, non-nested static classes. The first parameter of an extension method is restricted, as follows:
 
-- It may only be an input parameter if it has a value type
-- It may only be a reference parameter if it has a value type or has a generic type constrained to struct
+- It may only be an input parameter if it has a value type.
+- It may only be a reference parameter if it has a value type or has a generic type constrained to struct.
 - It shall not be an output parameter.
 - It shall not be a pointer type.
 


### PR DESCRIPTION
[I stumbled on this today while looking at how to spec the addition of  `scoped` to a parameter for a future version.]

The relevant grammar for method parameters in [§15.6.2.1](classes.md#15621-general) is, as follows:

```ANTLR
fixed_parameter
    : attributes? parameter_modifier? type identifier default_argument?
    ;

parameter_modifier
    : parameter_mode_modifier
    | 'this'
    ;

parameter_mode_modifier
    : 'ref'
    | 'out'
    | 'in'
    ;
```

Rule *parameter_modifier* allows *parameter_mode_modifier* or `this`, but not both. However, two combinations of these *are* permitted, as follows:

```csharp
public static class E
{
    public static void F1b(this in int p) { }
    public static void F1d(this ref int p) { }
}
```

This possibility *is* supported by the text in [§15.6.10 Extension methods](classes.md#15610-extension-methods), which states:

> When the first parameter of a method includes the `this` modifier, that method is said to be an ***extension method***. Extension methods shall only be declared in non-generic, non-nested static classes. **The first parameter of an extension method is restricted, as follows:**
>
> - It may only be an **input parameter** if it has a value type
> - It may only be a **reference parameter** if it has a value type or has a generic type constrained to struct
> - It shall not be a pointer type.

I propose the following grammar change:

```ANTLR
parameter_modifier
    : parameter_mode_modifier
    | 'this' parameter_mode_modifier?
    ;
```

Now this new grammar also allows `this out`, which according to my compiler is not permitted [CS8328], and that suggests we also add to the extension bullet list above, the following constraint:

> - It shall not be an **output parameter**.

