### PR TITLE
Unconstrained type parameters and `??`

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4828,8 +4828,7 @@ The type of the expression `a ?? b` depends on which implicit conversions are 
 - Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type, `b` has a type `B` and an implicit conversion exists from `A₀` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀` and converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
 - Otherwise, if `b` has a type `B` and an implicit conversion exists from `a` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
-
-Otherwise, `a` and `b` are incompatible, and a compile-time error occurs.
+- Otherwise, `a` and `b` are incompatible, and a compile-time error occurs.
 
 > *Example*:
 >

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4840,7 +4840,7 @@ The type of the expression `a ?? b` depends on which implicit conversions are 
 > int i = M(19, 23);
 > ```
 >
-> The parameters to `M` are unconstrained. Therefore, the type argument can be a reference type, or nullable value type, as shown in the first call to `M`. The type argument can also be a non-nullable value type, as shown in the second call to `M`. When the type argument is a non-nullable value type, the expression `a ?? b` is `a`.
+> The type parameter `T` for method `M` is unconstrained. Therefore, the type argument can be a reference type, or nullable value type, as shown in the first call to `M`. The type argument can also be a non-nullable value type, as shown in the second call to `M`. When the type argument is a non-nullable value type, the expression `a ?? b` is `a`.
 >
 > *end example*
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4841,7 +4841,7 @@ Otherwise, `a` and `b` are incompatible, and a compile-time error occurs.
 > int i = M(19, 23);
 > ```
 >
-> The parameters to `M` are unconstrained. Therefore, the type arguments can be reference types, or nullable value types, as shown in the first call to `M`. The type arguments can also be non-nullable value types, as shown in the second call to `M`. When the type argument is a non-nullable value type, the expression `a ?? b` is `a`.
+> The parameters to `M` are unconstrained. Therefore, the type argument can be a reference type, or nullable value type, as shown in the first call to `M`. The type argument can also be a non-nullable value type, as shown in the second call to `M`. When the type argument is a non-nullable value type, the expression `a ?? b` is `a`.
 >
 > *end example*
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4840,7 +4840,7 @@ The type of the expression `a ?? b` depends on which implicit conversions are 
 > int i = M(19, 23);
 > ```
 >
-> The type parameter `T` for method `M` is unconstrained. Therefore, the type argument can be a reference type, or nullable value type, as shown in the first call to `M`. The type argument can also be a non-nullable value type, as shown in the second call to `M`. When the type argument is a non-nullable value type, the expression `a ?? b` is `a`.
+> The type parameter `T` for method `M` is unconstrained. Therefore, the type argument can be a reference type, or nullable value type, as shown in the first call to `M`. The type argument can also be a non-nullable value type, as shown in the second call to `M`. When the type argument is a non-nullable value type, the value of the expression `a ?? b` is `a`.
 >
 > *end example*
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4822,7 +4822,7 @@ The null coalescing operator is right-associative, meaning that operations are g
 
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
-- If `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
+- If `A` exists and is not a nullable value type, a compile-time error occurs.
 - Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
 - Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4822,7 +4822,7 @@ The null coalescing operator is right-associative, meaning that operations are g
 
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
-- If `A` exists and is an unmanaged type (§8.8) or a non-nullable value type, a compile-time error occurs.
+- If `A` exists and is an unmanaged type (§8.8) or known to be a non-nullable value type, a compile-time error occurs.
 - Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
 - Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.
@@ -4830,6 +4830,20 @@ The type of the expression `a ?? b` depends on which implicit conversions are 
 - Otherwise, if `b` has a type `B` and an implicit conversion exists from `a` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.
 
 Otherwise, `a` and `b` are incompatible, and a compile-time error occurs.
+
+> *Example*:
+>
+> <!-- Example: {template:"standalone-console-without-using", name:"DeclarationExpressions1"} -->
+> ```csharp
+> T M<T>(T a, T b) => a ?? b;
+>
+> string s = M(null, "text");
+> int i = M(19, 23);
+> ```
+>
+> The parameters to `M` are unconstrained. Therefore, the type arguments can be reference types, or nullable value types, as shown in the first call to `M`. The type arguments can also be non-nullable value types, as shown in the second call to `M`. When the type argument is a non-nullable value type, the expression `a ?? b` is `a`.
+>
+> *end example*
 
 ## 12.16 The throw expression operator
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4822,7 +4822,7 @@ The null coalescing operator is right-associative, meaning that operations are g
 
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
-- If `A` exists and is a non-nullable value type a compile-time error occurs.
+- If `A` exists and is an unmanaged type (§8.8) or a non-nullable value type, a compile-time error occurs.
 - Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
 - Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4822,7 +4822,7 @@ The null coalescing operator is right-associative, meaning that operations are g
 
 The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
-- If `A` exists and is not a nullable value type, a compile-time error occurs.
+- If `A` exists and is a non-nullable value type a compile-time error occurs.
 - Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
 - Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4820,10 +4820,14 @@ The null coalescing operator is right-associative, meaning that operations are g
 
 > *Example*: An expression of the form `a ?? b ?? c` is evaluated as `a ?? (b ?? c)`. In general terms, an expression of the form `E1 ?? E2 ?? ... ?? EN` returns the first of the operands that is non-`null`, or `null` if all operands are `null`. *end example*
 
-The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
+The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, :
 
-- If `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
-- Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
+- If `A` is an unconstrained type parameter, `B` must be the same type parameter `T1`, a type parameter `T2` constrained to have an implicit reference conversion to `T1` or the type `dynamic`. The type of `a ?? b` is:
+  - The type of `T1` when the type argument for `T1` is a non-nullable value type. The result is `a`.
+  - Otherwise, the type `dynamic?` if `B` is the type `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic?`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
+  - Otherwise, the type `T1?`.
+- Otherwise, if `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
+- Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic?`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic?`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
 - Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type, `b` has a type `B` and an implicit conversion exists from `A₀` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀` and converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4820,14 +4820,10 @@ The null coalescing operator is right-associative, meaning that operations are g
 
 > *Example*: An expression of the form `a ?? b ?? c` is evaluated as `a ?? (b ?? c)`. In general terms, an expression of the form `E1 ?? E2 ?? ... ?? EN` returns the first of the operands that is non-`null`, or `null` if all operands are `null`. *end example*
 
-The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, :
+The type of the expression `a ?? b` depends on which implicit conversions are available on the operands. In order of preference, the type of `a ?? b` is `A₀`, `A`, or `B`, where `A` is the type of `a` (provided that `a` has a type), `B` is the type of `b`(provided that `b` has a type), and `A₀` is the underlying type of `A` if `A` is a nullable value type, or `A` otherwise. Specifically, `a ?? b` is processed as follows:
 
-- If `A` is an unconstrained type parameter, `B` must be the same type parameter `T1`, a type parameter `T2` constrained to have an implicit reference conversion to `T1` or the type `dynamic`. The type of `a ?? b` is:
-  - The type of `T1` when the type argument for `T1` is a non-nullable value type. The result is `a`.
-  - Otherwise, the type `dynamic?` if `B` is the type `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic?`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
-  - Otherwise, the type `T1?`.
-- Otherwise, if `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
-- Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic?`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic?`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
+- If `A` exists and is not a nullable value type or a reference type, a compile-time error occurs.
+- Otherwise, if `A` exists and `b` is a dynamic expression, the result type is `dynamic`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is converted to `dynamic`, and this becomes the result. Otherwise, `b` is evaluated, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type and an implicit conversion exists from `b` to `A₀`, the result type is `A₀`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀`, and this becomes the result. Otherwise, `b` is evaluated and converted to type `A₀`, and this becomes the result.
 - Otherwise, if `A` exists and an implicit conversion exists from `b` to `A`, the result type is `A`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` becomes the result. Otherwise, `b` is evaluated and converted to type `A`, and this becomes the result.
 - Otherwise, if `A` exists and is a nullable value type, `b` has a type `B` and an implicit conversion exists from `A₀` to `B`, the result type is `B`. At run-time, `a` is first evaluated. If `a` is not `null`, `a` is unwrapped to type `A₀` and converted to type `B`, and this becomes the result. Otherwise, `b` is evaluated and becomes the result.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -4832,7 +4832,7 @@ The type of the expression `a ?? b` depends on which implicit conversions are 
 
 > *Example*:
 >
-> <!-- Example: {template:"standalone-console-without-using", name:"DeclarationExpressions1"} -->
+> <!-- Example: {template:"standalone-console-without-using", name:"NullCoalescingGenerics"} -->
 > ```csharp
 > T M<T>(T a, T b) => a ?? b;
 >


### PR DESCRIPTION
Fixes #737

Add the language to the null-coalescing operator so that `??` can be used with an unconstrained type parameter.

Notes for reviewers:

After looking at the final change, glance at the commit by commit history.

The only change is to remove the phrase "or a reference type" from the first bullet. By doing that, an unconstrained type parameter `T` is allowed. It's not a reference type.

I tested the case Nigel and Kalle described for using `??` with an unconstrained type parameter, and the existing rules produce the behavior they described.

I ran a few other cases to validate, and those worked correctly as well.

The commit-by-commit history shows what I first started to write by adding a bullet for unconstrained type parameters, then spec'ing that behavior. That started me on the path of just removing the restriction. I checked with the compiler team, and they agreed.
