### PR TITLE
Add an exception to the requirement that partial method declarations have the same modifiers

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3034,7 +3034,8 @@ Partial methods shall not define access modifiers; they are implicitly private. 
 
 There are two kinds of partial method declarations: If the body of the method declaration is a semicolon, the declaration is said to be a ***defining partial method declaration***. If the body is other than a semicolon, the declaration is said to be an ***implementing partial method declaration***. Across the parts of a type declaration, there shall be only one defining partial method declaration with a given signature, and there shall be at most only one implementing partial method declaration with a given signature. If an implementing partial method declaration is given, a corresponding defining partial method declaration shall exist, and the declarations shall match as specified in the following:
 
-- The declarations shall have the same modifiers (although not necessarily in the same order), method name, number of type parameters and number of parameters.
+- The declarations shall have the same method name, number of type parameters, and number of parameters.
+- The declarations shall have the same modifiers (although not necessarily in the same order), with the exception of the `async` modifier which may only appear on an implementing part.
 - Corresponding parameters in the declarations shall have the same modifiers (although not necessarily in the same order) and the same types, or identity convertible types (modulo differences in type parameter names).
 - Corresponding type parameters in the declarations shall have the same constraints (modulo differences in type parameter names).
 

--- a/standard/classes.md
+++ b/standard/classes.md
@@ -3035,7 +3035,7 @@ Partial methods shall not define access modifiers; they are implicitly private. 
 There are two kinds of partial method declarations: If the body of the method declaration is a semicolon, the declaration is said to be a ***defining partial method declaration***. If the body is other than a semicolon, the declaration is said to be an ***implementing partial method declaration***. Across the parts of a type declaration, there shall be only one defining partial method declaration with a given signature, and there shall be at most only one implementing partial method declaration with a given signature. If an implementing partial method declaration is given, a corresponding defining partial method declaration shall exist, and the declarations shall match as specified in the following:
 
 - The declarations shall have the same method name, number of type parameters, and number of parameters.
-- The declarations shall have the same modifiers (although not necessarily in the same order), with the exception of the `async` modifier which may only appear on an implementing part.
+- The declarations shall have the same modifiers (although not necessarily in the same order), with the exception of the `async` modifier which shall not appear on a defining part.
 - Corresponding parameters in the declarations shall have the same modifiers (although not necessarily in the same order) and the same types, or identity convertible types (modulo differences in type parameter names).
 - Corresponding type parameters in the declarations shall have the same constraints (modulo differences in type parameter names).
 


### PR DESCRIPTION
This code is accepted just fine:
```cs
partial class C
{
    async partial void M() { }

    partial void M();
}
```

And this is by design. It's not _allowed_ for the `async` modifier to be on both parts. Nor would that make intuitive sense, since `async` is a keyword that only affects the body. It does not affect the signature.

```cs
partial class C
{
    async partial void M() { }

    // ❌ CS1994: The 'async' modifier can only be used in methods that have a body.
    async partial void M();
}
```

When C# 9 comes along, `extern` will have to be added as another exception for the same reason.