### PR TITLE
Reconcile library type name lists

### DIFF
--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -236,6 +236,13 @@ namespace System
         public static string Format(string format, params object[] args);
     }
 
+    public class SystemException : Exception
+    {
+        public SystemException();
+        public SystemException(string? message);
+        public SystemException(string? message, Exception? innerException);
+    }
+
     public abstract class Type : MemberInfo { }
 
     public sealed class TypeInitializationException : Exception
@@ -490,6 +497,73 @@ namespace System.Collections.Generic
     }
 }
 
+namespace System.Diagnostics.CodeAnalysis
+{
+    [System.AttributeUsage(System.AttributeTargets.Field |
+      System.AttributeTargets.Parameter | System.AttributeTargets.Property,
+      Inherited=false)]
+    public sealed class AllowNullAttribute : Attribute
+    {
+        public AllowNullAttribute() { }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Field |
+      System.AttributeTargets.Parameter | System.AttributeTargets.Property,
+      Inherited=false)]
+    public sealed class DisallowNullAttribute : Attribute
+    {
+        public DisallowNullAttribute() {}
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Method, Inherited=false)]
+    public sealed class DoesNotReturnAttribute : Attribute
+    {
+        public DoesNotReturnAttribute() {}
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Parameter, Inherited=false)]
+    public sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) {}
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Field | 
+      System.AttributeTargets.Parameter | System.AttributeTargets.Property | 
+      System.AttributeTargets.ReturnValue, Inherited=false)]
+    public sealed class MaybeNullAttribute : Attribute
+    {
+        public MaybeNullAttribute() {}
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Parameter, Inherited=false)]
+    public sealed class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) {}
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Field |
+      System.AttributeTargets.Parameter | System.AttributeTargets.Property | 
+      System.AttributeTargets.ReturnValue, Inherited=false)]
+    public sealed class NotNullAttribute : Attribute
+    {
+        public NotNullAttribute() {}
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Parameter | 
+      System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, 
+      AllowMultiple=true, Inherited=false)]
+    public sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) {}
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Parameter, Inherited=false)]
+    public sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) {}
+    }
+}
+
 namespace System.Linq.Expressions
 {
     public sealed class Expression<TDelegate>
@@ -570,70 +644,6 @@ namespace System.Runtime.CompilerServices
     {
         public bool IsCompleted { get; }
         public TResult GetResult();
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Field |
-      System.AttributeTargets.Parameter | System.AttributeTargets.Property,
-      Inherited=false)]
-    public sealed class AllowNullAttribute : Attribute
-    {
-        public AllowNullAttribute() { }
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Field |
-      System.AttributeTargets.Parameter | System.AttributeTargets.Property,
-      Inherited=false)]
-    public sealed class DisallowNullAttribute : Attribute
-    {
-        public DisallowNullAttribute() {}
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Method, Inherited=false)]
-    public sealed class DoesNotReturnAttribute : Attribute
-    {
-        public DoesNotReturnAttribute() {}
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Parameter, Inherited=false)]
-    public sealed class DoesNotReturnIfAttribute : Attribute
-    {
-        public DoesNotReturnIfAttribute(bool parameterValue) {}
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Field | 
-      System.AttributeTargets.Parameter | System.AttributeTargets.Property | 
-      System.AttributeTargets.ReturnValue, Inherited=false)]
-    public sealed class MaybeNullAttribute : Attribute
-    {
-        public MaybeNullAttribute() {}
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Parameter, Inherited=false)]
-    public sealed class MaybeNullWhenAttribute : Attribute
-    {
-        public MaybeNullWhenAttribute(bool returnValue) {}
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Field |
-      System.AttributeTargets.Parameter | System.AttributeTargets.Property | 
-      System.AttributeTargets.ReturnValue, Inherited=false)]
-    public sealed class NotNullAttribute : Attribute
-    {
-        public NotNullAttribute() {}
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Parameter | 
-      System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, 
-      AllowMultiple=true, Inherited=false)]
-    public sealed class NotNullIfNotNullAttribute : Attribute
-    {
-        public NotNullIfNotNullAttribute(string parameterName) {}
-    }
-
-    [System.AttributeUsage(System.AttributeTargets.Parameter, Inherited=false)]
-    public sealed class NotNullWhenAttribute : Attribute
-    {
-        public NotNullWhenAttribute(bool returnValue) {}
     }
 }
 
@@ -1057,29 +1067,16 @@ The following library types are referenced in this specification. The full names
 - `global::System.Boolean`
 - `global::System.Byte`
 - `global::System.Char`
-- `global::System.Collections.Generic.ICollection<T>`
-- `global::System.Collections.Generic.IEnumerable<T>`
-- `global::System.Collections.Generic.IEnumerator<T>`
-- `global::System.Collections.Generic.IList<T>`
-- `global::System.Collections.Generic.IReadonlyCollection<out T>`
-- `global::System.Collections.Generic.IReadOnlyList<out T>`
-- `global::System.Collections.ICollection`
-- `global::System.Collections.IEnumerable`
-- `global::System.Collections.IList`
-- `global::System.Collections.IEnumerator`
 - `global::System.Decimal`
 - `global::System.Delegate`
-- `global::System.Diagnostics.ConditionalAttribute`
 - `global::System.DivideByZeroException`
 - `global::System.Double`
 - `global::System.Enum`
 - `global::System.Exception`
+- `global::System.FormattableString`
 - `global::System.GC`
-- `global::System.ICollection`
 - `global::System.IDisposable`
-- `global::System.IEnumerable`
-- `global::System.IEnumerable<out T>`
-- `global::System.IList`
+- `global::System.IFormattable`
 - `global::System.IndexOutOfRangeException`
 - `global::System.Int16`
 - `global::System.Int32`
@@ -1087,37 +1084,73 @@ The following library types are referenced in this specification. The full names
 - `global::System.IntPtr`
 - `global::System.InvalidCastException`
 - `global::System.InvalidOperationException`
-- `global::System.Linq.Expressions.Expression<TDelegate>`
-- `global::System.MemberInfo`
 - `global::System.NotSupportedException`
 - `global::System.Nullable<T>`
 - `global::System.NullReferenceException`
 - `global::System.Object`
 - `global::System.ObsoleteAttribute`
+- `global::System.OperationCanceledException`
 - `global::System.OutOfMemoryException`
 - `global::System.OverflowException`
-- `global::System.Runtime.CompilerServices.CallerFileAttribute`
-- `global::System.Runtime.CompilerServices.CallerLineNumberAttribute`
-- `global::System.Runtime.CompilerServices.CallerMemberNameAttribute`
-- `global::System.Runtime.CompilerServices.ICriticalNotifyCompletion`
-- `global::System.Runtime.CompilerServices.IndexerNameAttribute`
-- `global::System.Runtime.CompilerServices.INotifyCompletion`
-- `global::System.Runtime.CompilerServices.TaskAwaiter`
-- `global::System.Runtime.CompilerServices.TaskAwaiter<T>`
+- `global::System.ReadOnlySpan`
 - `global::System.SByte`
 - `global::System.Single`
+- `global::System.Span`
 - `global::System.StackOverflowException`
 - `global::System.String`
 - `global::System.SystemException`
-- `global::System.Threading.Monitor`
-- `global::System.Threading.Tasks.Task`
-- `global::System.Threading.Tasks.Task<TResult>`
 - `global::System.Type`
 - `global::System.TypeInitializationException`
 - `global::System.UInt16`
 - `global::System.UInt32`
 - `global::System.UInt64`
 - `global::System.UIntPtr`
+- `global::System.ValueTuple<T1>`
+- `global::System.ValueTuple<T1, T2>`
+- `global::System.ValueTuple<T1, T2, T3>`
+- `global::System.ValueTuple<T1, T2, T3, T4>`
+- `global::System.ValueTuple<T1, T2, T3, T4, T5>`
+- `global::System.ValueTuple<T1, T2, T3, T4, T5, T6>`
+- `global::System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
+- `global::System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>`
 - `global::System.ValueType`
+- `global::System.Collections.ICollection`
+- `global::System.Collections.IEnumerable`
+- `global::System.Collections.IEnumerator`
+- `global::System.Collections.IList`
+- `global::System.Collections.Generic.ICollection<T>`
+- `global::System.Collections.Generic.IEnumerable<T>`
+- `global::System.Collections.Generic.IEnumerator<T>`
+- `global::System.Collections.Generic.IList<T>`
+- `global::System.Collections.Generic.IReadonlyCollection<out T>`
+- `global::System.Collections.Generic.IReadOnlyList<out T>`
+- `global::System.Diagnostics.ConditionalAttribute`
+- `global::System.Diagnostics.CodeAnalysis.AllowNullAttribute`
+- `global::System.Diagnostics.CodeAnalysis.DisallowNullAttribute`
+- `global::System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute`
+- `global::System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute`
+- `global::System.Diagnostics.CodeAnalysis.MaybeNullAttribute`
+- `global::System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute`
+- `global::System.Diagnostics.CodeAnalysis.NotNullAttribute`
+- `global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute`
+- `global::System.Diagnostics.CodeAnalysis.NotNullWhenAttribute `
+- `global::System.Linq.Expressions.Expression<TDelegate>`
+- `global::System.Reflection.MemberInfo`
+- `global::System.Runtime.CompilerServices.AsyncMethodBuilderAttribute`
+- `global::System.Runtime.CompilerServices.CallerFileAttribute`
+- `global::System.Runtime.CompilerServices.CallerLineNumberAttribute`
+- `global::System.Runtime.CompilerServices.CallerMemberNameAttribute`
+- `global::System.Runtime.CompilerServices.FormattableStringFactory`
+- `global::System.Runtime.CompilerServices.ICriticalNotifyCompletion`
+- `global::System.Runtime.CompilerServices.IndexerNameAttribute`
+- `global::System.Runtime.CompilerServices.INotifyCompletion`
+- `global::System.Runtime.CompilerServices.TaskAwaiter`
+- `global::System.Runtime.CompilerServices.TaskAwaiter<T>`
+- `global::System.Runtime.CompilerServices.ValueTaskAwaiter`
+- `global::System.Runtime.CompilerServices.ValueTaskAwaiter<TResult>`
+- `global::System.Runtime.CompilerServices.Unsafe`
+- `global::System.Threading.Monitor`
+- `global::System.Threading.Tasks.Task`
+- `global::System.Threading.Tasks.Task<TResult>`
 
 **End of informative text.**

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -1133,7 +1133,7 @@ The following library types are referenced in this specification. The full names
 - `global::System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute`
 - `global::System.Diagnostics.CodeAnalysis.NotNullAttribute`
 - `global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute`
-- `global::System.Diagnostics.CodeAnalysis.NotNullWhenAttribute `
+- `global::System.Diagnostics.CodeAnalysis.NotNullWhenAttribute`
 - `global::System.Linq.Expressions.Expression<TDelegate>`
 - `global::System.Reflection.MemberInfo`
 - `global::System.Runtime.CompilerServices.AsyncMethodBuilderAttribute`


### PR DESCRIPTION
[I consider this an editorial fix, and gave it a label of "formatting."]

Recently, I was looking at the library types we require from CLI ([C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)), those we require since the CLI spec ([C.3](standard/standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)), and the list of fully qualified type names in [C.5](standard-library.md#c5-library-type-abbreviations). There are discrepancies, and this PR addresses them. Specifically:

1. One type (`SystemException`) was missing from C2.
2. Some new types added post-CLI were not in the C.5 list.
1. The attribute types added for the nullable reference types PR were put in the wrong namespace in C.3. I put them in the correct namespace, `System.Diagnostics.CodeAnalysis`.
1. Some types in C.5 had the wrong qualified name.
1. The C.5 list was in alpha order, with types in different namespaces interspersed, which was not a useful order. So I put them in type order within namespace order.

Once this PR has been merged, I'll review V8 (and beyond) Draft PRs (such as Indexes/Ranges) to see which, if any, should also update C.5.