### PR TITLE
Fix broken example tester workflow on draft-v8, and make tools runnable out of the box

### DIFF
--- a/.github/workflows/do-not-merge-label-check.yml
+++ b/.github/workflows/do-not-merge-label-check.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: 'Check "${{ matrix.label }}" label'
         run: |
-          echo "::notice::Merging permission is diabled for PRs when the '${{ matrix.label }}' label is applied."
+          echo "::notice::Merging permission is disabled for PRs when the '${{ matrix.label }}' label is applied."
 
           if [ "${{ contains(github.event.pull_request.labels.*.name, matrix.label) }}" = "true" ]; then
             echo "::error::Pull request is labeled as '${{ matrix.label }}'. Please remove the label before merging."

--- a/.github/workflows/grammar-validator.yaml
+++ b/.github/workflows/grammar-validator.yaml
@@ -4,6 +4,11 @@ name: ANTLR Grammar validator
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "standard/**"
+      - "tools/GrammarTesting/**"
+      - "tools/validate-grammar.sh"
+      - ".github/workflows/dependencies/GrammarTestingEnv.tgz"
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -4,6 +4,10 @@ name: Renumber standard TOC
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "standard/**"
+      - "tools/StandardAnchorTags/**"
+      - "tools/run-section-renumber.sh"
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -6,6 +6,11 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "standard/*.md"
+      - "tools/example-templates/**"
+      - "tools/ExampleExtractor/**"
+      - "tools/ExampleTester/**"
+      - "tools/Utilities/**"
+      - "tools/test-examples.sh"
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/tools-tests.yaml
+++ b/.github/workflows/tools-tests.yaml
@@ -5,9 +5,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - '**.cs'
-      - '**.csproj'
-      - '**.sln'
+      - 'tools/**.cs'
+      - 'tools/**.csproj'
+      - 'tools/**.sln'
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/word-converter.yaml
+++ b/.github/workflows/word-converter.yaml
@@ -4,6 +4,10 @@ name: Word Converter
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "standard/**"
+      - "tools/MarkdownConverter/**"
+      - "tools/run-converter.sh"
   workflow_dispatch:
     inputs:
       reason:

--- a/.gitignore
+++ b/.gitignore
@@ -360,6 +360,3 @@ test-grammar/
 
 # don't checkin jar files:
 *.jar
-
-# don't checkin launchSettings:
-**/launchSettings.json

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -767,7 +767,7 @@ Specifically, an anonymous function `F` is compatible with a delegate type `D`
 
 > *Example*: The following examples illustrate these rules:
 >
-> <!-- Example: {template:"code-in-class-lib-without-using", name:"AnonymousFunctionsConv1", expectedErrors:["CS1593","CS1661","CS1678","CS8030","CS1688","CS1661","CS1676","CS1643","CS0126","CS0029","CS1662","CS1670","CS0029","CS1662"]} -->
+> <!-- Example: {template:"code-in-class-lib-without-using", name:"AnonymousFunctionsConv1", expectedErrors:["CS1593","CS1661","CS1678","CS8030","CS1688","CS1676","CS1643","CS0126","CS0029","CS1662","CS1670","CS0029","CS1662"]} -->
 > ```csharp
 > delegate void D(int x);
 > D d1 = delegate { };                         // Ok

--- a/tools/ExampleExtractor/Properties/launchSettings.json
+++ b/tools/ExampleExtractor/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "ExampleExtractor": {
+      "commandName": "Project",
+      "commandLineArgs": "../standard example-templates tmp",
+      "workingDirectory": "$(SolutionDir)"
+    }
+  }
+}

--- a/tools/ExampleFormatter/Properties/launchSettings.json
+++ b/tools/ExampleFormatter/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "ExampleFormatter": {
+      "commandName": "Project",
+      "commandLineArgs": "../standard",
+      "workingDirectory": "$(SolutionDir)"
+    }
+  }
+}

--- a/tools/ExampleTester/ExampleTester.csproj
+++ b/tools/ExampleTester/ExampleTester.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/tools/ExampleTester/GeneratedExample.cs
+++ b/tools/ExampleTester/GeneratedExample.cs
@@ -1,5 +1,4 @@
 ﻿using ExampleExtractor;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Newtonsoft.Json;
@@ -11,11 +10,6 @@ namespace ExampleTester;
 
 internal class GeneratedExample
 {
-    static GeneratedExample()
-    {
-        MSBuildLocator.RegisterDefaults();
-    }
-
     private readonly string directory;
     internal ExampleMetadata Metadata { get; }
 

--- a/tools/ExampleTester/Properties/launchSettings.json
+++ b/tools/ExampleTester/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "ExampleTester": {
+      "commandName": "Project",
+      "commandLineArgs": "tmp",
+      "workingDirectory": "$(SolutionDir)"
+    }
+  }
+}

--- a/tools/MarkdownConverter/Properties/launchSettings.json
+++ b/tools/MarkdownConverter/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "MarkdownConverter": {
+      "commandName": "Project",
+      "commandLineArgs": "../standard/*.md MarkdownConverter/template.docx -o tmp/standard.docx",
+      "workingDirectory": "$(SolutionDir)"
+    }
+  }
+}

--- a/tools/StandardAnchorTags/Properties/launchSettings.json
+++ b/tools/StandardAnchorTags/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "StandardAnchorTags": {
+      "commandName": "Project",
+      "commandLineArgs": "--owner dotnet --repo csharpstandard",
+      "workingDirectory": "$(SolutionDir)"
+    }
+  }
+}

--- a/tools/StandardAnchorTags/StandardAnchorTags.csproj
+++ b/tools/StandardAnchorTags/StandardAnchorTags.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,10 +6,6 @@
     <Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />


### PR DESCRIPTION
Fixes the following issues:

1. MSBuildLocator isn't needed (https://github.com/dotnet/roslyn/issues/78478#issuecomment-2856390151) and it is failing on my machine where I have only VS Preview installed. I believe MSBuildLocator by default doesn't see preview installations.

2. Add launch settings to the tools so that they are runnable immediately after cloning the repo by pressing F5 in Visual Studio. The launch settings contain the same arguments that are used for the workflow runs.

3. Fix the broken example tester workflow. <https://github.com/dotnet/csharpstandard/pull/1334#pullrequestreview-2886364073> caused it to start failing for the AnonymousFunctionsConv1 example because it pulled in Roslyn v4.14, which no longer reports a CS1661 diagnostic at the same location as a CS1678 error. (Discussed at https://github.com/dotnet/roslyn/pull/75400/files#r1866802220.) The workflow did not run for that PR, so this was not discovered until unrelated PRs started coming through.

4. Add more paths to the example tester workflow trigger to catch issues like the above next time.

Also, this PR adds path filters for the other PR-triggered workflows so that they only run when files change which can currently affect them.

@BillWagner You had [gitignored](https://github.com/dotnet/csharpstandard/pull/1179/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) the launch profiles; what do you think about reversing this?