### PR TITLE
[Version 10.0] Feature support for record class as an alias for record

### DIFF
--- a/standard/classes.md
+++ b/standard/classes.md
@@ -20,7 +20,7 @@ class_declaration
     ;
 
 class_tag
-    : 'class'
+    : 'record'? 'class'
     | 'record'
     ;
 ```
@@ -32,6 +32,8 @@ A class declaration shall not supply *type_parameter_constraints_clause*s unless
 A class declaration that supplies a *type_parameter_list* is a generic class declaration. Additionally, any class nested inside a generic class declaration or a generic struct declaration is itself a generic class declaration, since type arguments for the containing type shall be supplied to create a constructed type ([§8.4](types.md#84-constructed-types)).
 
 If *class_tag* contains `record`, that class is a ***record class***; otherwise, it is a ***non-record class***.
+
+The *class_tag*s `record` and `record class` are equivalent.
 
 For a record class, *class_modifier* shall not be `static`.
 


### PR DESCRIPTION
This is Rex's adaptation of the section "Improvements on records/Allow record class" in the corresponding [MS proposal](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-10.0/record-structs.md).