### PR TITLE
Add a new "General" subclause

### DIFF
--- a/standard/types.md
+++ b/standard/types.md
@@ -851,6 +851,8 @@ When the nullable context is ***enabled***:
 
 ### 8.9.5 Nullabilities and null states
 
+#### §null-analysis-general General
+
 A compiler is not required to perform any static analysis nor is it required to generate any diagnostic warnings related to nullability.
 
 **The remainder of this subclause is conditionally normative.**


### PR DESCRIPTION
#1351 added two new subclauses to 8.9.5. However, it also left text in 8.95.

IIRC, every heading must have either text or sub-headings. Never both. @RexJaeschke will know for sure.

This PR adds a new General clause for the text that was in 8.9.5