### PR TITLE
NuGet updates

### DIFF
--- a/tools/ExampleTester/ExampleTester.csproj
+++ b/tools/ExampleTester/ExampleTester.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/tools/MarkdownConverter.Tests/MarkdownConverter.Tests.csproj
+++ b/tools/MarkdownConverter.Tests/MarkdownConverter.Tests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="XMLUnit.Core" Version="2.10.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tools/MarkdownConverter/MarkdownConverter.csproj
+++ b/tools/MarkdownConverter/MarkdownConverter.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="csharp2colorized" Version="1.0.3" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
-    <PackageReference Include="FSharp.Core" Version="8.0.300" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="FSharp.Core" Version="9.0.101" />
     <PackageReference Include="FSharp.Formatting" Version="20.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Utilities/Utilities.csproj
+++ b/tools/Utilities/Utilities.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="13.0.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="Octokit" Version="14.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It appears that dependabot missed some of the updates when creating #1248.  As a result, there were some incompatibilities.

This PR (if successful) replaces that one and updates our tools to the latest packages. The difference is that this PR includes updates for:

- `Microsoft.CodeAnalysis.CSharp.Workspaces`
- `xunit`

Those are required when the following are updated:

- `Microsoft.CodeAnalysis.Workspaces.MSBuild`
- `xunit.runner.VisualStudio`
