### PR TITLE
Add InvalidOperationException to the list of common exceptions

### DIFF
--- a/standard/exceptions.md
+++ b/standard/exceptions.md
@@ -46,6 +46,7 @@ The following exceptions are thrown by certain C# operations.
 `System.DivideByZeroException`           | Thrown when an attempt to divide an integral value by zero occurs.
 `System.IndexOutOfRangeException`        | Thrown when an attempt to index an array via an index that is less than zero or outside the bounds of the array.
 `System.InvalidCastException`            | Thrown when an explicit conversion from a base type or interface to a derived type fails at run-time.
+`System.InvalidOperationException`       | Thrown when a method call is invalid for the object's current state.
 `System.NullReferenceException`          | Thrown when a `null` reference is used in a way that causes the referenced object to be required.
 `System.OutOfMemoryException`            | Thrown when an attempt to allocate memory (via `new`) fails.
 `System.OverflowException`               | Thrown when an arithmetic operation in a `checked` context overflows.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3912,7 +3912,7 @@ If a switch expression is not subject to a *switch expression conversion*, then
 It is an error if some *switch_expression_arm*’s pattern cannot affect the result because some previous pattern and guard will always match.
 
 A switch expression is said to be *exhaustive* if every value of its input is handled by at least one arm of the switch expression.  The compiler shall produce a warning if a switch expression is not exhaustive.
-At runtime, the result of the *switch_expression* is the value of the *expression* of the first *switch_expression_arm* for which the expression on the left-hand-side of the *switch_expression* matches the *switch_expression_arm*’s pattern, and for which the *case_guard* of the *switch_expression_arm*, if present, evaluates to `true`. If there is no such *switch_expression_arm*, the *switch_expression* throws an instance of the exception `System.Runtime.CompilerServices.SwitchExpressionException`.
+At runtime, the result of the *switch_expression* is the value of the *expression* of the first *switch_expression_arm* for which the expression on the left-hand-side of the *switch_expression* matches the *switch_expression_arm*’s pattern, and for which the *case_guard* of the *switch_expression_arm*, if present, evaluates to `true`. If there is no such *switch_expression_arm*, the *switch_expression* throws an instance of the exception `System.InvalidOperationException` (or a class derived from that).
 
 > *Example*: The following converts values of an enum representing visual directions on an online map to the corresponding cardinal directions:
 >


### PR DESCRIPTION
Additionally, modify switch expression handling to remove the reference to SwitchExpressionException, instead requiring that the exception thrown by a non-exhaustive switch expression is InvalidOperationException or a derived type.

Fixes #1021