### PR TITLE
[Version 10.0] Feature support for improved interpolated strings

### DIFF
--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -1248,7 +1248,7 @@ val = {  FF}; 2 * val = 510.
 
 In the call to `LogMessage`, the target of the interpolated string expression argument is parameter `msg`, which has type `string`. As such, according to [§12.8.3](expressions.md#1283-interpolated-string-expressions), the default interpolated string expression handler is invoked. The following subclause (§custInterpStrExpCustHandling) shows how to use a custom handler.
 
-In order to provide custom processing to the program shown in §custInterpStrExpDefHandling, a *custom interpolated string expression handler* is needed. Here then is the message logger with a custom handler added (which although it does nothing more than behave like the default handler, it provides the hooks for customization):
+In order to provide custom processing to the program above, a *custom interpolated string expression handler* is needed. Here then is the message logger with a custom handler added (which although it does nothing more than behave like the default handler, it provides the hooks for customization):
 
 <!-- Example: {template:"standalone-console-without-using", name:"DeclCustomHandler2", inferOutput:true} -->
 ```csharp
@@ -1313,7 +1313,7 @@ The output produced is, as follows:
 val = {  FF}; 2 * val = 510.
 ```
 
-A type having the attribute `System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute` is said to be an *applicable interpolated string handler type*. 
+A type having the attribute `System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute` is said to be an *applicable interpolated string handler type*.
 
 To qualify as a custom interpolated string expression handler, a class or struct type shall have the following characteristics:
 

--- a/standard/attributes.md
+++ b/standard/attributes.md
@@ -500,6 +500,7 @@ A number of attributes affect the language in some way. These attributes include
 - `System.Runtime.CompilerServices.CallerLineNumberAttribute` ([§23.5.6.2](attributes.md#23562-the-callerlinenumber-attribute)), `System.Runtime.CompilerServices.CallerFilePathAttribute` ([§23.5.6.3](attributes.md#23563-the-callerfilepath-attribute)), and `System.Runtime.CompilerServices.CallerMemberNameAttribute` ([§23.5.6.4](attributes.md#23564-the-callermembername-attribute)), which are used to supply information about the calling context to optional parameters.
 - `System.Runtime.CompilerServices.EnumeratorCancellationAttribute` ([§23.5.8](attributes.md#2358-the-enumeratorcancellation-attribute)), which is used to specify parameter for the cancellation token in an asynchronous iterator.
 - `System.Runtime.CompilerServices.ModuleInitializer` ([§23.5.9](attributes.md#2359-the-moduleinitializer-attribute)), which is used to mark a method as a module initializer.
+- `System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute` and `System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute`, which are used to declare a custom interpolated string expression handler (§custInterpStrExpHandler) and to call one of its constructors, respectively.
 
 The Nullable static analysis attributes ([§23.5.7](attributes.md#2357-code-analysis-attributes)) can improve the correctness of warnings generated for nullabilities and null states ([§8.9.5](types.md#895-nullabilities-and-null-states)).
 
@@ -1211,6 +1212,187 @@ A module initializer shall have the following characteristics:
 - Not be declared inside a *class_declaration* having a *type_parameter_list*.
 - Be accessible from the containing module (that is, have an access modifier `internal` or `public`).
 - Not be a local function.
+
+#### §custInterpStrExpHandler Custom interpolated string expression handlers
+
+##### §custInterpStrExpCustHandling Declaring a custom handler
+
+Consider the following program, which implements a simple message logger:
+
+<!-- Example: {template:"standalone-console", name:"DeclCustomHandler1", inferOutput:true} -->
+```csharp
+using System;
+public class Logger
+{
+    public void LogMessage(string msg)
+    {
+        Console.WriteLine(msg);
+    }
+}
+public class Program
+{
+    static void Main()
+    {
+        var logger = new Logger();
+        int val = 255;
+        logger.LogMessage($"val = {{{val,4:X}}}; 2 * val = {2 * val}.");
+    }
+}
+```
+
+The output produced is, as follows:
+
+```console
+val = {  FF}; 2 * val = 510.
+```
+
+In the call to `LogMessage`, the target of the interpolated string expression argument is parameter `msg`, which has type `string`. As such, according to [§12.8.3](expressions.md#1283-interpolated-string-expressions), the default interpolated string expression handler is invoked. The following subclause (§custInterpStrExpCustHandling) shows how to use a custom handler.
+
+In order to provide custom processing to the program shown in §custInterpStrExpDefHandling, a *custom interpolated string expression handler* is needed. Here then is the message logger with a custom handler added (which although it does nothing more than behave like the default handler, it provides the hooks for customization):
+
+<!-- Example: {template:"standalone-console-without-using", name:"DeclCustomHandler2", inferOutput:true} -->
+```csharp
+using System;
+using System.Text;
+using System.Runtime.CompilerServices;
+
+[InterpolatedStringHandler]
+public ref struct LogInterpolatedStringHandler
+{
+    StringBuilder builder; // Storage for the built-up string
+    public LogInterpolatedStringHandler(int literalLength, int formattedCount)
+    {
+        builder = new StringBuilder(literalLength);
+    }
+    public void AppendLiteral(string s)
+    {
+        builder.Append(s);
+    }
+    public void AppendFormatted<T>(T t)
+    {
+        builder.Append(t?.ToString());
+    }
+    public void AppendFormatted<T>(T t, string format) where T : IFormattable
+    {
+        builder.Append(t?.ToString(format, null));
+    }
+    public void AppendFormatted<T>(T t, int alignment, string format)
+        where T : IFormattable
+    {
+        builder.Append(String.Format("{0" + "," + alignment + ":" + format + "}", t));
+    }
+    public override string ToString() => builder.ToString();
+}
+
+public class Logger
+{
+    public void LogMessage(string msg)
+    {
+        Console.WriteLine(msg);
+    }
+    public void LogMessage(LogInterpolatedStringHandler builder)
+    {
+        Console.WriteLine(builder.ToString());
+    }
+}
+
+public class Program
+{
+    static void Main()
+    {
+        var logger = new Logger();
+        int val = 255;
+        logger.LogMessage($"val = {{{val,4:X}}}; 2 * val = {2 * val}.");
+    }
+}
+```
+
+The output produced is, as follows:
+
+```console
+val = {  FF}; 2 * val = 510.
+```
+
+A type having the attribute `System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute` is said to be an *applicable interpolated string handler type*. 
+
+To qualify as a custom interpolated string expression handler, a class or struct type shall have the following characteristics:
+
+- Be marked with the attribute `System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute`.
+- Have an accessible constructor whose first two parameters have type `int`. (Other parameters may follow, which are used to pass information to/from the handler. These are discussed in §custInterpStrExpPassInfo. An optional final parameter may be declared to inhibit the handler from processing the interpolated string. This is discussed in §custInterpStrExpInhibCustHandler).
+
+When the compiler-generated code calls the constructor, the first parameter is set to the sum of the lengths of the interpolated string expression segments ([§12.8.3](expressions.md#1283-interpolated-string-expressions)) in the interpolated string expression, and the second parameter is set to the number of interpolations. (For `($"val = {{{val,4:X}}}; 2 * val = {2 * val}."`, these values are 21 and 2, respectively.)
+
+- Have an accessible method with the signature `void AppendLiteral(string s)`, which is called to process a single interpolated string expression literal segment.
+- Have a set of accessible overloaded methods called `AppendFormatted`, one of which is called to process a single interpolation, based on that interpolation’s content. Their signatures are, as follows:
+  - `void AppendFormatted<T>(T t)`, which deals with interpolations having no explicit format or alignment, as in the case of `{2 * val}`.
+  - `void AppendFormatted<T>(T t, string format) where T : System.IFormattable`, which deals with interpolations having an explicit format, but no alignment, as in the case of `{val:X4}`.
+  - `void AppendFormatted<T>(T t, int alignment, string format) where T : System.IFormattable`, which deals with interpolations having an explicit format and alignment, as in the case of `{val,4:X}`.
+- Have a public method with the signature `override string ToString()`, which returns the built string.
+
+> *Note*: It is not a compile-time error to omit any of the `AppendFormatted` overloads, but if the handler is to be maximally robust, it should support all the formats recognized by the default handler. *end note*
+
+The new overload of `LogMessage` takes a custom handler instead of `string`, and retrieves the string as formatted by that handler. When such overloads exist, if a corresponding handler exists and the interpolated string expression is not a constant ([§12.8.3](expressions.md#1283-interpolated-string-expressions)), the compiler generates code to call the one taking a handler. In such cases, the compiler generates code to
+
+- call the handler constructor
+- in lexical order within the interpolated string expression
+  - pass each interpolated string expression segment to `AppendLiteral`
+  - pass each interpolation to the appropriate `AppendFormatted` method.
+- return the final string as the value of the interpolated string expression.
+- execute the body of `LogMessage`.
+
+##### §custInterpStrExpInhibCustHandler Inhibiting a custom handler
+
+If a handler constructor has a final parameter of type `bool` that is an out parameter, when that constructor is called that parameter’s value is tested. If it is true, the behavior is as if that parameter were omitted. However, if it is false, the interpolated string expression is not processed further; that is, the handler is *inhibited*. Specifically, the interpolation expressions are not evaluated, and the methods `AppendLiteral` and `AppendFormatted` are not called.
+
+``` csharp
+public LogInterpolatedStringHandler(int literalLength, int formattedCount,
+    out bool processString)
+{
+    if (some_condition)
+    {
+        processString = false;
+        return;
+    }
+    else 
+    {
+        processString = true;
+        // continue construction
+    }
+}
+```
+
+*Note*: The interpolations in an interpolated string expression may contain side effects (as result from `++`, `--`,  assignment, and some method calls). If a handler is inhibited, none of the side effects in the interpolated string expression are evaluated. If a handler is not inhibited, all of the side effects in the interpolated string expression are evaluated. *end note*
+
+##### §custInterpStrExpPassInfo Passing information to/from a custom handler
+
+It can be useful to pass other information to, and receive information back from, the custom handler. This is done via the attribute `System.Runtime.CompilerServices.InterpolatedStringHandlerArgument`. Consider the following new overloads to the message logger program:
+
+```csharp
+public class Logger
+{
+    // …
+    public void LogMessage(bool flag, int count,
+        [InterpolatedStringHandlerArgument("count","flag","")] 
+        LogInterpolatedStringHandler builder)
+    {
+        // …
+    }
+}
+
+public ref struct LogInterpolatedStringHandler
+{
+    // …
+    public LogInterpolatedStringHandler(int literalLength, int formattedCount,
+        int count, bool flag, Logger logger)
+    {
+        // …
+    }
+}
+```
+
+Attribute `InterpolatedStringHandlerArgument` is applied to the handler parameter, which shall follow the declarations of the parameters that are to be passed to the handler. The attribute constructor argument shall be a comma-separated list of zero or more strings that name the parameters to be passed, along with their order. An empty string designates the instance from which the handler is being invoked. As such, the attribute constructor call above containing `"count","flag",""` requires a matching handler constructor. If the attribute constructor argument list is empty, the behavior is as if the attribute was omitted.
+
+If an `out bool` parameter is also declared to allow the handler to be inhibited (§custInterpStrExpInhibCustHandler) that parameter shall be the final one.
 
 ## 23.6 Attributes for interoperation
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -145,8 +145,7 @@ An implicit enumeration conversion permits a *constant_expression* ([§12.26](ex
 
 ### 10.2.5 Implicit interpolated string conversions
 
-An implicit interpolated string conversion permits an *interpolated_string_expression* ([§12.8.3](expressions.md#1283-interpolated-string-expressions)) to be converted to `System.IFormattable` or `System.FormattableString` (which implements `System.IFormattable`).
-When this conversion is applied, a string value is not composed from the interpolated string. Instead an instance of `System.FormattableString` is created, as further described in [§12.8.3](expressions.md#1283-interpolated-string-expressions).
+For any type `T` that is an applicable interpolated string handler type (§custInterpStrExpCustHandling), there exists an implicit interpolated string handler conversion to `T` from a non-constant *ISE* ([§12.8.3](expressions.md#1283-interpolated-string-expressions)). This conversion exists, regardless of whether errors are found later when attempting to lower the interpolation using the handler pattern. This ensures that there are predictable and useful errors, and that runtime behavior doesn't change based on the content of an interpolated string.
 
 ### 10.2.6 Implicit nullable conversions
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -145,6 +145,8 @@ An implicit enumeration conversion permits a *constant_expression* ([§12.26](ex
 
 ### 10.2.5 Implicit interpolated string conversions
 
+An implicit interpolated string conversion permits an *interpolated_string_expression* ([§12.8.3](expressions.md#1283-interpolated-string-expressions)) to be converted to `System.IFormattable` or `System.FormattableString` (which implements `System.IFormattable`). When this conversion is applied, a string value is not composed from the interpolated string. Instead an instance of `System.FormattableString` is created, as further described in [§12.8.3](expressions.md#1283-interpolated-string-expressions).
+
 For any type `T` that is an applicable interpolated string handler type (§custInterpStrExpCustHandling), there exists an implicit interpolated string handler conversion to `T` from a non-constant *ISE* ([§12.8.3](expressions.md#1283-interpolated-string-expressions)). This conversion exists, regardless of whether errors are found later when attempting to lower the interpolation using the handler pattern. This ensures that there are predictable and useful errors, and that runtime behavior doesn't change based on the content of an interpolated string.
 
 ### 10.2.6 Implicit nullable conversions

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1521,8 +1521,8 @@ An *interpolated_string_expression* is classified as a value, which is evaluated
 1. If the target of an assignment or method-call argument has type `string`, the expression is processed by the default interpolated string handler, `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler`, and the result has type `string`.
 1. If the target of an assignment or method-call argument has a custom interpolated string handler (§custInterpStrExpHandler) type, then
 
-  - If the interpolated string contains no interpolations, the expression is processed as if the target type was `string`.
-  - Otherwise, the expression is processed by the custom interpolated string handler and the result has that custom interpolated string handler’s type.
+- If the interpolated string contains no interpolations, the expression is processed as if the target type was `string`.
+- Otherwise, the expression is processed by the custom interpolated string handler and the result has that custom interpolated string handler’s type.
 
 These rules are illustrated by the following:
 
@@ -1535,7 +1535,7 @@ M($"no interpolations");// invokes M(string)
 M($"{val}");            // invokes M(SomeInterpolatedStringHandler)
 string s1 = $"{val}";   // default handler used, as target has type string
 M(s1);                  // invokes M(string)
-SomeInterpolatedStringHandler str2 = $"{val}";	 // custom handler used
+SomeInterpolatedStringHandler str2 = $"{val}";   // custom handler used
 M(s2);                  // invokes M(SomeInterpolatedStringHandler)
 ```
 
@@ -1607,8 +1607,8 @@ Then:
 
 A *constant interpolated string* is an *interpolated_string_expression* that contains
 
-  - no interpolations, or
-  - interpolations whose *expression*s are constant expressions of type `string`, and these interpolations have no *interpolation_minimum_width*, *Regular_Interpolation_Format*, or *Verbatim_Interpolation_Format* specifiers.
+- no interpolations, or
+- interpolations whose *expression*s are constant expressions of type `string`, and these interpolations have no *interpolation_minimum_width*, *Regular_Interpolation_Format*, or *Verbatim_Interpolation_Format* specifiers.
 
 For example, $"Hello", $"{cs1}, world!" (given `const string cs1 = $"Hello";`), $"{"Hello," + $"world!"}", and $"xxx{(true ? $"{"X"}" : $"{$"{"Y"}"}")}yyy" are all constant interpolated strings. However, $"{123}" and $"{"abc"}{123.45}" are not.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1520,6 +1520,7 @@ An *interpolated_string_expression* is classified as a value, which is evaluated
 
 1. If the target of an assignment or method-call argument has type `string`, the expression is processed by the default interpolated string handler, `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler`, and the result has type `string`.
 1. If the target of an assignment or method-call argument has a custom interpolated string handler (§custInterpStrExpHandler) type, then
+
   - If the interpolated string contains no interpolations, the expression is processed as if the target type was `string`.
   - Otherwise, the expression is processed by the custom interpolated string handler and the result has that custom interpolated string handler’s type.
 
@@ -1532,7 +1533,7 @@ static void M(SomeInterpolatedStringHandler s) { }
 int val = 255;
 M($"no interpolations");// invokes M(string)
 M($"{val}");            // invokes M(SomeInterpolatedStringHandler)
-string s1 = $"{val}";	// default handler used, as target has type string
+string s1 = $"{val}";   // default handler used, as target has type string
 M(s1);                  // invokes M(string)
 SomeInterpolatedStringHandler str2 = $"{val}";	 // custom handler used
 M(s2);                  // invokes M(SomeInterpolatedStringHandler)
@@ -1605,6 +1606,7 @@ Then:
 *end example*
 
 A *constant interpolated string* is an *interpolated_string_expression* that contains
+
   - no interpolations, or
   - interpolations whose *expression*s are constant expressions of type `string`, and these interpolations have no *interpolation_minimum_width*, *Regular_Interpolation_Format*, or *Verbatim_Interpolation_Format* specifiers.
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1052,6 +1052,7 @@ A function member is said to be an ***applicable function member*** with respect
 - Each argument in `A` corresponds to a parameter in the function member declaration as described in [§12.6.2.2](expressions.md#12622-corresponding-parameters), at most one argument corresponds to each parameter, and any parameter to which no argument corresponds is an optional parameter.
 - For each argument in `A`, the parameter-passing mode of the argument is identical to the parameter-passing mode of the corresponding parameter, and
   - for a value parameter or a parameter array, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter, or
+  - for a reference parameter whose type is a struct type, an implicit interpolated string handler conversion exists from the argument to the type of the corresponding parameter, or
   - for a reference or output parameter, there is an identity conversion between the type of the argument expression (if any) and the type of the corresponding parameter, or
   - for an input parameter when the corresponding argument has the `in` modifier, there is an identity conversion between the type of the argument expression (if any) and the type of the corresponding parameter, or
   - for an input parameter when the corresponding argument omits the `in` modifier, an implicit conversion ([§10.2](conversions.md#102-implicit-conversions)) exists from the argument expression to the type of the corresponding parameter.
@@ -1375,7 +1376,13 @@ A *primary_expression* that consists of a *literal* ([§6.4.5](lexical-structure
 
 ### 12.8.3 Interpolated string expressions
 
-An *interpolated_string_expression* consists of `$`, `$@`, or `@$`, immediately followed by text within `"` characters. Within the quoted text there are zero or more ***interpolations*** delimited by `{` and `}` characters, each of which encloses an *expression* and optional formatting specifications.
+An *interpolated_string_expression* consists of `$`, `$@`, or `@$`, immediately followed by text within `"` characters. Within the quoted text there are zero or more ***interpolations*** delimited by `{` and `}` characters, each of which encloses an *expression* and optional formatting specifications. Any quoted text that is not part of an interpolation (as defined by the grammar rules *Interpolated_Regular_String_Mid* and *Interpolated_Verbatim_String_Mid* shown below) is part of an *interpolated string expression segment*. As such, the quoted text contains zero or more interpolated string expression segments. Consider the following *interpolated_string_expression*:
+
+```csharp
+$"val = {{{val,4:X}}}; 2 * val = {2 * val}."
+```
+
+This contains the interpolated string expression segments `"val = {"`, `"}; 2 * val = "`, and `"."`, the first of which factors in the presence of the open/close brace escape sequences described in the grammar below. The quoted text also contains the interpolations `"{val,4:X}"` and `"{2 * val}"`.
 
 Interpolated string expressions have two forms; regular (*interpolated_regular_string_expression*)
 and verbatim (*interpolated_verbatim_string_expression*); which are lexically similar to, but differ semantically from, the two forms of string
@@ -1509,13 +1516,31 @@ other tokens in the language. *end note*
 other lexer generators ANTLR supports context sensitive lexical rules, for example using its *lexical modes*,
 but this is an implementation detail and therefore not part of this specification. *end note*
 
-An *interpolated_string_expression* is classified as a value. If it is immediately converted to `System.IFormattable` or `System.FormattableString` with an implicit interpolated string conversion ([§10.2.5](conversions.md#1025-implicit-interpolated-string-conversions)), the interpolated string expression has that type. Otherwise, it has the type `string`.
+An *interpolated_string_expression* is classified as a value, which is evaluated in one of the following ways depending on the context in which it appears:
 
-> *Note*: The differences between the possible types an *interpolated_string_expression* may be determined from the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). *end note*
+1. If the target of an assignment or method-call argument has type `string`, the expression is processed by the default interpolated string handler, `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler`, and the result has type `string`.
+1. If the target of an assignment or method-call argument has a custom interpolated string handler (§custInterpStrExpHandler) type, then
+  - If the interpolated string contains no interpolations, the expression is processed as if the target type was `string`.
+  - Otherwise, the expression is processed by the custom interpolated string handler and the result has that custom interpolated string handler’s type.
+
+These rules are illustrated by the following:
+
+```csharp
+static void M(string s) { }
+static void M(SomeInterpolatedStringHandler s) { }
+
+int val = 255;
+M($"no interpolations");// invokes M(string)
+M($"{val}");            // invokes M(SomeInterpolatedStringHandler)
+string s1 = $"{val}";	// default handler used, as target has type string
+M(s1);                  // invokes M(string)
+SomeInterpolatedStringHandler str2 = $"{val}";	 // custom handler used
+M(s2);                  // invokes M(SomeInterpolatedStringHandler)
+```
+
+The remainder of this subclause deals with the default interpolated string handler behavior only. The declaration and use of custom interpolated string handlers is described in §custInterpStrExpHandler.
 
 The meaning of an interpolation, both *regular_interpolation* and *verbatim_interpolation*, is to format the value of the *expression* as a `string` either according to the format specified by the *Regular_Interpolation_Format* or *Verbatim_Interpolation_Format*, or according to a default format for the type of *expression*. The formatted string is then modified by the *interpolation_minimum_width*, if any, to produce the final `string` to be interpolated into the *interpolated_string_expression*.
-
-> *Note*: How the default format for a type is determined is detailed in the documentation for `System.String` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) and `System.FormattableString` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)). Descriptions of standard formats, which are identical for *Regular_Interpolation_Format* and *Verbatim_Interpolation_Format*, may be found in the documentation for `System.IFormattable` ([§C.4](standard-library.md#c4-format-specifications)) and in other types in the standard library ([§C](standard-library.md#annex-c-standard-library)). *end note*
 
 In an *interpolation_minimum_width* the *constant_expression* shall have an implicit conversion to `int`. Let the *field width* be the absolute value of this *constant_expression* and the *alignment* be the sign (positive or negative) of the value of this *constant_expression*:
 
@@ -1524,9 +1549,7 @@ In an *interpolation_minimum_width* the *constant_expression* shall have an impl
   - If the alignment is positive the formatted string is right-aligned by prepending the padding,
   - Otherwise it is left-aligned by appending the padding.
 
-The overall meaning of an *interpolated_string_expression*, including the above formatting and padding of interpolations, is defined by a conversion of the expression to a method invocation: if the type of the expression is `System.IFormattable` or `System.FormattableString` that method is `System.Runtime.CompilerServices.FormattableStringFactory.Create` ([§C.3](standard-library.md#c3-standard-library-types-not-defined-in-isoiec-23271)) which returns a value of type `System.FormattableString`; otherwise the type shall be `string` and the method is `string.Format` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)) which returns a value of type `string`.
-
-In both cases, the argument list of the call consists of a *format string literal* with *format specifications* for each interpolation, and an argument for each expression corresponding to the format specifications.
+The interpolated string expression is treated as a *format string literal* with *format specifications* for each interpolation.
 
 The format string literal is constructed as follows, where `N` is the number of interpolations in the *interpolated_string_expression*. The format string literal consists of, in order:
 
@@ -1580,6 +1603,14 @@ Then:
 | `$"{(number==0?"Zero":"Non-zero")}"` | `string.Format("{0}", (number==0?"Zero":"Non-zero"))`         | `"Non-zero"` |
 
 *end example*
+
+A *constant interpolated string* is an *interpolated_string_expression* that contains
+  - no interpolations, or
+  - interpolations whose *expression*s are constant expressions of type `string`, and these interpolations have no *interpolation_minimum_width*, *Regular_Interpolation_Format*, or *Verbatim_Interpolation_Format* specifiers.
+
+For example, $"Hello", $"{cs1}, world!" (given `const string cs1 = $"Hello";`), $"{"Hello," + $"world!"}", and $"xxx{(true ? $"{"X"}" : $"{$"{"Y"}"}")}yyy" are all constant interpolated strings. However, $"{123}" and $"{"abc"}{123.45}" are not.
+
+For simplicity, the term *ISE* is used throughout this specification to mean either an *interpolated_string_expression* or an *additive_expression* composed entirely of *interpolated_string_expression*s and binary `+` operators.
 
 ### 12.8.4 Simple names
 
@@ -7359,6 +7390,7 @@ A *constant_expression* of type `nint` shall have a value in the range \[-214748
 Only the following constructs are permitted in constant expressions:
 
 - Literals (including the `null` literal).
+- Constant interpolated strings.
 - References to `const` members of class, struct, and interface types.
 - References to members of enumeration types.
 - References to local constants.

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -1150,14 +1150,16 @@ Given `int i = 10;`, according to [§12.6.4.2](expressions.md#12642-applicable-f
 
 #### 12.6.4.5 Better conversion from expression
 
-Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a ***better conversion*** than `C₂` if `E` does not exactly match `T₂` and at least one of the following holds:
+Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a ***better conversion*** than `C₂` if one of the following holds:
 
-- `E` exactly matches `T₁` and `E` does not exactly match `T₂` ([§12.6.4.6](expressions.md#12646-exactly-matching-expression))
-- `C₁` is not a conditional expression conversion and `C₂` is a conditional expression conversion.
-- `E` exactly matches both or neither of `T₁` and `T₂`, and `T₁` is a better conversion target than `T₂` ([§12.6.4.7](expressions.md#12647-better-conversion-target)) and either `C₁` and `C₂` are both conditional expression conversions or neither is a conditional expression conversion.
-  - `V` is a function pointer type `delegate*<V2..Vk, V1>` and `U` is a function pointer type `delegate*<U2..Uk, U1>`, and the calling convention of `V` is identical to `U`, and the refness of `Vi` is identical to `Ui`.
-    > *Note*: This is only applicable in unsafe code. *end note*
-- `E` is a method group ([§12.2](expressions.md#122-expression-classifications)), `T₁` is compatible ([§21.4](delegates.md#214-delegate-compatibility)) with the single best method from the method group for conversion `C₁`, and `T₂` is not compatible with the single best method from the method group for conversion `C₂`
+- `E` is a non-constant *interpolated_string_expression*, `C₁` is an implicit interpolated string handler conversion, `T₁` is an applicable interpolated string handler type, and `C₂` is not an implicit interpolated string handler conversion.
+- `E` does not exactly match `T₂` and at least one of the following holds:
+  - `E` exactly matches `T₁` and `E` does not exactly match `T₂` ([§12.6.4.6](expressions.md#12646-exactly-matching-expression))
+  - `C₁` is not a conditional expression conversion and `C₂` is a conditional expression conversion.
+  - `E` exactly matches both or neither of `T₁` and `T₂`, and `T₁` is a better conversion target than `T₂` ([§12.6.4.7](expressions.md#12647-better-conversion-target)) and either `C₁` and `C₂` are both conditional expression conversions or neither is a conditional expression conversion.
+    - `V` is a function pointer type `delegate*<V2..Vk, V1>` and `U` is a function pointer type `delegate*<U2..Uk, U1>`, and the calling convention of `V` is identical to `U`, and the refness of `Vi` is identical to `Ui`.
+      > *Note*: This is only applicable in unsafe code. *end note*
+  - `E` is a method group ([§12.2](expressions.md#122-expression-classifications)), `T₁` is compatible ([§21.4](delegates.md#214-delegate-compatibility)) with the single best method from the method group for conversion `C₁`, and `T₂` is not compatible with the single best method from the method group for conversion `C₂`
 
 #### 12.6.4.6 Exactly matching expression
 
@@ -1519,6 +1521,7 @@ but this is an implementation detail and therefore not part of this specificatio
 An *interpolated_string_expression* is classified as a value, which is evaluated in one of the following ways depending on the context in which it appears:
 
 1. If the target of an assignment or method-call argument has type `string`, the expression is processed by the default interpolated string handler, `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler`, and the result has type `string`.
+1. If the target of an assignment or method-call argument has type `System.IFormattable` or `System.FormattableString`, a string value is not composed from the interpolated string. Instead an instance of `System.FormattableString` is created.
 1. If the target of an assignment or method-call argument has a custom interpolated string handler (§custInterpStrExpHandler) type, then
 
 - If the interpolated string contains no interpolations, the expression is processed as if the target type was `string`.
@@ -1536,7 +1539,7 @@ M($"{val}");            // invokes M(SomeInterpolatedStringHandler)
 string s1 = $"{val}";   // default handler used, as target has type string
 M(s1);                  // invokes M(string)
 SomeInterpolatedStringHandler str2 = $"{val}";   // custom handler used
-M(s2);                  // invokes M(SomeInterpolatedStringHandler)
+M(str2);                // invokes M(SomeInterpolatedStringHandler)
 ```
 
 The remainder of this subclause deals with the default interpolated string handler behavior only. The declaration and use of custom interpolated string handlers is described in §custInterpStrExpHandler.

--- a/standard/standard-library.md
+++ b/standard/standard-library.md
@@ -779,6 +779,31 @@ namespace System.Linq.Expressions
 
 namespace System.Runtime.CompilerServices
 {
+    public ref struct DefaultInterpolatedStringHandler
+    {
+        public DefaultInterpolatedStringHandler(int literalLength,
+            int formattedCount);
+        public DefaultInterpolatedStringHandler(int literalLength,
+            int formattedCount, IFormatProvider? provider);
+        public DefaultInterpolatedStringHandler(int literalLength,
+            int formattedCount, IFormatProvider? provider, Span<char> initialBuffer);
+        public void AppendFormatted(scoped ReadOnlySpan<char> value);
+        public void AppendFormatted(string? value);
+        public void AppendFormatted(object? value, int alignment = 0,
+            string? format = default);
+        public void AppendFormatted(scoped ReadOnlySpan<char> value,
+            int alignment = 0, string? format = default);
+        public void AppendFormatted(string? value, int alignment = 0,
+            string? format = default);
+        public void AppendFormatted<T>(T value);
+        public void AppendFormatted<T>(T value, int alignment);
+        public void AppendFormatted<T>(T value, string? format);
+        public void AppendFormatted<T>(T value, int alignment, string? format);
+        public void AppendLiteral(string value);
+        public override string ToString();
+        public string ToStringAndClear();
+    }
+
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | 
         AttributeTargets.Interface, 
         Inherited = false, AllowMultiple = false)]
@@ -827,6 +852,21 @@ namespace System.Runtime.CompilerServices
     public interface INotifyCompletion
     {
         void OnCompleted(Action continuation);
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Parameter,
+        AllowMultiple=false, Inherited=false)]
+    public sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
+    {
+        public InterpolatedStringHandlerArgumentAttribute(string argument);
+        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments);
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class |
+        System.AttributeTargets.Struct, AllowMultiple=false, Inherited=false)]
+    public sealed class InterpolatedStringHandlerAttribute : Attribute
+    {
+        public InterpolatedStringHandlerAttribute (); 
     }
 
     /// <summary>
@@ -1428,10 +1468,13 @@ The following library types are referenced in this specification. The full names
 - `global::System.Runtime.CompilerServices.CallerFilePathAttribute`
 - `global::System.Runtime.CompilerServices.CallerLineNumberAttribute`
 - `global::System.Runtime.CompilerServices.CallerMemberNameAttribute`
+- `global::System.Runtime.CompilerServices.DefaultInterpolatedStringHandler`
 - `global::System.Runtime.CompilerServices.FormattableStringFactory`
 - `global::System.Runtime.CompilerServices.ICriticalNotifyCompletion`
 - `global::System.Runtime.CompilerServices.IndexerNameAttribute`
 - `global::System.Runtime.CompilerServices.INotifyCompletion`
+- `global::System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute`
+- `global::System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute`
 - `global::System.Runtime.CompilerServices.ITuple`
 - `global::System.Runtime.CompilerServices.ModuleInitializerAttribute`
 - `global::System.Runtime.CompilerServices.TaskAwaiter`


### PR DESCRIPTION
This is Rex's adaptation of the following: [MS proposal](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-10.0/constant_interpolated_strings.md) and [MS proposal](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-10.0/improved-interpolated-strings.md). As the first is trivial and defines a term that is used by the second, Rex combined the two into this one PR.

Rex decided that the minimum set of members a robust handler must have are, as follows: one constructor having two `int` parameters, method `AppendLiteral`, a `ToString` method to get at the built string, and three `AppendFormatted` methods, so that handler can be called using all interpolated string formats a programmer might throw at it *without* requiring extra arguments to be passed to the constructor. That is, it can correctly handle formats with or without alignment. I’ve used the default handler member set in this decision. Is this OK?