### PR TITLE
Revert path filters on required checks

### DIFF
--- a/.github/workflows/grammar-validator.yaml
+++ b/.github/workflows/grammar-validator.yaml
@@ -4,11 +4,6 @@ name: ANTLR Grammar validator
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "standard/**"
-      - "tools/GrammarTesting/**"
-      - "tools/validate-grammar.sh"
-      - ".github/workflows/dependencies/GrammarTestingEnv.tgz"
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -4,10 +4,6 @@ name: Renumber standard TOC
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "standard/**"
-      - "tools/StandardAnchorTags/**"
-      - "tools/run-section-renumber.sh"
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/word-converter.yaml
+++ b/.github/workflows/word-converter.yaml
@@ -4,6 +4,10 @@ name: Word Converter
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "standard/**"
+      - "tools/MarkdownConverter/**"
+      - "tools/run-converter.sh"
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/word-converter.yaml
+++ b/.github/workflows/word-converter.yaml
@@ -4,10 +4,6 @@ name: Word Converter
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "standard/**"
-      - "tools/MarkdownConverter/**"
-      - "tools/run-converter.sh"
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
Three of the four workflows which gained new path filters in https://github.com/dotnet/csharpstandard/pull/1336 are required checks. It appears that if a workflow is a required check, GitHub will not allow that check to be satisfied when the workflow's filter tells it not to be triggered:

![image](https://github.com/user-attachments/assets/83fcfd91-53ba-4729-9b5f-0910048732f4)