### PR TITLE
Split the workflow that runs our tools from the workflow that writes the checks.

### DIFF
--- a/.github/workflows/grammar-validator.yaml
+++ b/.github/workflows/grammar-validator.yaml
@@ -21,10 +21,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 9.0
+    - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 8.0.x
 
     - name: Set up JDK 15
       uses: actions/setup-java@v2

--- a/.github/workflows/grammar-validator.yaml
+++ b/.github/workflows/grammar-validator.yaml
@@ -21,10 +21,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Set up JDK 15
       uses: actions/setup-java@v2

--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -29,9 +29,28 @@ jobs:
     - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Run section renumbering dry run
+      id: section-renumber
       run: |
         cd tools
         ./run-section-renumber.sh
+
+    - name: Trigger Workflow
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'report-status.yml',
+            ref: '${{ github.head_ref }}',
+            inputs: {
+              "head_sha": '${{ steps.section-renumber.output.head_sha }}',
+              "name": '${{ steps.section-renumber.output.check_name }}',
+              "conclusion": '${{ steps.section-renumber.output.conclusion }}',
+              "summary": '${{ steps.section-renumber.output.summary }}',
+              "annotations": '${{ steps.section-renumber.output.annotations }}'
+            }
+          })

--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -38,7 +38,7 @@ jobs:
         ./run-section-renumber.sh
 
     - name: Trigger Workflow
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -42,8 +42,8 @@ jobs:
       with:
         script: |
           github.rest.actions.createWorkflowDispatch({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
+            owner: "dotnet",
+            repo: "csharpstandard",
             workflow_id: 'report-status.yml',
             ref: '${{ github.head_ref }}',
             inputs: {

--- a/.github/workflows/report-status.yml
+++ b/.github/workflows/report-status.yml
@@ -1,0 +1,26 @@
+name: Report status
+
+# Triggers the workflow when a workflow that generates status completes
+on:
+  workflow_run:
+    workflows: ["Renumber standard TOC"]
+    types:
+      - completed
+
+jobs:
+  report-status:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ inputs.head_sha }}
+        name: ${{ inputs.check_name }}
+        conclusion: ${{ inputs.conclusion}}
+        # output.summary is required with actions!
+        output: |
+          {"summary":"${{inputs.summary}}"}
+        annotations: ${{ inputs.annotations }}

--- a/.github/workflows/smart-quotes.yaml
+++ b/.github/workflows/smart-quotes.yaml
@@ -24,10 +24,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Smarten quotes
       id: smarten-quote

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -32,12 +32,12 @@ jobs:
     # 8.0 for the tools themselves. (The closer we
     # are to the target language version we're standardising,
     # the better.)
-    - name: Setup .NET 6.0 and 8.0
+    - name: Setup .NET 6.0 and 9.0
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.0.x
-          8.0.x
+          9.0.x
 
     - name: Extract and validate tests
       run: |

--- a/.github/workflows/tools-tests.yaml
+++ b/.github/workflows/tools-tests.yaml
@@ -25,10 +25,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Run all tests
       run: |

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -30,10 +30,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Set up JDK 15
       uses: actions/setup-java@v1

--- a/.github/workflows/word-converter.yaml
+++ b/.github/workflows/word-converter.yaml
@@ -26,10 +26,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Run converter
       run: |

--- a/tools/ExampleTester/ExampleTester.csproj
+++ b/tools/ExampleTester/ExampleTester.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/MarkdownConverter.Tests/MarkdownConverter.Tests.csproj
+++ b/tools/MarkdownConverter.Tests/MarkdownConverter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tools/MarkdownConverter/MarkdownConverter.csproj
+++ b/tools/MarkdownConverter/MarkdownConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>NU1701</NoWarn>

--- a/tools/StandardAnchorTags/Program.cs
+++ b/tools/StandardAnchorTags/Program.cs
@@ -61,7 +61,7 @@ public class Program
         {
             if ((token is not null) && (headSha is not null))
             {
-                await logger.BuildCheckRunResult(token, owner, repo, headSha);
+                var annotations = await logger.BuildCheckRunResult(token, owner, repo, headSha);
             }
         }
         return logger.Success ? 0 : 1;

--- a/tools/StandardAnchorTags/StandardAnchorTags.csproj
+++ b/tools/StandardAnchorTags/StandardAnchorTags.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tools/Utilities/CustomSerializer.cs
+++ b/tools/Utilities/CustomSerializer.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+using Octokit;
+
+namespace Utilities;
+
+// This defines the custom serializer for the annotations block.
+// That enables the status checks to write the annotations to
+// the GitHub Actions output. That lets a subsequent action read
+// these annotations in a different security context and write
+// them to the PR.
+[JsonSerializable(typeof(IList<NewCheckRunAnnotation>))]
+public sealed partial class JsonCheckRunAnnotationSerializerContext : JsonSerializerContext;

--- a/tools/Utilities/StatusCheckLogger.cs
+++ b/tools/Utilities/StatusCheckLogger.cs
@@ -27,13 +27,15 @@ public record StatusCheckMessage(string file, int StartLine, int EndLine, string
 /// <param name="toolName">The name of the tool that is running the check</param>
 public class StatusCheckLogger(string pathToRoot, string toolName)
 {
-    private static ICoreService? gitHubCoreService;
-    public static void Initializer()
+    private Lazy<ICoreService> _gitHubCoreService = new(() => InitializeCoreService());
+    
+    private static ICoreService InitializeCoreService()
     {
         using var provider = new ServiceCollection()
             .AddGitHubActionsCore()
             .BuildServiceProvider();
-        gitHubCoreService = provider.GetRequiredService<ICoreService>();
+        
+        return provider.GetRequiredService<ICoreService>();
     }
 
     private List<NewCheckRunAnnotation> annotations = [];
@@ -200,25 +202,30 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
         }
         try
         { 
-            var asyncTask = gitHubCoreService?.SetOutputAsync("check_name", title, JsonCheckRunAnnotationSerializerContext.Default.String)
-                ?? ValueTask.CompletedTask;
-            await asyncTask;
+            var core = _gitHubCoreService.Value;
+            
+            await core.GroupAsync("Writing run outputs", async () => 
+            {
+                await core.SetOutputAsync("check_name", title, JsonCheckRunAnnotationSerializerContext.Default.String);
+                
+                core.WriteInfo("Set check_name output");
+                
+                await core.SetOutputAsync("conclusion", Success ? "success" : "failure", JsonCheckRunAnnotationSerializerContext.Default.String);
 
-            asyncTask = gitHubCoreService?.SetOutputAsync("conclusion", Success ? "success" : "failure", JsonCheckRunAnnotationSerializerContext.Default.String)
-                ?? ValueTask.CompletedTask;
-            await asyncTask;
+                core.WriteInfo("Set conclusion output");
 
-            asyncTask = gitHubCoreService?.SetOutputAsync("summary", summary, JsonCheckRunAnnotationSerializerContext.Default.String)
-                ?? ValueTask.CompletedTask;
-            await asyncTask;
+                await core.SetOutputAsync("summary", summary, JsonCheckRunAnnotationSerializerContext.Default.String);
 
-            asyncTask = gitHubCoreService?.SetOutputAsync("head_sha", sha, JsonCheckRunAnnotationSerializerContext.Default.String)
-                ?? ValueTask.CompletedTask;
-            await asyncTask;
+                core.WriteInfo("Set summary output");
 
-            asyncTask = gitHubCoreService?.SetOutputAsync("annotations", annotations, JsonCheckRunAnnotationSerializerContext.Default.IListNewCheckRunAnnotation)
-                ?? ValueTask.CompletedTask;
-            await asyncTask;
+                await core.SetOutputAsync("head_sha", sha, JsonCheckRunAnnotationSerializerContext.Default.String);
+
+                core.WriteInfo("Set head_sha output");
+
+                await core.SetOutputAsync("annotations", annotations, JsonCheckRunAnnotationSerializerContext.Default.IListNewCheckRunAnnotation);
+                
+                core.WriteInfo("Set annotations output");
+            });
             // Now, we have a file named annotations.
         }
         // If the token does not have the correct permissions, we will get a 403

--- a/tools/Utilities/StatusCheckLogger.cs
+++ b/tools/Utilities/StatusCheckLogger.cs
@@ -189,6 +189,17 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
         try
         {
             await client.Check.Run.Create(owner, repo, result);
+        }
+        // If the token does not have the correct permissions, we will get a 403
+        // Once running on a branch on the dotnet org, this should work correctly.
+        catch (ForbiddenException e)
+        {
+            Console.WriteLine("===== WARNING: Could not create a check run.=====");
+            Console.WriteLine("Exception details:");
+            Console.WriteLine(e);
+        }
+        try
+        { 
             var asyncTask = gitHubCoreService?.SetOutputAsync("check_name", title, JsonCheckRunAnnotationSerializerContext.Default.String)
                 ?? ValueTask.CompletedTask;
             await asyncTask;

--- a/tools/Utilities/StatusCheckLogger.cs
+++ b/tools/Utilities/StatusCheckLogger.cs
@@ -1,4 +1,7 @@
 ﻿using Octokit;
+using Actions.Core.Extensions;
+using Actions.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Utilities;
 
@@ -24,6 +27,15 @@ public record StatusCheckMessage(string file, int StartLine, int EndLine, string
 /// <param name="toolName">The name of the tool that is running the check</param>
 public class StatusCheckLogger(string pathToRoot, string toolName)
 {
+    private static ICoreService? gitHubCoreService;
+    public static void Initializer()
+    {
+        using var provider = new ServiceCollection()
+            .AddGitHubActionsCore()
+            .BuildServiceProvider();
+        gitHubCoreService = provider.GetRequiredService<ICoreService>();
+    }
+
     private List<NewCheckRunAnnotation> annotations = [];
     public bool Success { get; private set; } = true;
 
@@ -153,13 +165,17 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
     /// <param name="repo">The GitHub repo name</param>
     /// <param name="sha">The head sha when running as a GitHub action</param>
     /// <returns>The full check run result object</returns>
-    public async Task BuildCheckRunResult(string token, string owner, string repo, string sha)
+    public async Task<IList<NewCheckRunAnnotation>> BuildCheckRunResult(string token, string owner, string repo, string sha)
     {
+
+        var title = $"{toolName} Check Run results";
+        var summary = $"{toolName} result is {(Success ? "success" : "failure")} with {annotations.Count} diagnostics.";
+
         NewCheckRun result = new(toolName, sha)
         {
             Status = CheckStatus.Completed,
             Conclusion = Success ? CheckConclusion.Success : CheckConclusion.Failure,
-            Output = new($"{toolName} Check Run results", $"{toolName} result is {(Success ? "success" : "failure")} with {annotations.Count} diagnostics.")
+            Output = new(title, summary)
             {
                 Annotations = annotations
             }
@@ -173,6 +189,26 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
         try
         {
             await client.Check.Run.Create(owner, repo, result);
+            var asyncTask = gitHubCoreService?.SetOutputAsync("check_name", title, JsonCheckRunAnnotationSerializerContext.Default.String)
+                ?? ValueTask.CompletedTask;
+            await asyncTask;
+
+            asyncTask = gitHubCoreService?.SetOutputAsync("conclusion", Success ? "success" : "failure", JsonCheckRunAnnotationSerializerContext.Default.String)
+                ?? ValueTask.CompletedTask;
+            await asyncTask;
+
+            asyncTask = gitHubCoreService?.SetOutputAsync("summary", summary, JsonCheckRunAnnotationSerializerContext.Default.String)
+                ?? ValueTask.CompletedTask;
+            await asyncTask;
+
+            asyncTask = gitHubCoreService?.SetOutputAsync("head_sha", sha, JsonCheckRunAnnotationSerializerContext.Default.String)
+                ?? ValueTask.CompletedTask;
+            await asyncTask;
+
+            asyncTask = gitHubCoreService?.SetOutputAsync("annotations", annotations, JsonCheckRunAnnotationSerializerContext.Default.IListNewCheckRunAnnotation)
+                ?? ValueTask.CompletedTask;
+            await asyncTask;
+            // Now, we have a file named annotations.
         }
         // If the token does not have the correct permissions, we will get a 403
         // Once running on a branch on the dotnet org, this should work correctly.
@@ -182,5 +218,6 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
             Console.WriteLine("Exception details:");
             Console.WriteLine(e);
         }
+        return annotations;
     }
 }

--- a/tools/Utilities/StatusCheckLogger.cs
+++ b/tools/Utilities/StatusCheckLogger.cs
@@ -225,6 +225,7 @@ public class StatusCheckLogger(string pathToRoot, string toolName)
                 await core.SetOutputAsync("annotations", annotations, JsonCheckRunAnnotationSerializerContext.Default.IListNewCheckRunAnnotation);
                 
                 core.WriteInfo("Set annotations output");
+                return true; // to get a natural lambda type.
             });
             // Now, we have a file named annotations.
         }

--- a/tools/Utilities/Utilities.csproj
+++ b/tools/Utilities/Utilities.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHub.Actions.Core" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>

--- a/tools/run-section-renumber.sh
+++ b/tools/run-section-renumber.sh
@@ -8,5 +8,6 @@ dotnet run --project $PROJECT -- --owner dotnet --repo csharpstandard
 
 if [ -n "$GITHUB_OUTPUT" ]
 then
-    echo "status=success" >> $GITHUB_OUTPUT 
+    echo "status=success" >> $GITHUB_OUTPUT
+    # blob is in the GITHUB_OUTPUT
 fi


### PR DESCRIPTION
Make the initial code to create a check run using a chained workflow.

This improves security. Our automated tools can run in the `pull_request` context, which means it runs in the context of a fork, rather than the context of the base repository. 

That means our actions can't create status checks. That REST API requires write access to the base repository. 

So, run the tools and build the text output for the status check.

That workflow's completion triggers a workflow that writes the status check.