### PR TITLE
Use the latest action to make a PR

### DIFF
--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -56,7 +56,7 @@ jobs:
       shell: bash
 
     - name: Create pull request
-      uses: dotnet/actions-create-pull-request@v4
+      uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412
       if: ${{ steps.renumber-sections.outputs.status }} == 'success' && ${{ steps.update-grammar.outputs.status }} == 'success'
       with:
         title: "Automated Section renumber and grammar extraction"


### PR DESCRIPTION
This SHA matches version 7.0.9. By using the SHA, this remains the same version even if the tag is redefined.

Note that dependabot honors this use and will update the sha if a newer version is tagged.