### PR TITLE
Tweak the MaybeNull attribute test examples

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -982,15 +982,6 @@ Specifies that a non-nullable return value may be null.
 
 > *Example*: Consider the following generic method:
 >
-> <!-- TODO:  This sample no longer generates the error in C# 9. This could be part of the new nullable constraints. Was: , expectedErrors:["CS8627"]-->
-> <!-- Example: {template:"code-in-class-lib", name:"MaybeNull1Attribute", replaceEllipsis:true, customEllipsisReplacements: ["return default;"]} -->
-> ```csharp
-> #nullable enable
-> public T? Find<T>(IEnumerable<T> sequence, Func<T, bool> predicate) { ... }
-> ```
->
-> The idea of this code is that if `T` is replaced by `string`, `T?` becomes a nullable annotation. However, this code is not legal because `T` is not constrained to be a reference type. However, adding this attribute solves the problem:
->
 > <!-- Example: {template:"code-in-class-lib", name:"MaybeNull2Attribute", replaceEllipsis:true, customEllipsisReplacements: ["return default;"]} -->
 > ```csharp
 > #nullable enable
@@ -998,7 +989,7 @@ Specifies that a non-nullable return value may be null.
 > public T Find<T>(IEnumerable<T> sequence, Func<T, bool> predicate) { ... }
 > ```
 >
-> The attribute informs callers that the contract implies a non-nullable type, but the return value may actually be `null`. *end example*
+> Without the attribute the compiler might generate a warning if the method could return `null`. The presence of the attribute suppresses that warning. *end example*
 
 #### 23.5.7.7 The MaybeNullWhen attribute
 


### PR DESCRIPTION
[Addresses the 2nd test issue in PR #1451.]

@BillWagner I couldn't come up with a failing-code replacement for MaybeNull1Attribute, but other sibling attributes don't show an error case that is resolved by the presence of an attribute, so I mimicked them.

Note that I wrote "the compiler ***might*** generate a warning if the method could return `null`." In the test case, the return value of `default` is seen by the compiler, so it knows a null is being returned. I couldn't come up with a replacement for the return statement that didn't explicitly return null. So I couldn't say for certain that it ***would*** generate a warning.