### PR TITLE
“Review” of PR #1437

### DIFF
--- a/standard/ranges.md
+++ b/standard/ranges.md
@@ -86,7 +86,7 @@ The required members for a type to qualify as a sequence or sliceable may be inh
 
 ## 18.2 The Index type
 
-The `System.Index` type represents an *abstract* index which is either a from-start index or a from-end index.
+The `System.Index` type represents an *abstract* index which represents either a *from-start index* or a *from-end index*.
 
 ```csharp
     public readonly struct Index : IEquatable<Index>

--- a/standard/ranges.md
+++ b/standard/ranges.md
@@ -86,7 +86,7 @@ The required members for a type to qualify as a sequence or sliceable may be inh
 
 ## 18.2 The Index type
 
-The `System.Index` type represents an *abstract* index which represents either a *from-start index* or a *from-end index*.
+The `System.Index` type represents an *abstract* index which represents either a from-start index or a from-end index.
 
 ```csharp
     public readonly struct Index : IEquatable<Index>


### PR DESCRIPTION
Apologies, came here to write a review and the boat has sailed.

@jskeet –I don’t see why ranges.md@89 was changed at all and I wouldn’t even have looked at the line for #1437. The *abstract* is for emphasis, i.e. that it is abstract! Maybe @RexJaeschke has an English reason to remove the other italics, but to me it delineates the two different kinds of index clearly.

Looking at the line now I think the “is” would be better as “represents”, so I’ve made that change.

Over to you two to judge: accept/modify/reject the changed line – no version is wrong *per se*!