### PR TITLE
update dependency action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions" # Core GitHub Actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
   - package-ecosystem: "nuget"
     directory: "/tools" #tools.sln
     schedule:

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -69,7 +69,7 @@ jobs:
       shell: bash
 
     - name: Upload Word artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: > 
         ${{ steps.renumber-sections.outputs.status }} == 'success' && 
         ${{ steps.update-grammar.outputs.status }} == 'success' && 


### PR DESCRIPTION
The action that generates the PR when we merge changes is failing because the dependent action for uploading the Word doc is deprecated.

Update it, and configure dependabot to tell us about these updates so this doesn't happen again.