### PR TITLE
Remove path filters for required workflows

### DIFF
--- a/.github/workflows/grammar-validator.yaml
+++ b/.github/workflows/grammar-validator.yaml
@@ -4,11 +4,6 @@ name: ANTLR Grammar validator
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "standard/**"
-      - "tools/GrammarTesting/**"
-      - "tools/validate-grammar.sh"
-      - ".github/workflows/dependencies/GrammarTestingEnv.tgz"
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -4,10 +4,6 @@ name: Renumber standard TOC
 on: 
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "standard/**"
-      - "tools/StandardAnchorTags/**"
-      - "tools/run-section-renumber.sh"
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
It's a good idea to save time and resources to not run those workflows that don't need to run.

However, that introduces a problem for workflows that are required before merging a PR. If the work flow doesn't run, it doesn't succeed.

@jnm2 We need a different way to short-circuit the work and report success when a check isn't necessary.