### PR TITLE
Small correction after #873 merge

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -148,7 +148,7 @@ The precedence of an operator is established by the definition of its associated
 > |  **Subclause**      | **Category**                     | **Operators**                                          |
 > |  -----------------  | -------------------------------  | -------------------------------------------------------|
 > |  [§12.8](expressions.md#128-primary-expressions)              | Primary                          | `x.y` `x?.y` `f(x)` `a[x]` `a?[x]` `x++` `x--` `x!` `new` `typeof` `default` `checked` `unchecked` `delegate` `stackalloc`  |
-> |  [§12.9](expressions.md#129-unary-operators)              | Unary                            | `+` `-` `!` `~` `^` `++x` `--x` `(T)x` `await x` |
+> |  [§12.9](expressions.md#129-unary-operators)              | Unary                            | `+` `-` `!x` `~` `^` `++x` `--x` `(T)x` `await x` |
 > |  [§12.10](expressions.md#1210-range-operator) | Range | `..` |
 > |  [§12.11](expressions.md#1211-switch-expression)                                   | Switch                           | `switch { … }` |
 > |  [§12.12](expressions.md#1212-arithmetic-operators)              | Multiplicative                   | `*` `/` `%` |


### PR DESCRIPTION
#873 changed `!x` to `!` on the second row of the table in §12.4.2; this PR reverts that change.

The `x` is required to indicate that this is the prefix logical negation operator, the first row of the table contains `x!` for the postfix null-forgiving operator