### PR TITLE
Disable the table format rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,6 +7,7 @@
     "MD046": {
         "style": "fenced"
     },
+    "MD060": false,
     "proper-names": {
         "code_blocks": false,
         "names": [


### PR DESCRIPTION
MD060 has gotten much more persnickety. Disable it. This should fix the build issues on #1447