### PR TITLE
Add support for variance safety for static interface members

### DIFF
--- a/standard/interfaces.md
+++ b/standard/interfaces.md
@@ -91,9 +91,9 @@ If a generic interface is declared in multiple parts ([§15.2.3](classes.md#1523
 
 #### 18.2.3.2 Variance safety
 
-The occurrence of variance annotations in the type parameter list of a type restricts the places where types can occur within the type declaration.
+The occurrence of variance annotations in the type parameter list of a type restricts the places where types can occur within the type declaration. However, these restrictions do not apply to occurrences of types within a declaration of a static member.
 
-A type T is ***output-unsafe*** if one of the following holds:
+A type `T` is ***output-unsafe*** if one of the following holds:
 
 - `T` is a contravariant type parameter
 - `T` is an array type with an output-unsafe element type
@@ -101,11 +101,11 @@ A type T is ***output-unsafe*** if one of the following holds:
   - `Xᵢ` is covariant or invariant and `Aᵢ` is output-unsafe.
   - `Xᵢ` is contravariant or invariant and `Aᵢ` is input-unsafe.
 
-A type T is ***input-unsafe*** if one of the following holds:
+A type `T` is ***input-unsafe*** if one of the following holds:
 
 - `T` is a covariant type parameter
 - `T` is an array type with an input-unsafe element type
-- `T` is an interface or delegate type  `S<Aᵢ,... Aₑ>` constructed from a generic type `S<Xᵢ, ... Xₑ>` where for at least one `Aᵢ` one of the following holds:
+- `T` is an interface or delegate type `S<Aᵢ,... Aₑ>` constructed from a generic type `S<Xᵢ, ... Xₑ>` where for at least one `Aᵢ` one of the following holds:
   - `Xᵢ` is covariant or invariant and `Aᵢ` is input-unsafe.
   - `Xᵢ` is contravariant or invariant and `Aᵢ` is output-unsafe.
 


### PR DESCRIPTION
I just discovered this V9 feature spec [here](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/variance-safety-for-static-interface-members.md). To make sure this was actually implemented in V9, I compiled the following code:

```csharp
using System;
using System.Threading.Tasks;

public interface I<out T>
{
    static Task<T> F = Task.FromResult(default(T)); // No problem
    static Task<T> P => Task.FromResult(default(T));   //CS8904 in V8 but OK in V9
    static Task<T> M() => Task.FromResult(default(T));    //CS8904 in V8 but OK in V9
    static event EventHandler<T>? E; // CS8904 in V8 but OK in V9
}
```

The errors produced by V8 do *not* occur in V9.

