### PR TITLE
Remove optional members from C.3 type `System.Threading.CancellationToken`

### DIFF
--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -711,8 +711,6 @@ namespace System.Threading.Tasks
         public CancellationTokenRegistration UnsafeRegister(Action<object?> callback, object? state);
         public CancellationTokenRegistration UnsafeRegister(Action<object?, CancellationToken> callback, object? state);
         public bool Equals(CancellationToken other);
-        public override bool Equals([NotNullWhen(true)] object? other);
-        public override int GetHashCode();
         public static bool operator ==(CancellationToken left, CancellationToken right);
         public static bool operator !=(CancellationToken left, CancellationToken right);
         public void ThrowIfCancellationRequested();


### PR DESCRIPTION
## Primary Issue

In C.2, we declare type `System.Object` with the following members (among others):

```csharp
public virtual bool Equals(object obj);
public virtual int GetHashCode();
public virtual string? ToString();
```

As Nigel recently pointed out, until recently our spec did *not* require these be overridden by any types we added in C.3. However, the recent addition of type `CancellationToken` includes two of these three, and after talking to Bill, this PR removes them.

## Secondary Issue

Do we even need `CancellationToken`?

[Note that the MS proposal for [async streams](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-8.0/async-streams.md) mentions this type 28 times!]

In C.3, we declare

```csharp
namespace System.Collections.Generic
{
    public interface IAsyncEnumerable<out T>
    {
        IAsyncEnumerator<T> GetAsyncEnumerator();
    }
}
```

Now the .NET library actually declares that method, as follows:

```csharp
public System.Collections.Generic.IAsyncEnumerator<out T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default);
```

which caused me to initially ask the question, "Do we need to say anything about `CancellationToken`?"

BTW, in the Statements clause we do call that method, as follows:

```csharp
IAsyncEnumerator<T> GetAsyncEnumerator();
E e = ((C)(x)).GetAsyncEnumerator();
var enumerator = enumerable.GetAsyncEnumerator();
```

**all without an explicit argument**.

As best as I can see, we do *not* currently mention `CancellationToken` except to declare it in C.3; however, @BillWagner might still have some work pending re this topic, which might use that type.

If he does not, we can remove the whole type. If he does, we can retain the type but remove all members we don't *require*, as has been our custom with C.3 types.

FYI, the current set of "required" members for this type is

```csharp
public static CancellationToken None { get; }
public bool IsCancellationRequested { get; }
public bool CanBeCanceled { get; }
public WaitHandle WaitHandle { get; }
public CancellationToken(bool canceled);
public CancellationTokenRegistration Register(Action callback);
public CancellationTokenRegistration Register(Action callback, bool useSynchronizationContext);
public CancellationTokenRegistration Register(Action<object?> callback, object? state);
public CancellationTokenRegistration Register(Action<object?, CancellationToken> callback, object? state);
public CancellationTokenRegistration Register(Action<object?> callback, object? state, bool useSynchronizationContext);
public CancellationTokenRegistration UnsafeRegister(Action<object?> callback, object? state);
public CancellationTokenRegistration UnsafeRegister(Action<object?, CancellationToken> callback, object? state);
public bool Equals(CancellationToken other);
public static bool operator ==(CancellationToken left, CancellationToken right);
public static bool operator !=(CancellationToken left, CancellationToken right);
public void ThrowIfCancellationRequested();
```

