### PR TITLE
Refactor the subsections of §12.8.17, "The new operator"

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -346,11 +346,12 @@
     - [§12.8.17](expressions.md#12817-the-new-operator)  The new operator
       - [§12.8.17.1](expressions.md#128171-general)  General
       - [§12.8.17.2](expressions.md#128172-object-creation-expressions)  Object creation expressions
-      - [§12.8.17.3](expressions.md#128173-object-initializers)  Object initializers
-      - [§12.8.17.4](expressions.md#128174-collection-initializers)  Collection initializers
-      - [§12.8.17.5](expressions.md#128175-array-creation-expressions)  Array creation expressions
-      - [§12.8.17.6](expressions.md#128176-delegate-creation-expressions)  Delegate creation expressions
-      - [§12.8.17.7](expressions.md#128177-anonymous-object-creation-expressions)  Anonymous object creation expressions
+        - [§12.8.17.2.1](§NewGeneral)  General
+        - [§12.8.17.2.2](expressions.md#1281722-object-initializers)  Object initializers
+        - [§12.8.17.2.3](expressions.md#1281723-collection-initializers)  Collection initializers
+        - [§12.8.17.2.4](expressions.md#1281724-anonymous-object-creation-expressions)  Anonymous object creation expressions
+      - [§12.8.17.3](expressions.md#128173-array-creation-expressions)  Array creation expressions
+      - [§12.8.17.4](expressions.md#128174-delegate-creation-expressions)  Delegate creation expressions
     - [§12.8.18](expressions.md#12818-the-typeof-operator)  The typeof operator
     - [§12.8.19](expressions.md#12819-the-sizeof-operator)  The sizeof operator
     - [§12.8.20](expressions.md#12820-the-checked-and-unchecked-operators)  The checked and unchecked operators

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -102,7 +102,7 @@ When an array type `S[]` implements `IList<T>`, some of the members of the imple
 
 ## 17.3 Array creation
 
-Array instances are created by *array_creation_expression*s ([§12.8.17.5](expressions.md#128175-array-creation-expressions)) or by field or local variable declarations that include an *array_initializer* ([§17.7](arrays.md#177-array-initializers)). Array instances can also be created implicitly as part of evaluating an argument list involving a parameter array ([§15.6.2.4](classes.md#15624-parameter-arrays)).
+Array instances are created by *array_creation_expression*s ([§12.8.17.3](expressions.md#128173-array-creation-expressions)) or by field or local variable declarations that include an *array_initializer* ([§17.7](arrays.md#177-array-initializers)). Array instances can also be created implicitly as part of evaluating an argument list involving a parameter array ([§15.6.2.4](classes.md#15624-parameter-arrays)).
 
 When an array instance is created, the rank and length of each dimension are established and then remain constant for the entire lifetime of the instance. In other words, it is not possible to change the rank of an existing array instance, nor is it possible to resize its dimensions.
 
@@ -158,7 +158,7 @@ Array covariance specifically does not extend to arrays of *value_type*s. For ex
 
 ## 17.7 Array initializers
 
-Array initializers may be specified in field declarations ([§15.5](classes.md#155-fields)), local variable declarations ([§13.6.2](statements.md#1362-local-variable-declarations)), and array creation expressions ([§12.8.17.5](expressions.md#128175-array-creation-expressions)):
+Array initializers may be specified in field declarations ([§15.5](classes.md#155-fields)), local variable declarations ([§13.6.2](statements.md#1362-local-variable-declarations)), and array creation expressions ([§12.8.17.3](expressions.md#128173-array-creation-expressions)):
 
 ```ANTLR
 array_initializer

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3013,7 +3013,7 @@ If an implementing declaration exists for a given partial method, the invocation
 
 If a defining declaration but not an implementing declaration is given for a partial method `M`, the following restrictions apply:
 
-- It is a compile-time error to create a delegate from `M` ([§12.8.17.6](expressions.md#128176-delegate-creation-expressions)).
+- It is a compile-time error to create a delegate from `M` ([§12.8.17.4](expressions.md#128174-delegate-creation-expressions)).
 
 - It is a compile-time error to refer to `M` inside an anonymous function that is converted to an expression tree type ([§8.6](types.md#86-expression-tree-types)).
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -849,7 +849,7 @@ Anonymous functions may influence overload resolution, and participate in type i
 
 ### 10.7.2 Evaluation of anonymous function conversions to delegate types
 
-Conversion of an anonymous function to a delegate type produces a delegate instance that references the anonymous function and the (possibly empty) set of captured outer variables that are active at the time of the evaluation. When the delegate is invoked, the body of the anonymous function is executed. The code in the body is executed using the set of captured outer variables referenced by the delegate. A *delegate_creation_expression* ([§12.8.17.6](expressions.md#128176-delegate-creation-expressions)) can be used as an alternate syntax for converting an anonymous method to a delegate type.
+Conversion of an anonymous function to a delegate type produces a delegate instance that references the anonymous function and the (possibly empty) set of captured outer variables that are active at the time of the evaluation. When the delegate is invoked, the body of the anonymous function is executed. The code in the body is executed using the set of captured outer variables referenced by the delegate. A *delegate_creation_expression* ([§12.8.17.4](expressions.md#128174-delegate-creation-expressions)) can be used as an alternate syntax for converting an anonymous method to a delegate type.
 
 The invocation list of a delegate produced from an anonymous function contains a single entry. The exact target object and target method of the delegate are unspecified. In particular, it is unspecified whether the target object of the delegate is `null`, the `this` value of the enclosing function member, or some other object.
 

--- a/standard/delegates.md
+++ b/standard/delegates.md
@@ -178,11 +178,11 @@ This definition of compatibility allows covariance in return type and contravari
 
 ## 20.5 Delegate instantiation
 
-An instance of a delegate is created by a *delegate_creation_expression* ([§12.8.17.6](expressions.md#128176-delegate-creation-expressions)), a conversion to a delegate type, delegate combination or delegate removal. The newly created delegate instance then refers to one or more of:
+An instance of a delegate is created by a *delegate_creation_expression* ([§12.8.17.4](expressions.md#128174-delegate-creation-expressions)), a conversion to a delegate type, delegate combination or delegate removal. The newly created delegate instance then refers to one or more of:
 
 - The static method referenced in the *delegate_creation_expression*, or
 - The target object (which cannot be `null`) and instance method referenced in the *delegate_creation_expression*, or
-- Another delegate ([§12.8.17.6](expressions.md#128176-delegate-creation-expressions)).
+- Another delegate ([§12.8.17.4](expressions.md#128174-delegate-creation-expressions)).
 
 > *Example*:
 >
@@ -212,7 +212,7 @@ An instance of a delegate is created by a *delegate_creation_expression* ([§12.
 
 The set of methods encapsulated by a delegate instance is called an *invocation list*. When a delegate instance is created from a single method, it encapsulates that method, and its invocation list contains only one entry. However, when two non-`null` delegate instances are combined, their invocation lists are concatenated—in the order left operand then right operand—to form a new invocation list, which contains two or more entries.
 
-When a new delegate is created from a single delegate the resultant invocation list has just one entry, which is the source delegate ([§12.8.17.6](expressions.md#128176-delegate-creation-expressions)).
+When a new delegate is created from a single delegate the resultant invocation list has just one entry, which is the source delegate ([§12.8.17.4](expressions.md#128174-delegate-creation-expressions)).
 
 Delegates are combined using the binary `+` ([§12.10.5](expressions.md#12105-addition-operator)) and `+=` operators ([§12.21.4](expressions.md#12214-compound-assignment)). A delegate can be removed from a combination of delegates, using the binary `-` ([§12.10.6](expressions.md#12106-subtraction-operator)) and `-=` operators ([§12.21.4](expressions.md#12214-compound-assignment)). Delegates can be compared for equality ([§12.12.9](expressions.md#12129-delegate-equality-operators)).
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -23,7 +23,7 @@ For expressions which occur as subexpressions of larger expressions, with the no
 
 - A namespace. An expression with this classification can only appear as the left-hand side of a *member_access* ([§12.8.7](expressions.md#1287-member-access)). In any other context, an expression classified as a namespace causes a compile-time error.
 - A type. An expression with this classification can only appear as the left-hand side of a *member_access* ([§12.8.7](expressions.md#1287-member-access)). In any other context, an expression classified as a type causes a compile-time error.
-- A method group, which is a set of overloaded methods resulting from a member lookup ([§12.5](expressions.md#125-member-lookup)). A method group may have an associated instance expression and an associated type argument list. When an instance method is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§12.8.14](expressions.md#12814-this-access)). A method group is permitted in an *invocation_expression* ([§12.8.10](expressions.md#12810-invocation-expressions)) or a *delegate_creation_expression* ([§12.8.17.6](expressions.md#128176-delegate-creation-expressions)), and can be implicitly converted to a compatible delegate type ([§10.8](conversions.md#108-method-group-conversions)). In any other context, an expression classified as a method group causes a compile-time error.
+- A method group, which is a set of overloaded methods resulting from a member lookup ([§12.5](expressions.md#125-member-lookup)). A method group may have an associated instance expression and an associated type argument list. When an instance method is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§12.8.14](expressions.md#12814-this-access)). A method group is permitted in an *invocation_expression* ([§12.8.10](expressions.md#12810-invocation-expressions)) or a *delegate_creation_expression* ([§12.8.17.4](expressions.md#128174-delegate-creation-expressions)), and can be implicitly converted to a compatible delegate type ([§10.8](conversions.md#108-method-group-conversions)). In any other context, an expression classified as a method group causes a compile-time error.
 - An event access. Every event access has an associated type, namely the type of the event. Furthermore, an event access may have an associated instance expression. An event access may appear as the left operand of the `+=` and `-=` operators ([§12.21.5](expressions.md#12215-event-assignment)). In any other context, an expression classified as an event access causes a compile-time error. When an accessor of an instance event access is invoked, the result of evaluating the instance expression becomes the instance represented by `this` ([§12.8.14](expressions.md#12814-this-access)).
 - A throw expression, which may be used is several contexts to throw an exception in an expression. A throw expression may be converted by an implicit conversion to any type.
 
@@ -685,7 +685,7 @@ The expressions of an argument list are always evaluated in textual order.
 >
 > *end example*
 
-When a function member with a parameter array is invoked in its expanded form with at least one expanded argument, the invocation is processed as if an array creation expression with an array initializer ([§12.8.17.5](expressions.md#128175-array-creation-expressions)) was inserted around the expanded arguments. An empty array is passed when there are no arguments for the parameter array; it is unspecified whether the reference passed is to a newly allocated or existing empty array.
+When a function member with a parameter array is invoked in its expanded form with at least one expanded argument, the invocation is processed as if an array creation expression with an array initializer ([§12.8.17.3](expressions.md#128173-array-creation-expressions)) was inserted around the expanded arguments. An empty array is passed when there are no arguments for the parameter array; it is unspecified whether the reference passed is to a newly allocated or existing empty array.
 
 > *Example*: Given the declaration
 >
@@ -1822,7 +1822,7 @@ A  *null_conditional_member_access* expression `E` is of the form `P?.A`. The me
 >
 > *end note*
 
-A *null_conditional_projection_initializer* is a restriction of *null_conditional_member_access* and has the same semantics. It only occurs as a projection initializer in an anonymous object creation expression ([§12.8.17.7](expressions.md#128177-anonymous-object-creation-expressions)).
+A *null_conditional_projection_initializer* is a restriction of *null_conditional_member_access* and has the same semantics. It only occurs as a projection initializer in an anonymous object creation expression ([§12.8.17.2.4](expressions.md#1281724-anonymous-object-creation-expressions)).
 
 ### 12.8.9 Null-forgiving expressions
 
@@ -2414,7 +2414,7 @@ The `new` operator is used to create new instances of types.
 
 There are three forms of new expressions:
 
-- Object creation expressions and anonymous object creation expressions are used to create new instances of class types and value types.
+- Object creation expressions are used to create new instances of class types and value types.
 - Array creation expressions are used to create new instances of array types.
 - Delegate creation expressions are used to obtain instances of delegate types.
 
@@ -2423,6 +2423,8 @@ The `new` operator implies creation of an instance of a type, but does not neces
 > *Note*: Delegate creation expressions do not always create new instances. When the expression is processed in the same way as a method group conversion ([§10.8](conversions.md#108-method-group-conversions)) or an anonymous function conversion ([§10.7](conversions.md#107-anonymous-function-conversions)) this may result in an existing delegate instance being reused. *end note*
 
 #### 12.8.17.2 Object creation expressions
+
+##### §NewGeneral General
 
 An *object_creation_expression* is used to create a new instance of a *class_type* or a *value_type*.
 
@@ -2444,7 +2446,7 @@ The optional *argument_list* ([§12.6.2](expressions.md#1262-argument-lists)) is
 
 An object creation expression can omit the constructor argument list and enclosing parentheses provided it includes an object initializer or collection initializer. Omitting the constructor argument list and enclosing parentheses is equivalent to specifying an empty argument list.
 
-Processing of an object creation expression that includes an object initializer or collection initializer consists of first processing the instance constructor and then processing the member or element initializations specified by the object initializer ([§12.8.17.3](expressions.md#128173-object-initializers)) or collection initializer ([§12.8.17.4](expressions.md#128174-collection-initializers)).
+Processing of an object creation expression that includes an object initializer or collection initializer consists of first processing the instance constructor and then processing the member or element initializations specified by the object initializer ([§12.8.17.2.2](expressions.md#1281722-object-initializers)) or collection initializer ([§12.8.17.2.3](expressions.md#1281723-collection-initializers)).
 
 If any of the arguments in the optional *argument_list* has the compile-time type `dynamic` then the *object_creation_expression* is dynamically bound ([§12.3.3](expressions.md#1233-dynamic-binding)) and the following rules are applied at run-time using the run-time type of those arguments of the *argument_list* that have the compile-time type `dynamic`. However, the object creation undergoes a limited compile-time check as described in [§12.6.5](expressions.md#1265-compile-time-checking-of-dynamic-member-invocation).
 
@@ -2473,7 +2475,7 @@ The run-time processing of an *object_creation_expression* of the form new `T(A)
   - An instance of type `T` is created by allocating a temporary local variable. Since an instance constructor of a *struct_type* is required to definitely assign a value to each field of the instance being created, no initialization of the temporary variable is necessary.
   - The instance constructor is invoked according to the rules of function member invocation ([§12.6.6](expressions.md#1266-function-member-invocation)). A reference to the newly allocated instance is automatically passed to the instance constructor and the instance can be accessed from within that constructor as this.
 
-#### 12.8.17.3 Object initializers
+##### 12.8.17.2.2 Object initializers
 
 An ***object initializer*** specifies values for zero or more fields, properties, or indexed elements of an object.
 
@@ -2512,7 +2514,7 @@ A member initializer that specifies an expression after the equals sign is proce
 
 A member initializer that specifies an object initializer after the equals sign is a ***nested object initializer***, i.e., an initialization of an embedded object. Instead of assigning a new value to the field or property, the assignments in the nested object initializer are treated as assignments to members of the field or property. Nested object initializers cannot be applied to properties with a value type, or to read-only fields with a value type.
 
-A member initializer that specifies a collection initializer after the equals sign is an initialization of an embedded collection. Instead of assigning a new collection to the target field, property, or indexer, the elements given in the initializer are added to the collection referenced by the target. The target shall be of a collection type that satisfies the requirements specified in [§12.8.17.4](expressions.md#128174-collection-initializers).
+A member initializer that specifies a collection initializer after the equals sign is an initialization of an embedded collection. Instead of assigning a new collection to the target field, property, or indexer, the elements given in the initializer are added to the collection referenced by the target. The target shall be of a collection type that satisfies the requirements specified in [§12.8.17.2.3](expressions.md#1281723-collection-initializers).
 
 When an initializer target refers to an indexer, the arguments to the indexer shall always be evaluated exactly once. Thus, even if the arguments end up never getting used (e.g., because of an empty nested initializer), they are evaluated for their side effects.
 
@@ -2622,7 +2624,7 @@ When an initializer target refers to an indexer, the arguments to the indexer sh
 >
 > *end example*
 
-#### 12.8.17.4 Collection initializers
+##### 12.8.17.2.3 Collection initializers
 
 A collection initializer specifies the elements of a collection.
 
@@ -2712,7 +2714,96 @@ The collection object to which a collection initializer is applied shall be of a
 >
 > *end example*
 
-#### 12.8.17.5 Array creation expressions
+#### 12.8.17.2.4 Anonymous object creation expressions
+
+An *anonymous_object_creation_expression* is used to create an object of an anonymous type.
+
+```ANTLR
+anonymous_object_creation_expression
+    : 'new' anonymous_object_initializer
+    ;
+
+anonymous_object_initializer
+    : '{' member_declarator_list? '}'
+    | '{' member_declarator_list ',' '}'
+    ;
+
+member_declarator_list
+    : member_declarator (',' member_declarator)*
+    ;
+
+member_declarator
+    : simple_name
+    | member_access
+    | null_conditional_projection_initializer
+    | base_access
+    | identifier '=' expression
+    ;
+```
+
+An anonymous object initializer declares an anonymous type and returns an instance of that type. An anonymous type is a nameless class type that inherits directly from `object`. The members of an anonymous type are a sequence of read-only properties inferred from the anonymous object initializer used to create an instance of the type. Specifically, an anonymous object initializer of the form
+
+`new {` *p₁* `=` *e₁* `,` *p₂* `=` *e₂* `,` … *pᵥ* `=` *eᵥ* `}`
+
+declares an anonymous type of the form
+
+```csharp
+class __Anonymous1
+{
+    private readonly «T1» «f1»;
+    private readonly «T2» «f2»;
+    ...
+    private readonly «Tn» «fn»;
+
+    public __Anonymous1(«T1» «a1», «T2» «a2»,..., «Tn» «an»)
+    {
+        «f1» = «a1»;
+        «f2» = «a2»;
+        ...
+        «fn» = «an»;
+    }
+
+    public «T1» «p1» { get { return «f1»; } }
+    public «T2» «p2» { get { return «f2»; } }
+    ...
+    public «Tn» «pn» { get { return «fn»; } }
+    public override bool Equals(object __o) { ... }
+    public override int GetHashCode() { ... }
+}
+```
+
+where each «Tx» is the type of the corresponding expression «ex». The expression used in a *member_declarator* shall have a type. Thus, it is a compile-time error for an expression in a *member_declarator* to be `null` or an anonymous function.
+
+The names of an anonymous type and of the parameter to its `Equals` method are automatically generated by the compiler and cannot be referenced in program text.
+
+Within the same program, two anonymous object initializers that specify a sequence of properties of the same names and compile-time types in the same order will produce instances of the same anonymous type.
+
+> *Example*: In the example
+>
+> <!-- Example: {template:"standalone-console-without-using", name:"AnonymousObjectCreationExpressions"} -->
+> ```csharp
+> var p1 = new { Name = "Lawnmower", Price = 495.00 };
+> var p2 = new { Name = "Shovel", Price = 26.95 };
+> p1 = p2;
+> ```
+>
+> the assignment on the last line is permitted because `p1` and `p2` are of the same anonymous type.
+>
+> *end example*
+
+The `Equals` and `GetHashcode` methods on anonymous types override the methods inherited from `object`, and are defined in terms of the `Equals` and `GetHashcode` of the properties, so that two instances of the same anonymous type are equal if and only if all their properties are equal.
+
+A member declarator can be abbreviated to a simple name ([§12.8.4](expressions.md#1284-simple-names)), a member access ([§12.8.7](expressions.md#1287-member-access)), a null conditional projection initializer [§12.8.8](expressions.md#1288-null-conditional-member-access) or a base access ([§12.8.15](expressions.md#12815-base-access)). This is called a ***projection initializer*** and is shorthand for a declaration of and assignment to a property with the same name. Specifically, member declarators of the forms
+
+`«identifier»`, `«expr» . «identifier»` and `«expr» ? . «identifier»`
+
+are precisely equivalent to the following, respectively:
+
+`«identifer» = «identifier»`, `«identifier» = «expr» . «identifier»` and `«identifier» = «expr» ? . «identifier»`
+
+Thus, in a projection initializer the identifier selects both the value and the field or property to which the value is assigned. Intuitively, a projection initializer projects not just a value, but also the name of the value.
+
+#### 12.8.17.3 Array creation expressions
 
 An *array_creation_expression* is used to create a new instance of an *array_type*.
 
@@ -2819,7 +2910,7 @@ An array creation expression permits instantiation of an array with elements of 
 >
 > *end example*
 
-Implicitly typed array creation expressions can be combined with anonymous object initializers ([§12.8.17.7](expressions.md#128177-anonymous-object-creation-expressions)) to create anonymously typed data structures.
+Implicitly typed array creation expressions can be combined with anonymous object initializers ([§12.8.17.2.4](expressions.md#1281724-anonymous-object-creation-expressions)) to create anonymously typed data structures.
 
 > *Example*:
 >
@@ -2842,7 +2933,7 @@ Implicitly typed array creation expressions can be combined with anonymous objec
 >
 > *end example*
 
-#### 12.8.17.6 Delegate creation expressions
+#### 12.8.17.4 Delegate creation expressions
 
 A *delegate_creation_expression* is used to obtain an instance of a *delegate_type*.
 
@@ -2854,7 +2945,7 @@ delegate_creation_expression
 
 The argument of a delegate creation expression shall be a method group, an anonymous function, or a value of either the compile-time type `dynamic` or a *delegate_type*. If the argument is a method group, it identifies the method and, for an instance method, the object for which to create a delegate. If the argument is an anonymous function it directly defines the parameters and method body of the delegate target. If the argument is a value it identifies a delegate instance of which to create a copy.
 
-If the *expression* has the compile-time type `dynamic`, the *delegate_creation_expression* is dynamically bound ([§12.8.17.6](expressions.md#128176-delegate-creation-expressions)), and the rules below are applied at run-time using the run-time type of the *expression*. Otherwise, the rules are applied at compile-time.
+If the *expression* has the compile-time type `dynamic`, the *delegate_creation_expression* is dynamically bound ([§12.8.17.4](expressions.md#128174-delegate-creation-expressions)), and the rules below are applied at run-time using the run-time type of the *expression*. Otherwise, the rules are applied at compile-time.
 
 The binding-time processing of a *delegate_creation_expression* of the form new `D(E)`, where `D` is a *delegate_type* and `E` is an *expression*, consists of the following steps:
 
@@ -2897,95 +2988,6 @@ It is not possible to create a delegate that refers to a property, indexer, user
 > the `A.f` field is initialized with a delegate that refers to the second `Square` method because that method exactly matches the parameter list and return type of `DoubleFunc`. Had the second `Square` method not been present, a compile-time error would have occurred.
 >
 > *end example*
-
-#### 12.8.17.7 Anonymous object creation expressions
-
-An *anonymous_object_creation_expression* is used to create an object of an anonymous type.
-
-```ANTLR
-anonymous_object_creation_expression
-    : 'new' anonymous_object_initializer
-    ;
-
-anonymous_object_initializer
-    : '{' member_declarator_list? '}'
-    | '{' member_declarator_list ',' '}'
-    ;
-
-member_declarator_list
-    : member_declarator (',' member_declarator)*
-    ;
-
-member_declarator
-    : simple_name
-    | member_access
-    | null_conditional_projection_initializer
-    | base_access
-    | identifier '=' expression
-    ;
-```
-
-An anonymous object initializer declares an anonymous type and returns an instance of that type. An anonymous type is a nameless class type that inherits directly from `object`. The members of an anonymous type are a sequence of read-only properties inferred from the anonymous object initializer used to create an instance of the type. Specifically, an anonymous object initializer of the form
-
-`new {` *p₁* `=` *e₁* `,` *p₂* `=` *e₂* `,` … *pᵥ* `=` *eᵥ* `}`
-
-declares an anonymous type of the form
-
-```csharp
-class __Anonymous1
-{
-    private readonly «T1» «f1»;
-    private readonly «T2» «f2»;
-    ...
-    private readonly «Tn» «fn»;
-
-    public __Anonymous1(«T1» «a1», «T2» «a2»,..., «Tn» «an»)
-    {
-        «f1» = «a1»;
-        «f2» = «a2»;
-        ...
-        «fn» = «an»;
-    }
-
-    public «T1» «p1» { get { return «f1»; } }
-    public «T2» «p2» { get { return «f2»; } }
-    ...
-    public «Tn» «pn» { get { return «fn»; } }
-    public override bool Equals(object __o) { ... }
-    public override int GetHashCode() { ... }
-}
-```
-
-where each «Tx» is the type of the corresponding expression «ex». The expression used in a *member_declarator* shall have a type. Thus, it is a compile-time error for an expression in a *member_declarator* to be `null` or an anonymous function.
-
-The names of an anonymous type and of the parameter to its `Equals` method are automatically generated by the compiler and cannot be referenced in program text.
-
-Within the same program, two anonymous object initializers that specify a sequence of properties of the same names and compile-time types in the same order will produce instances of the same anonymous type.
-
-> *Example*: In the example
->
-> <!-- Example: {template:"standalone-console-without-using", name:"AnonymousObjectCreationExpressions"} -->
-> ```csharp
-> var p1 = new { Name = "Lawnmower", Price = 495.00 };
-> var p2 = new { Name = "Shovel", Price = 26.95 };
-> p1 = p2;
-> ```
->
-> the assignment on the last line is permitted because `p1` and `p2` are of the same anonymous type.
->
-> *end example*
-
-The `Equals` and `GetHashcode` methods on anonymous types override the methods inherited from `object`, and are defined in terms of the `Equals` and `GetHashcode` of the properties, so that two instances of the same anonymous type are equal if and only if all their properties are equal.
-
-A member declarator can be abbreviated to a simple name ([§12.8.4](expressions.md#1284-simple-names)), a member access ([§12.8.7](expressions.md#1287-member-access)), a null conditional projection initializer [§12.8.8](expressions.md#1288-null-conditional-member-access) or a base access ([§12.8.15](expressions.md#12815-base-access)). This is called a ***projection initializer*** and is shorthand for a declaration of and assignment to a property with the same name. Specifically, member declarators of the forms
-
-`«identifier»`, `«expr» . «identifier»` and `«expr» ? . «identifier»`
-
-are precisely equivalent to the following, respectively:
-
-`«identifer» = «identifier»`, `«identifier» = «expr» . «identifier»` and `«identifier» = «expr» ? . «identifier»`
-
-Thus, in a projection initializer the identifier selects both the value and the field or property to which the value is assigned. Intuitively, a projection initializer projects not just a value, but also the name of the value.
 
 ### 12.8.18 The typeof operator
 
@@ -6807,7 +6809,7 @@ Constant expressions are required in the contexts listed below and this is indic
 - Default arguments of parameter lists ([§15.6.2](classes.md#1562-method-parameters))
 - `case` labels of a `switch` statement ([§13.8.3](statements.md#1383-the-switch-statement)).
 - `goto case` statements ([§13.10.4](statements.md#13104-the-goto-statement))
-- Dimension lengths in an array creation expression ([§12.8.17.5](expressions.md#128175-array-creation-expressions)) that includes an initializer.
+- Dimension lengths in an array creation expression ([§12.8.17.3](expressions.md#128173-array-creation-expressions)) that includes an initializer.
 - Attributes ([§22](attributes.md#22-attributes))
 - In a *constant_pattern* ([§11.2.3](patterns.md#1123-constant-pattern))
 

--- a/standard/portability-issues.md
+++ b/standard/portability-issues.md
@@ -58,7 +58,7 @@ A conforming implementation is required to document its choice of behavior in ea
 1. The representation of `true` ([§8.3.9](types.md#839-the-bool-type)).
 1. The value of the result when converting out-of-range values from `float` or `double` values to an integral type in an `unchecked` context ([§10.3.2](conversions.md#1032-explicit-numeric-conversions)).
 1. The exact target object and target method of the delegate produced from an *anonymous_method_expression* contains ([§10.7.2](conversions.md#1072-evaluation-of-anonymous-function-conversions-to-delegate-types)).
-1. The layout of arrays, except in an unsafe context ([§12.8.17.5](expressions.md#128175-array-creation-expressions)).
+1. The layout of arrays, except in an unsafe context ([§12.8.17.3](expressions.md#128173-array-creation-expressions)).
 1. Whether there is any way to execute the *block* of an anonymous function other than through evaluation and invocation of the *lambda_expression* or *anonymous_method-expression* ([§12.19.3](expressions.md#12193-anonymous-function-bodies)).
 1. The exact timing of static field initialization ([§15.5.6.2](classes.md#15562-static-field-initialization)).
 1. The result of invoking `MoveNext` when an enumerator object is running ([§15.14.5.2](classes.md#151452-the-movenext-method)).

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -176,7 +176,7 @@ A *pointer_type* may be used as the type of a volatile field ([§15.5.4](classes
 
 The *dynamic erasure* of a type `E*` is the pointer type with referent type of the dynamic erasure of `E`.
 
-An expression with a pointer type cannot be used to provide the value in a *member_declarator* within an *anonymous_object_creation_expression* ([§12.8.17.7](expressions.md#128177-anonymous-object-creation-expressions)).
+An expression with a pointer type cannot be used to provide the value in a *member_declarator* within an *anonymous_object_creation_expression* ([§12.8.17.2.4](expressions.md#1281724-anonymous-object-creation-expressions)).
 
 The default value ([§9.3](variables.md#93-default-values)) for any pointer type is `null`.
 
@@ -345,7 +345,7 @@ Mappings between pointers and integers are implementation-defined.
 
 ### 23.5.2 Pointer arrays
 
-Arrays of pointers can be constructed using *array_creation_expression* ([§12.8.17.5](expressions.md#128175-array-creation-expressions)) in an unsafe context. Only some of the conversions that apply to other array types are allowed on pointer arrays:
+Arrays of pointers can be constructed using *array_creation_expression* ([§12.8.17.3](expressions.md#128173-array-creation-expressions)) in an unsafe context. Only some of the conversions that apply to other array types are allowed on pointer arrays:
 
 - The implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)) from any *array_type* to `System.Array` and the interfaces it implements also applies to pointer arrays. However, any attempt to access the array elements through `System.Array` or the interfaces it implements may result in an exception at run-time, as pointer types are not convertible to `object`.
 - The implicit and explicit reference conversions ([§10.2.8](conversions.md#1028-implicit-reference-conversions), [§10.3.5](conversions.md#1035-explicit-reference-conversions)) from a single-dimensional array type `S[]` to `System.Collections.Generic.IList<T>` and its generic base interfaces never apply to pointer arrays.

--- a/standard/variables.md
+++ b/standard/variables.md
@@ -697,7 +697,7 @@ new «type» ( «arg₁», «arg₂», … , «argₓ» )
 - For each argument *argᵢ*, the definite assignment state of *v* after *argᵢ* is determined by the normal expression rules, ignoring any `in`, `out`, or `ref` modifiers.
 - For each argument *argᵢ* for any *i* greater than one, the definite assignment state of *v* before *argᵢ* is the same as the state of *v* after *argᵢ₋₁*.
 - If the variable *v* is passed as an `out` argument (i.e., an argument of the form “out *v*”) in any of the arguments, then the state of *v* after *expr* is definitely assigned. Otherwise, the state of *v* after *expr* is the same as the state of *v* after *argₓ*.
-- For array initializers ([§12.8.17.5](expressions.md#128175-array-creation-expressions)), object initializers ([§12.8.17.3](expressions.md#128173-object-initializers)), collection initializers ([§12.8.17.4](expressions.md#128174-collection-initializers)) and anonymous object initializers ([§12.8.17.7](expressions.md#128177-anonymous-object-creation-expressions)), the definite-assignment state is determined by the expansion that these constructs are defined in terms of.
+- For array initializers ([§12.8.17.3](expressions.md#128173-array-creation-expressions)), object initializers ([§12.8.17.2.2](expressions.md#1281722-object-initializers)), collection initializers ([§12.8.17.2.3](expressions.md#1281723-collection-initializers)) and anonymous object initializers ([§12.8.17.2.4](expressions.md#1281724-anonymous-object-creation-expressions)), the definite-assignment state is determined by the expansion that these constructs are defined in terms of.
 
 #### 9.4.4.25 Simple assignment expressions
 


### PR DESCRIPTION
[As we discussed, Bill, here are the changes needed.]

Regarding §[12.8.17](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12817-the-new-operator), "The new operator", we currently have the following section organization:
 
§12.8.17 The new operator
- §12.8.17.1 General
- §12.8.17.2 Object creation expressions
- §12.8.17.3 Object initializers
- §12.8.17.4 Collection initializers
- §12.8.17.5 Array creation expressions
- §12.8.17.6 Delegate creation expressions
- §12.8.17.7 Anonymous object creation expressions
 
I'm refactoring this, as follows:
 
§12.8.17 The new operator
- §12.8.17.1 General
- §12.8.17.2 Object creation expressions
  - §12.8.17.2.1 General                                                               // new; simply contains the content of current §12.8.17.2 Object creation expressions
  - §12.8.17.2.2 Object initializers                                               // renumbered
  - §12.8.17.2.3 Collection initializers                                        // renumbered
  - §12.8.17.2.4 Anonymous object creation expressions      // renumbered and moved from current §12.8.17.7 Anonymous object creation expressions
- §12.8.17.3 Array creation expressions                                                // renumbered
- §12.8.17.4 Delegate creation expressions                                         // renumbered
 
The rationale for this comes from [§12.8.17.1](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128171-general), where we say,
 
There are three forms of new expressions:

- Object creation expressions [[will strike this: and anonymous object creation expressions]] are used to create new instances of class types and value types.
- Array creation expressions are used to create new instances of array types.
- Delegate creation expressions are used to obtain instances of delegate types.

So, I’ve simply rearranged the existing section list to reflect there are 3 categories instead of the 6 currently implied.

And I adjusted all the links to those sections.