### PR TITLE
Allow arrays of nullable reference types

### DIFF
--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -54,9 +54,7 @@ At run-time, a value of an array type can be `null` or a reference to an instanc
 
 The nullable annotation `?` may be placed on an array type, as in `T[R]?`. Such an annotated array type may be used as the element type of another array type, as in `T[R]?[R₂]`.
 
-`T[R₁][R₂]?[R₃][R₄]` is not a single *array_type* with four ranks. Rather, it is two *array_type*s, each of which has two ranks. The outer *array_type* has ranks `[R₃][R₄]`, read left to right, and its element type is `T[R₁][R₂]?`. The element type is another *array_type* with a nullable annotation, and this inner *array_type* has ranks `[R₁][R₂]`, read left to right.
-
-> *Note*: This is the sole exception to the general rule that the meaning of a program remains the same when nullable reference types annotations are removed. *end note*
+`T[R₁][R₂]?[R₃][R₄]` is not a single *array_type* with four ranks. Rather, it is two *array_type*s, each of which has two ranks. The outer *array_type* has ranks `[R₃][R₄]`, read left to right, and its element type is `T[R₁][R₂]?`. The element type is another *array_type* with a nullable annotation, and this inner *array_type* has ranks `[R₁][R₂]`, read left to right. This is the sole exception to the general rule that the meaning of a program remains the same when nullable reference types annotations are removed.
 
 Every reference type which contains nullable annotations has a corresponding unannotated type with no semantic difference (§8.9.1). The corresponding unannotated type for an array of nullable arrays is a single array type which recursively collects all the ranks of all the nested *array_type*s.
 

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -52,9 +52,9 @@ At run-time, a value of an array type can be `null` or a reference to an instanc
 
 ### §arrays-of-nullable-arrays Arrays of nullable arrays
 
-The nullable annotation `?` may be placed on an array type, as in `T[R]?`. Such an array type may be used as the element type of another array type, as in `T[R]?[R₂]`.
+The nullable annotation `?` may be placed on an array type, as in `T[R]?`. Such an annotated array type may be used as the element type of another array type, as in `T[R]?[R₂]`.
 
-The intervening nullable annotation `?` separates the grammar into multiple *array_types*. `T[R₁][R₂]?[R₃][R₄]` is not a single *array_type* with four ranks. Rather, it is two *array_type*s, each of which has two ranks. The outer *array_type* has ranks `[R₃][R₄]`, read left to right, and its element type is `T[R₁][R₂]?`. The element type is another *array_type* with a nullable annotation, and this inner *array_type* has ranks `[R₁][R₂]`, read left to right.
+`T[R₁][R₂]?[R₃][R₄]` is not a single *array_type* with four ranks. Rather, it is two *array_type*s, each of which has two ranks. The outer *array_type* has ranks `[R₃][R₄]`, read left to right, and its element type is `T[R₁][R₂]?`. The element type is another *array_type* with a nullable annotation, and this inner *array_type* has ranks `[R₁][R₂]`, read left to right.
 
 > *Note*: This is the sole exception to the general rule that the meaning of a program remains the same when nullable reference types annotations are removed. *end note*
 

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -58,7 +58,14 @@ The nullable annotation `?` may be placed on an array type, as in `T[R]?`. Such 
 
 Every reference type which contains nullable annotations has a corresponding unannotated type with no semantic difference (§8.9.1). The corresponding unannotated type for an array of nullable arrays is a single array type which recursively collects all the ranks of all the nested *array_type*s.
 
-The unannotated array type of an array of nullable arrays cannot be found by simply removing the nullable annotations `?` from the grammar and reparsing. This is because array ranks are read left to right while nested *array_type* productions are read outside-in, with outer array type ranks to the right, inner array type ranks to the left. Thus, the type `T[R₁][R₂]?[R₃][R₄]` has an unannotated array type of `T[R₃][R₄][R₁][R₂]`. To obtain the unannotated array type of an array of nullable arrays, first take the ranks on the outermost array type in order from left to right, then move to the array type inside the nullable element type and take its ranks in order from left to right. Repeat until the element type is no longer a nullable array type. Then take this remaining element type and place on it all the collected ranks in order from first to last to obtain the unannotated array type.
+The unannotated array type of an array of nullable arrays cannot be found by simply removing the nullable annotations `?` from the grammar and reparsing. This is because array ranks are read left to right while nested *array_type* productions are read outside-in, with outer array type ranks to the right, inner array type ranks to the left. Thus, the type `T[R₁][R₂]?[R₃][R₄]` has an unannotated array type of `T[R₃][R₄][R₁][R₂]`.
+
+To obtain the unannotated array type of an array of nullable arrays, the following steps are followed:
+
+1. Take the ranks on the outermost array type in order from left to right. (From `T[R₁][R₂]?[R₃][R₄]`, take `[R₃]` and then `[R₄]`.)
+2. Move to the array type inside the nullable element type and take its ranks in order from left to right. (From `T[R₁][R₂]`, take `[R₁]` and then `[R₂]`.)
+3. Repeat in this fashion until the element type is no longer a nullable array type. (`T`)
+4. Take this remaining element type and place on it all the collected ranks in order from first to last to obtain the unannotated array type. (On `T`, place `[R₃]`, then `[R₄]`, then `[R₁]`, then `[R₂]`, obtaining the final result of `T[R₃][R₄][R₁][R₂]`.)
 
 > *Example*:
 >

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -50,6 +50,33 @@ At run-time, a value of an array type can be `null` or a reference to an instanc
 
 > *Note*: Following the rules of [§17.6](arrays.md#176-array-covariance), the value may also be a reference to a covariant array type. *end note*
 
+### §arrays-of-nullable-arrays Arrays of nullable arrays
+
+The nullable annotation `?` may be placed on an array type, as in `T[R]?`. Such an array type may be used as the element type of another array type, as in `T[R]?[R₂]`.
+
+The intervening nullable annotation (`?`) separates the grammar into multiple *array_types*. `T[R₁][R₂]?[R₃][R₄]` is not a single *array_type* with four ranks. Rather, it is two *array_type*s, each of which has two ranks. The outer *array_type* has ranks `[R₃][R₄]`, read left to right, and its element type is `T[R₁][R₂]?`. The element type is another *array_type* with a nullable annotation, and this inner array type has ranks `[R₁][R₂]`, read left to right.
+
+> *Note*: This is the sole exception to the general rule that the meaning of a program remains the same when nullable reference types annotations are removed. *end note*
+
+Every reference type which contains nullable annotations has a corresponding unannotated type with no semantic difference (§8.9.1). The corresponding unannotated type for an array of nullable arrays is a single array type which recursively collects all the ranks of all the nested *array_type*s.
+
+The unannotated array type of an array of nullable arrays cannot be found by simply removing the nullable annotations `?` from the grammar and reparsing. This is because array ranks are read left to right while nested *array_type* productions are read outside-in, with outer array type ranks to the right, inner array type ranks to the left. Thus, the type `T[R₁][R₂]?[R₃][R₄]` has an underlying array type of `T[R₃][R₄][R₁][R₂]`. To obtain the underlying array type of an array of nullable arrays, first take the ranks on the outermost array type in order from left to right, then move to the array type inside the nullable element type and take its ranks in order from left to right. Repeat until the element type is no longer a nullable array type. Then take this remaining element type and place on it all the collected ranks in order from first to last to obtain the unannotated array type.
+
+> *Example*:
+>
+> The following table demonstrates the effect on the underlying array type caused by breaking up array types by inserting nullable annotations:
+>
+> | Annotated                        | Underlying                                |
+> |----------------------------------|-------------------------------------------|
+> | `T?[][,][,,]`                    | `T[][,][,,]` (not intervening, no change) |
+> | `T[][,][,,]?`                    | `T[][,][,,]` (not intervening, no change) |
+> | `T[]?[,]?[,,]`                   | `T[,,][,][]`                              |
+> | `T[]?[,][,,]`                    | `T[,][,,][]`                              |
+> | `T[][,]?[,,]`                    | `T[,,][][,]`                              |
+> | `T[][,]?[,,][,,,]?[,,,,][,,,,,]` | `T[,,,,][,,,,,][,,][,,,][][,]`            |
+>
+> *end example*
+
 ### 17.2.2 The System.Array type
 
 The type `System.Array` is the abstract base type of all array types. An implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)) exists from any array type to `System.Array` and to any interface type implemented by `System.Array`. An explicit reference conversion ([§10.3.5](conversions.md#1035-explicit-reference-conversions)) exists from `System.Array` and any interface type implemented by `System.Array` to any array type. `System.Array` is not itself an *array_type*. Rather, it is a *class_type* from which all *array_type*s are derived.

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -54,19 +54,19 @@ At run-time, a value of an array type can be `null` or a reference to an instanc
 
 The nullable annotation `?` may be placed on an array type, as in `T[R]?`. Such an array type may be used as the element type of another array type, as in `T[R]?[R₂]`.
 
-The intervening nullable annotation (`?`) separates the grammar into multiple *array_types*. `T[R₁][R₂]?[R₃][R₄]` is not a single *array_type* with four ranks. Rather, it is two *array_type*s, each of which has two ranks. The outer *array_type* has ranks `[R₃][R₄]`, read left to right, and its element type is `T[R₁][R₂]?`. The element type is another *array_type* with a nullable annotation, and this inner array type has ranks `[R₁][R₂]`, read left to right.
+The intervening nullable annotation `?` separates the grammar into multiple *array_types*. `T[R₁][R₂]?[R₃][R₄]` is not a single *array_type* with four ranks. Rather, it is two *array_type*s, each of which has two ranks. The outer *array_type* has ranks `[R₃][R₄]`, read left to right, and its element type is `T[R₁][R₂]?`. The element type is another *array_type* with a nullable annotation, and this inner *array_type* has ranks `[R₁][R₂]`, read left to right.
 
 > *Note*: This is the sole exception to the general rule that the meaning of a program remains the same when nullable reference types annotations are removed. *end note*
 
 Every reference type which contains nullable annotations has a corresponding unannotated type with no semantic difference (§8.9.1). The corresponding unannotated type for an array of nullable arrays is a single array type which recursively collects all the ranks of all the nested *array_type*s.
 
-The unannotated array type of an array of nullable arrays cannot be found by simply removing the nullable annotations `?` from the grammar and reparsing. This is because array ranks are read left to right while nested *array_type* productions are read outside-in, with outer array type ranks to the right, inner array type ranks to the left. Thus, the type `T[R₁][R₂]?[R₃][R₄]` has an underlying array type of `T[R₃][R₄][R₁][R₂]`. To obtain the underlying array type of an array of nullable arrays, first take the ranks on the outermost array type in order from left to right, then move to the array type inside the nullable element type and take its ranks in order from left to right. Repeat until the element type is no longer a nullable array type. Then take this remaining element type and place on it all the collected ranks in order from first to last to obtain the unannotated array type.
+The unannotated array type of an array of nullable arrays cannot be found by simply removing the nullable annotations `?` from the grammar and reparsing. This is because array ranks are read left to right while nested *array_type* productions are read outside-in, with outer array type ranks to the right, inner array type ranks to the left. Thus, the type `T[R₁][R₂]?[R₃][R₄]` has an unannotated array type of `T[R₃][R₄][R₁][R₂]`. To obtain the unannotated array type of an array of nullable arrays, first take the ranks on the outermost array type in order from left to right, then move to the array type inside the nullable element type and take its ranks in order from left to right. Repeat until the element type is no longer a nullable array type. Then take this remaining element type and place on it all the collected ranks in order from first to last to obtain the unannotated array type.
 
 > *Example*:
 >
-> The following table demonstrates the effect on the underlying array type caused by breaking up array types by inserting nullable annotations:
+> The following table demonstrates the effect on the unannotated array type caused by breaking up array types by inserting nullable annotations:
 >
-> | Annotated                        | Underlying                                |
+> | Annotated                        | Unannotated                                |
 > |----------------------------------|-------------------------------------------|
 > | `T?[][,][,,]`                    | `T[][,][,,]` (not intervening, no change) |
 > | `T[][,][,,]?`                    | `T[][,][,,]` (not intervening, no change) |

--- a/standard/arrays.md
+++ b/standard/arrays.md
@@ -66,7 +66,7 @@ The unannotated array type of an array of nullable arrays cannot be found by sim
 >
 > The following table demonstrates the effect on the unannotated array type caused by breaking up array types by inserting nullable annotations:
 >
-> | Annotated                        | Unannotated                                |
+> | Annotated                        | Unannotated                               |
 > |----------------------------------|-------------------------------------------|
 > | `T?[][,][,,]`                    | `T[][,][,,]` (not intervening, no change) |
 > | `T[][,][,,]?`                    | `T[][,][,,]` (not intervening, no change) |

--- a/standard/types.md
+++ b/standard/types.md
@@ -729,7 +729,25 @@ There are two forms of nullability for reference types:
 
 > *Note:* The types `R` and `R?` are represented by the same underlying type, `R`. A variable of that underlying type can either contain a reference to an object or be the value `null`, which indicates “no reference.” *end note*
 
-The syntactic distinction between a *nullable reference type* and its corresponding *non-nullable reference type* enables a compiler to generate diagnostics. A compiler must allow the *nullable_type_annotation* as defined in [§8.2.1](types.md#821-general). The diagnostics must be limited to warnings. Neither the presence or absence of nullable annotations, nor the state of the nullable context can change the compile time or runtime behavior of a program except for changes in any diagnostic messages generated at compile time.
+The syntactic distinction between a *nullable reference type* and its corresponding *non-nullable reference type* enables a compiler to generate diagnostics. A compiler must allow the *nullable_type_annotation* as defined in [§8.2.1](types.md#821-general). The diagnostics must be limited to warnings. Neither the presence or absence of nullable annotations, nor the state of the nullable context can change the compile time or runtime behavior of a program except for changes in any diagnostic messages generated at compile time, with one exception:
+
+A compiler must respect the effect that *nullable_type_annotation* has on the ordering of array rank specifiers. Whereas `A[][,]` is a single *array_type* with two *rank_specifier*s, the presence of a nullable annotation between the rank specifiers in `A[]?[,]` causes it to no longer be a single *array_type*, but rather two: an outer *array_type* with a single *rank_specifier* of `[,]`, and an element type of `A[]?` which is a *nullable_reference_type* containing an inner *array_type* with a single *rank_specifier* of `[]`. Because of this, `A[]?[,]` and `A[,][]` are represented by the same underlying type, while `A[]?[,]` and `A[][,]` are not.
+
+> *Example*: The array ranks are interrupted by the '?' in the parameter type, changing the meaning of the underlying array type:
+>
+> <!-- Example: {template:"code-in-class-lib", name:"ArraysOfNullAbleArrays"} -->
+> ```csharp
+> #nullable enable
+> class C
+> {
+>     void M(string[][,]?[,,][,,,] arrays)
+>     {
+>         string? value = arrays[3, 3, 3][4, 4, 4, 4]?[1][2, 2];
+>     }
+> }
+> ```
+>
+> *end example*
 
 ### 8.9.2 Non-nullable reference types
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -59,9 +59,17 @@ array_type
     ;
 
 non_array_type
-    : value_type
-    | (class_type | interface_type | delegate_type | 'dynamic' | type_parameter) nullable_type_annotation?
+    : non_array_non_nullable_type nullable_type_annotation?
     | pointer_type      // unsafe code support
+    ;
+
+non_array_non_nullable_type
+    : non_nullable_value_type
+    | class_type
+    | interface_type
+    | delegate_type
+    | 'dynamic'
+    | type_parameter
     ;
 
 rank_specifier

--- a/standard/types.md
+++ b/standard/types.md
@@ -54,16 +54,13 @@ interface_type
     ;
 
 array_type
-    : non_array_type rank_specifier+
+    : array_type nullable_type_annotation rank_specifier+
+    | non_array_type rank_specifier+
     ;
 
 non_array_type
     : value_type
-    | class_type
-    | interface_type
-    | delegate_type
-    | 'dynamic'
-    | type_parameter
+    | (class_type | interface_type | delegate_type | 'dynamic' | type_parameter) nullable_type_annotation?
     | pointer_type      // unsafe code support
     ;
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -737,25 +737,7 @@ There are two forms of nullability for reference types:
 
 > *Note:* The types `R` and `R?` are represented by the same underlying type, `R`. A variable of that underlying type can either contain a reference to an object or be the value `null`, which indicates “no reference.” *end note*
 
-The syntactic distinction between a *nullable reference type* and its corresponding *non-nullable reference type* enables a compiler to generate diagnostics. A compiler must allow the *nullable_type_annotation* as defined in [§8.2.1](types.md#821-general). The diagnostics must be limited to warnings. Neither the presence or absence of nullable annotations, nor the state of the nullable context can change the compile time or runtime behavior of a program except for changes in any diagnostic messages generated at compile time, with one exception:
-
-A compiler must respect the effect that *nullable_type_annotation* has on the ordering of array rank specifiers. Whereas `A[][,]` is a single *array_type* with two *rank_specifier*s, the presence of a nullable annotation between the rank specifiers in `A[]?[,]` causes it to no longer be a single *array_type*, but rather two: an outer *array_type* with a single *rank_specifier* of `[,]`, and an element type of `A[]?` which is a *nullable_reference_type* containing an inner *array_type* with a single *rank_specifier* of `[]`. Because of this, `A[]?[,]` and `A[,][]` are represented by the same underlying type, while `A[]?[,]` and `A[][,]` are not.
-
-> *Example*: The array ranks are interrupted by the '?' in the parameter type, changing the meaning of the underlying array type:
->
-> <!-- Example: {template:"code-in-class-lib", name:"ArraysOfNullAbleArrays"} -->
-> ```csharp
-> #nullable enable
-> class C
-> {
->     void M(string[][,]?[,,][,,,] arrays)
->     {
->         string? value = arrays[3, 3, 3][4, 4, 4, 4]?[1][2, 2];
->     }
-> }
-> ```
->
-> *end example*
+The syntactic distinction between a *nullable reference type* and its corresponding *non-nullable reference type* enables a compiler to generate diagnostics. A compiler must allow the *nullable_type_annotation* as defined in [§8.2.1](types.md#821-general). The diagnostics must be limited to warnings. Neither the presence or absence of nullable annotations, nor the state of the nullable context can change the compile time or runtime behavior of a program except for changes in any diagnostic messages generated at compile time, with one exception: arrays of nullable arrays are not parsed as a single *array_type*, but rather as multiple nested *array_type*s. The corresponding *non-nullable reference type* of an array of nullable arrays is not the single array type that would be parsed if the nullable annotations were removed; see §arrays-of-nullable-arrays.
 
 ### 8.9.2 Non-nullable reference types
 
@@ -1121,6 +1103,8 @@ A compiler may issue a warning when nullability annotations differ between two t
 
 A compiler may follow rules for interface variance ([§18.2.3.3](interfaces.md#18233-variance-conversion)), delegate variance ([§20.4](delegates.md#204-delegate-compatibility)), and array covariance ([§17.6](arrays.md#176-array-covariance)) in determining whether to issue a warning for type conversions.
 
+(See §arrays-of-nullable-arrays for the specification of the corresponding non-nullable array type used in `M7` and `M8`.)
+
 > <!-- Example: {template:"code-in-class-lib", name:"NullVariance", ignoredWarnings:["CS8619"]} -->
 > ```csharp
 > #nullable enable
@@ -1157,6 +1141,17 @@ A compiler may follow rules for interface variance ([§18.2.3.3](interfaces.md#1
 >     {
 >         string[] v1 = p; // Warning
 >         string[] v2 = p!; // No warning
+>     }
+>
+>     public void M7(string[][,] p)
+>     {
+>         string[,]?[] v1 = p; // No warning
+>     }
+>
+>     public void M6(string[]?[,] p)
+>     {
+>         string[,][] v1 = p; // Warning
+>         string[,][] v2 = p!; // No warning
 >     }
 > }
 > ```


### PR DESCRIPTION
Proposed replacement for @Nigel-Ecma's https://github.com/dotnet/csharpstandard/pull/1287 and @gafter's https://github.com/dotnet/csharpstandard/pull/1297

Will fix #1385

I was trying not to end up creating new names like `non_array_non_nullable_reference_type` and `non_array_nullable_reference_type` which don't sound like core concepts we'd want to be referencing elsewhere. (Cf https://github.com/dotnet/csharpstandard/pull/1287)

TODO:

- [ ] Add samples for the grammer tester. (Getting help from @Nigel-Ecma offline. I would like to create tests that show that `string?[]` and `int[]?[]` were disallowed prior to the grammar changes in this PR.)