### PR TITLE
[Version 9.0] Feature support for extension GetEnumerator in foreach

### DIFF
--- a/standard/statements.md
+++ b/standard/statements.md
@@ -1176,6 +1176,15 @@ Before the process described in [§13.9.5.1](statements.md#13951-general), the f
 If the process in [§13.9.5.1](statements.md#13951-general) completes without producing a single collection type, enumerator type, and iteration type, the following steps are taken:
 
 - If there is an implicit conversion from `X` to the `System.Collections.IEnumerable` interface, then the collection type is this interface, the enumerator type is the interface `System.Collections.IEnumerator`, and the iteration type is `object`.
+- Otherwise, determine whether the type 'X' has an appropriate `GetEnumerator` extension method:
+  - Perform extension method lookup on the type `X` with identifier `GetEnumerator`. If the member lookup does not produce a match, or it produces an ambiguity, or produces a match which is not a method group, an error is produced, and no further steps are taken. It is recommended that a warning be issued if member lookup produces anything except a method group or no match.
+  - Perform overload resolution using the resulting method group and a single argument of type `X`. If overload resolution produces no applicable methods, results in an ambiguity, or results in a single best method but that method is not accessible, an error is produced an no further steps are taken.
+  - This resolution permits the first argument to be passed by ref if `X` is a struct type, and the ref kind is `in`.
+  - If the return type `E` of the `GetEnumerator` method is not a class, struct or interface type, an error is produced, and no further steps are taken.
+  - Member lookup is performed on `E` with the identifier `Current` and no type arguments. If the member lookup produces no match, the result is an error, or the result is anything except a public instance property that permits reading, an error is produced, and no further steps are taken.
+  - Member lookup is performed on `E` with the identifier `MoveNext` and no type arguments. If the member lookup produces no match, the result is an error, or the result is anything except a method group, an error is produced, and no further steps are taken.
+  - Overload resolution is performed on the method group with an empty argument list. If overload resolution results in no applicable methods, results in an ambiguity, or results in a single best method but that method is either static or not public, or its return type is not `bool`, an error is produced, and no further steps are taken.
+  - The collection type is `X`, the enumerator type is `E`, and the iteration type is the type of the `Current` property.
 - Otherwise, an error is produced, and no further steps are taken.
 
 A `foreach` statement of the form


### PR DESCRIPTION
This PR contains all the changes in #989. It also replaces PR #1463, which has been retired.

Some background: When Rex created 989, he used draft-v7 as the base. However, during the v8 work the affected subclause, 13.9.5 "The foreach statement," was subsequently split into 3 subclauses, and text was moved around, changed, and augmented due to the addition of the async streams and using declarations features. Then when Bill pushed 989 into 1463, things got confused with unchanged text being reported as new, and Rex's new text going in the wrong place.

Reviewers: The changes made by this PR were done **without consideration of any impact the v8 features async streams and using declarations might have. As such, see if these changes are impacted by 13.5.3, "await foreach."**