### PR TITLE
Addresses issue #1283.

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4161,7 +4161,7 @@ equality_expression
     ;
 ```
 
-> *Note*: Lookup for the right operand of the `is` operator must first test as a *type*, then as an *expression* which may span multiple tokens. In the case where the operand is an *expreesion*, the pattern expression must have precedence at least as high as *shift_expression*. *end note*
+> *Note*: Lookup for the right operand of the `is` operator must first test as a *type*, then as an *expression* which may span multiple tokens. In the case where the operand is an *expression*, the pattern expression must have precedence at least as high as *shift_expression*. *end note*
 
 The `is` operator is described in [§12.12.12](expressions.md#121212-the-is-operator) and the `as` operator is described in [§12.12.13](expressions.md#121213-the-as-operator).
 

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -76,9 +76,7 @@ These productions occur in contexts where a value can occur in an expression, an
 >
 > *end example*
 
-If a sequence of tokens can be parsed, in context, as one of the disambiguated productions
-including an optional *type_argument_list* ([§8.4.2](types.md#842-type-arguments)), then
-the token immediately following the closing `>` token shall be examined and if it is:
+If a sequence of tokens can be parsed, in context, as one of the disambiguated productions including an optional *type_argument_list* ([§8.4.2](types.md#842-type-arguments)), then the token immediately following the closing `>` token shall be examined and if it is:
 
 - one of `(  )  ]  }  :  ;  ,  .  ?  ==  !=  |  ^  &&  ||  &  [`; or
 - one of the relational operators `<  <=  >=  is as`; or
@@ -86,7 +84,7 @@ the token immediately following the closing `>` token shall be examined and if 
 
 then the *type_argument_list* shall be retained as part of the disambiguated production and any other possible parse of the sequence of tokens discarded. Otherwise, the tokens parsed as a *type_argument_list* shall not be considered to be part of the disambiguated production, even if there is no other possible parse of those tokens.
 
-> *Note*: These disambiguation rules shall not be applied when parsing other productions even if they similarly end in “`identifier type_argument_list?`”; such productions shall be parsed as normal. Examples include: *namespace_or_type_name* ([§7.8](basic-concepts.md#78-namespace-and-type-names)); *named_entity* ([§12.8.23](expressions.md#12823-the-nameof-operator)); *null_conditional_projection_initializer* ([§12.8.8](expressions.md#§1288-null-conditional-member-access)); and *qualified_alias_member* ([§14.8.1](namespaces.md#1481-general)). *end note*
+> *Note*: These disambiguation rules shall not be applied when parsing other productions even if they similarly end in “`identifier type_argument_list?`”; such productions shall be parsed as normal. Examples include: *namespace_or_type_name* ([§7.8](basic-concepts.md#78-namespace-and-type-names)); *named_entity* ([§12.8.23](expressions.md#12823-the-nameof-operator)); *null_conditional_projection_initializer* ([§12.8.8](expressions.md#1288-null-conditional-member-access)); and *qualified_alias_member* ([§14.8.1](namespaces.md#1481-general)). *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->

--- a/standard/lexical-structure.md
+++ b/standard/lexical-structure.md
@@ -57,7 +57,7 @@ The productions for:
 - *simple_name* ([§12.8.4](expressions.md#1284-simple-names)),
 - *member_access* ([§12.8.7](expressions.md#1287-member-access)),
 - *null_conditional_member_access* ([§12.8.8](expressions.md#1288-null-conditional-member-access)),
-- *dependent_access* ([§12.8.8](expressions.md#1288-dependent-access)),
+- *dependent_access* ([§12.8.8](expressions.md#1288-null-conditional-member-access)),
 - *base_access* ([§12.8.15](expressions.md#12815-base-access)) and
 - *pointer_member_access* ([§23.6.3](unsafe-code.md#2363-pointer-member-access));
 
@@ -86,7 +86,7 @@ the token immediately following the closing `>` token shall be examined and if 
 
 then the *type_argument_list* shall be retained as part of the disambiguated production and any other possible parse of the sequence of tokens discarded. Otherwise, the tokens parsed as a *type_argument_list* shall not be considered to be part of the disambiguated production, even if there is no other possible parse of those tokens.
 
-> *Note*: These disambiguation rules shall not be applied when parsing other productions even if they similarly end in “`identifier type_argument_list?`”; such productions shall be parsed as normal. Examples include: *namespace_or_type_name* ([§7.8](basic-concepts.md#78-namespace-and-type-names)); *named_entity* ([§12.8.23](expressions.md#12823-named-entity)); *null_conditional_projection_initializer* ([§12.8.8](expressions.md#§1288-null_conditional-projection-initializer)); and *qualified_alias_member* ([§14.8.1](namespaces.md#1481-qualified-alias-member)). *end note*
+> *Note*: These disambiguation rules shall not be applied when parsing other productions even if they similarly end in “`identifier type_argument_list?`”; such productions shall be parsed as normal. Examples include: *namespace_or_type_name* ([§7.8](basic-concepts.md#78-namespace-and-type-names)); *named_entity* ([§12.8.23](expressions.md#12823-the-nameof-operator)); *null_conditional_projection_initializer* ([§12.8.8](expressions.md#§1288-null-conditional-member-access)); and *qualified_alias_member* ([§14.8.1](namespaces.md#1481-general)). *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->


### PR DESCRIPTION
Updates §6.2.5 as per issue and also changes the descriptive style to the proscriptive requirement of the Standard.

Issuing as draft to allow time for comments on #1283.

Note: In #1283 I promised test cases for *type_argument_list* parsing. These have been incorporated into a grammar testing update, #1284, and can be found in `tools/GrammarTesting/Tests/Parsing/Samples/v8` samples `Type argument list` and `TAL Query expressions`.