### PR TITLE
Update expressions.md

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4820,7 +4820,7 @@ The type of the expression `a ?? b` depends on which implicit conversions are 
 - Otherwise, if `A` exists and is a nullable value type, `b` has a type `B` and an implicit conversion exists from `A₀` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀` and converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
 - Otherwise, if `b` has a type `B` and an implicit conversion exists from `a` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
 
-Otherwise, `a` and `b` are incompatible, and `a` compile-time error occurs.
+Otherwise, `a` and `b` are incompatible, and a compile-time error occurs.
 
 ## 12.16 The throw expression operator
 


### PR DESCRIPTION
The final sentence of section 12.15 (The null coalescing operator) reads:

Otherwise, `a` and `b` are incompatible, and `a` compile-time error occurs.

The formatting around the word "a" in the third clause is a typo - it is not a reference to an object, it is just the word "a".  The sentence should read:

Otherwise, `a` and `b` are incompatible, and a compile-time error occurs.

PR consists of this change and nothing else.