### PR TITLE
Update ECMA-TC49-TG2-New-Member-Orientation.md

### DIFF
--- a/admin/ECMA-TC49-TG2-New-Member-Orientation.md
+++ b/admin/ECMA-TC49-TG2-New-Member-Orientation.md
@@ -24,7 +24,7 @@ Some years ago, we moved the spec source from MS Word to GitHub/md, and later th
   - Chair of ECMA TC49: This keeps him in touch with the Ecma Secretary General, the bi-annual General Assembly, and the associated Ecma Executive Committee (ExeComm).
   - Ecma liaison to ISO/IEC JTC/1 SC22 (programming languages, tools, and environments): For TC49 (C#, CLI, Eiffel) and TC39 (ECMAScript).
   - Background task: Rex has been creating formal feature specs from [MS’ specs](https://github.com/dotnet/csharplang/tree/main/proposals) for V9–14. The V9 ones are already in the repo as Draft PRs. The formal feature specs for versions beyond V9 are kept offline by Rex (with Jon and Bill also having copies). When V8 is completed and we start work on the V9 Draft PRs, Rex will make the V10 Draft PRs available.
-    
+
 ## Official Document Home
 
 All meeting agendas and minutes are assigned numbers by Ecma admin staff, and are posted to the Ecma-hosted TG2 website to which all members have access. Draft versions of these documents are posted privately to members.
@@ -37,22 +37,20 @@ To avoid that extra ISO step and to eliminate the 1-year delay, in December 2022
 
 Ordinarily, Ecma approves new specs at its June and December General Assemblies (GAs). To get considered at one of those, we need to have a feature-complete and almost technically complete spec ready by mid-March or mid-September, respectively. If we submit a new version at any other time, rather than have it voted on via a letter ballot, it typcially waits until the next GA. That said, once TG2 completes a version it typically starts work on next one, as Draft PRs for that are already available.
 
-If errors are found in a published spec, we do ***not*** make available a corrected version; corrections simply go into the next version. 
+If errors are found in a published spec, we do ***not*** make available a corrected version; corrections simply go into the next version.
 
 ## C# Formal Grammar
 
-Some time ago, we moved from an eBNF form to [ANTLR](https://en.wikipedia.org/wiki/ANTLR).
+Some time ago, we moved from an eBNF form to [ANTLR](https://en.wikipedia.org/wiki/ANTLR) notation for the grammar.
 
-Nigel is our resident grammar expert.
+While the grammar is written in ANTLR notation the ANTLR parser generator itself cannot be used to build a parser directly based on it. This is due either to the use of grammar features the generator does not support, or the need to use non-grammar features of the ANTLR generator to support them. An example of the former is the C# grammar’s use in a few placers of mutual left recursion, which the ANTLR generator does not support. An example of the latter is C#’s interpolated strings which, like in many languages, are a “language within a language”. Standard *implementation* techniques exist to support such features, which as such are outside the scope of the C# Standard.
 
-The core ANTLR implementation doesn’t allow left recursion, although a C#-code-generating version does.
+We have an internal tool to extract the grammar from the spec, apply ANTLR generator specific implementation techniques, validate the grammar, and run grammar tests. (See [antlr-testing](https://github.com/ECMA-TC49-TG2/antlr-testing/blob/v2/ReadMe.md).)
 
-Nigel made a tool to extract the grammar from the spec and to rearrange the grammar to get it to pass the ANTLR validator.
- 
 ## Examples in the spec
 
 We have tools to extract the examples and compile them and execute them. (See https://github.com/dotnet/csharpstandard/blob/draft-v8/tools/README.md.)
- 
+
 ## Status of Features in the Current Spec Draft
 
 For a given version *X*, see file v*X*-feature-tracker.md in https://github.com/dotnet/csharpstandard/tree/draft-v8/admin.


### PR DESCRIPTION
Fix mistake, ANTLR does not support *mutual* left recursion. In the process expanded the para.