### PR TITLE
Add rules for `readonly` members

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -2100,7 +2100,7 @@ ref_method_modifier
     | 'override'
     | 'abstract'
     | 'extern'
-    | 'readonly'        // direct struct members only
+    | 'readonly'        // struct members only
     | unsafe_modifier   // unsafe code support
     ;
 
@@ -3315,7 +3315,7 @@ property_modifier
     | 'override'
     | 'abstract'
     | 'extern'
-    | 'readonly'        // direct struct members only
+    | 'readonly'        // struct members only
     | unsafe_modifier   // unsafe code support
     ;
     
@@ -3401,7 +3401,7 @@ accessor_modifier
     | 'internal' 'protected'
     | 'protected' 'private'
     | 'private' 'protected'
-    | 'readonly'        // direct struct members only
+    | 'readonly'        // struct members only
     ;
 
 accessor_body
@@ -4061,7 +4061,7 @@ event_modifier
     | 'override'
     | 'abstract'
     | 'extern'
-    | 'readonly'        // direct struct members only
+    | 'readonly'        // struct members only
     | unsafe_modifier   // unsafe code support
     ;
 
@@ -4342,7 +4342,7 @@ indexer_modifier
     | 'override'
     | 'abstract'
     | 'extern'
-    | 'readonly'        // direct struct members only
+    | 'readonly'        // struct members only
     | unsafe_modifier   // unsafe code support
     ;
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -178,7 +178,7 @@ An instance member definition or accessor of an instance property, indexer, or e
 > }
 > ```
 >
-> The `readonly` method `AddMessage` can change the state of a message list. The `InitializeMessages` member can clear and re-initialize the list of messages. In the first case, the `readonly` modifier is valid. In the case of `InitializeMessages`, adding the `readonly` modifier is invalid. *end example*
+> The `readonly` method `AddMessage` can change the state of a message list. The `InitializeMessages` member can clear and re-initialize the list of messages. In the case of `AddMessage`, the `readonly` modifier is valid. In the case of `InitializeMessages`, adding the `readonly` modifier is invalid. *end example*
 
 ## 16.4 Class and struct differences
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -114,6 +114,8 @@ struct_body
 
 ## 16.3 Struct members
 
+### §struct_general General
+
 The members of a struct consist of the members introduced by its *struct_member_declaration*s and the members inherited from the type `System.ValueType`.
 
 ```ANTLR
@@ -137,6 +139,51 @@ struct_member_declaration
 > *Note*: All kinds of *class_member_declaration*s except *finalizer_declaration* are also *struct_member_declaration*s. *end note*
 
 Except for the differences noted in [§16.4](structs.md#164-class-and-struct-differences), the descriptions of class members provided in [§15.3](classes.md#153-class-members) through [§15.12](classes.md#1512-static-constructors) apply to struct members as well.
+
+### §struct_readonly Readonly members
+
+An instance member definition that includes the `readonly` modifier has the following restrictions:
+
+- The member shall not modify the value of a direct instance member of the receiver.
+- A readonly member may call a non-readonly member using the receiver instance only if it ensures no modifications to the receiver are observable after the readonly member returns.
+
+> *Example*: The following code demonstrates the rule that a readonly member shall not modify the value of a direct instance member, but can modify the members of a direct instance member:
+>
+> <!-- Example: {template:"standalone-lib-without-using", name:"ReadonlyMember" } -->
+> ```csharp
+> public struct S
+> {
+>    private bool[] flags;
+>
+>    public S(int size)
+>    {
+>       flags = new bool[size];
+>    }
+>
+>    public readonly bool this[int index]
+>    {
+>       get => flags[index]; 
+>       set => flags[index] = value;
+>    }
+>
+>    // Not readonly
+>    public void ResetFlags()
+>    {
+>       flags = new bool[flags.Length];
+>    }
+>
+>    // Allowed on readonly member
+>    public readonly void ReadonlyResetFlags()
+>    {
+>       for (int i = 0; i < flags.Length; i++)
+>       {
+>          flags[i] = false;
+>       }
+>    }
+> }
+> ```
+>
+> The `readonly` indexer can change the state of a single member of the `flags` array. The `ReadonlyResetFlags` member can set all flags to false. In both those cases, the direct member, `flags` has not been reassigned. The `ResetFlags` member reassigns the direct member, and therefore cannot include the `readonly` modifier. *end example*
 
 ## 16.4 Class and struct differences
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -144,7 +144,7 @@ Except for the differences noted in [§16.4](structs.md#164-class-and-struct-dif
 
 An instance member definition or property accessor of an instance property that includes the `readonly` modifier has the following restrictions:
 
-- The member shall not reassign the value of an instance field of the receiver.
+- The member shall not reassign the value of `this` or an instance field of the receiver.
 - The member shall not reassign the value of an instance field-like event (§15.8.2) of the receiver.
 - A readonly member may call a non-readonly member using the receiver instance only if it ensures no modifications to the receiver are observable after the readonly member returns.
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -142,7 +142,7 @@ Except for the differences noted in [§16.4](structs.md#164-class-and-struct-dif
 
 ### §struct_readonly Readonly members
 
-An instance member definition or property accessor of an instance property that includes the `readonly` modifier has the following restrictions:
+An instance member definition or accessor of an instance property, indexer, or event that includes the `readonly` modifier has the following restrictions:
 
 - The member shall not reassign the value of `this` or an instance field of the receiver.
 - The member shall not reassign the value of an instance field-like event (§15.8.2) of the receiver.

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -144,51 +144,41 @@ Except for the differences noted in [§16.4](structs.md#164-class-and-struct-dif
 
 An instance member definition or accessor of an instance property, indexer, or event that includes the `readonly` modifier has the following restrictions:
 
+- The `this` parameter is a `ref readonly` reference.
 - The member shall not reassign the value of `this` or an instance field of the receiver.
 - The member shall not reassign the value of an instance field-like event (§15.8.2) of the receiver.
-- A readonly member may call a non-readonly member using the receiver instance only if it ensures no modifications to the receiver are observable after the readonly member returns.
+- If a readonly member invokes a non-readonly member, the structure referred to by `this` must be copied to use a writable reference for the `this` argument.
 
 > *Note:* Instance fields include the hidden backing field used for automatically implemented properties (§15.7.4). *end note*
 <!-- markdownlint-disable MD028 -->
 
 <!-- markdownlint-enable MD028 -->
-> *Example*: The following code demonstrates the reassigning and modifying an instance field. Obfuscating the intent of `readonly` in this manner is discouraged:
+> *Example*: A readonly member can modify the state of an object referred to by an instance field, even though the readonly member can't reassign that instance member. The following code demonstrates the reassigning and modifying an instance field:
 >
 > <!-- Example: {template:"standalone-lib-without-using", name:"ReadonlyMember" } -->
 > ```csharp
 > public struct S
 > {
->    private bool[] flags;
+>     private List<string> messages;
 >
->    public S(int size)
->    {
->       flags = new bool[size];
->    }
+>     public S(IEnumerable<string> messages) =>
+>         this.messages = new List<string>(messages);
 >
->    public readonly bool this[int index]
->    {
->       get => flags[index]; 
->       set => flags[index] = value;
->    }
+>     public void InitializeMessages() =>
+>         messages = new List<string>();
 >
->    // Not readonly
->    public void ResetFlags()
->    {
->       flags = new bool[flags.Length];
->    }
->
->    // Allowed on readonly member
->    public readonly void ReadonlyResetFlags()
->    {
->       for (int i = 0; i < flags.Length; i++)
->       {
->          flags[i] = false;
->       }
->    }
+>     public readonly void AddMessage(string message)
+>     {
+>         if (messages == null)
+>         {
+>             throw new InvalidOperationException("Messages collection is not initialized.");
+>         }
+>         messages.Add(message);
+>     }
 > }
 > ```
 >
-> The `readonly` indexer can change the state of a single member of the `flags` array. The `ReadonlyResetFlags` member can set all flags to false. In both those cases, the field, `flags` has not been reassigned to a new array. The `ResetFlags` member reassigns the direct member, and therefore cannot include the `readonly` modifier. *end example*
+> The `readonly` method `AddMessage` can change the state of a message list. The `InitializeMessages` member can clear and re-initialize the list of messages. In the first case, the `readonly` modifier is valid. In the case of `InitializeMessages`, adding the `readonly` modifier is invalid. *end example*
 
 ## 16.4 Class and struct differences
 

--- a/standard/structs.md
+++ b/standard/structs.md
@@ -142,12 +142,17 @@ Except for the differences noted in [§16.4](structs.md#164-class-and-struct-dif
 
 ### §struct_readonly Readonly members
 
-An instance member definition that includes the `readonly` modifier has the following restrictions:
+An instance member definition or property accessor of an instance property that includes the `readonly` modifier has the following restrictions:
 
-- The member shall not modify the value of a direct instance member of the receiver.
+- The member shall not reassign the value of an instance field of the receiver.
+- The member shall not reassign the value of an instance field-like event (§15.8.2) of the receiver.
 - A readonly member may call a non-readonly member using the receiver instance only if it ensures no modifications to the receiver are observable after the readonly member returns.
 
-> *Example*: The following code demonstrates the rule that a readonly member shall not modify the value of a direct instance member, but can modify the members of a direct instance member:
+> *Note:* Instance fields include the hidden backing field used for automatically implemented properties (§15.7.4). *end note*
+<!-- markdownlint-disable MD028 -->
+
+<!-- markdownlint-enable MD028 -->
+> *Example*: The following code demonstrates the reassigning and modifying an instance field. Obfuscating the intent of `readonly` in this manner is discouraged:
 >
 > <!-- Example: {template:"standalone-lib-without-using", name:"ReadonlyMember" } -->
 > ```csharp
@@ -183,7 +188,7 @@ An instance member definition that includes the `readonly` modifier has the foll
 > }
 > ```
 >
-> The `readonly` indexer can change the state of a single member of the `flags` array. The `ReadonlyResetFlags` member can set all flags to false. In both those cases, the direct member, `flags` has not been reassigned. The `ResetFlags` member reassigns the direct member, and therefore cannot include the `readonly` modifier. *end example*
+> The `readonly` indexer can change the state of a single member of the `flags` array. The `ReadonlyResetFlags` member can set all flags to false. In both those cases, the field, `flags` has not been reassigned to a new array. The `ResetFlags` member reassigns the direct member, and therefore cannot include the `readonly` modifier. *end example*
 
 ## 16.4 Class and struct differences
 


### PR DESCRIPTION
Fixes #1339

Add a new section for the rules on `readonly` members of structs.

I didn't write a specific rule that `readonly` members can modify `static` fields. There's no rule prohibiting it, so it should be allowed.

I chose language consistent with the future work on #1053 to consider. One popular implementation creates a "defensive copy" of the receiver to invoke a non-readonly member.

Finally, add an example that demonstrates the "direct member of a struct" rule by having a `readonly` property and `readonly` method modify the members of a direct member, which is allowed.