### PR TITLE
Fix note on unmanaged, `?`

### DIFF
--- a/standard/types.md
+++ b/standard/types.md
@@ -623,10 +623,10 @@ Since a type parameter can be instantiated with many different type arguments, t
 > - The available conversions for a type parameter depend on the constraints, if any, applied to the type parameter. They are detailed in [§10.2.12](conversions.md#10212-implicit-conversions-involving-type-parameters) and [§10.3.8](conversions.md#1038-explicit-conversions-involving-type-parameters).
 > - The literal `null` cannot be converted to a type given by a type parameter, except if the type parameter is known to be a reference type ([§10.2.12](conversions.md#10212-implicit-conversions-involving-type-parameters)). However, a default expression ([§12.8.21](expressions.md#12821-default-value-expressions)) can be used instead. In addition, a value with a type given by a type parameter *can* be compared with null using `==` and `!=` ([§12.14.7](expressions.md#12147-reference-type-equality-operators)) unless the type parameter has the value type constraint.
 > - A `new` expression ([§12.8.17.2](expressions.md#128172-object-creation-expressions)) can only be used with a type parameter if the type parameter is constrained by a *constructor_constraint* or the value type constraint ([§15.2.5](classes.md#1525-type-parameter-constraints)).
-> - A type parameter cannot be used anywhere within an attribute.
+> - A type parameter cannot be used anywhere within an attribute (§23.2.1).
 > - A type parameter cannot be used in a member access ([§12.8.7](expressions.md#1287-member-access)) or type name ([§7.8](basic-concepts.md#78-namespace-and-type-names)) to identify a static member or a nested type.
 > - A type parameter can only be used as an *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)) if the type parameter is constrained by the unmanaged constraint ([§15.2.5](classes.md#1525-type-parameter-constraints)).
-> - Nullable annotations (`?`) aren't allowed on an instance of a type parameter unless that type parameter is constrained to be either a reference type or a value type.  
+> - Nullable annotations (`?`) aren't allowed on an instance of a type parameter unless that type parameter is constrained to be either a reference type or a value type ([§15.2.5](classes.md#1525-type-parameter-constraints)).  
 >
 > *end note*
 

--- a/standard/types.md
+++ b/standard/types.md
@@ -625,7 +625,8 @@ Since a type parameter can be instantiated with many different type arguments, t
 > - A `new` expression ([§12.8.17.2](expressions.md#128172-object-creation-expressions)) can only be used with a type parameter if the type parameter is constrained by a *constructor_constraint* or the value type constraint ([§15.2.5](classes.md#1525-type-parameter-constraints)).
 > - A type parameter cannot be used anywhere within an attribute.
 > - A type parameter cannot be used in a member access ([§12.8.7](expressions.md#1287-member-access)) or type name ([§7.8](basic-concepts.md#78-namespace-and-type-names)) to identify a static member or a nested type.
-> - A type parameter cannot be used as an *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)).
+> - A type parameter can only be used as an *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)) if the type parameter is constrained by the unmanaged constraint ([§15.2.5](classes.md#1525-type-parameter-constraints)).
+> - Nullable annotations (`?`) aren't allowed on an instance of a type parameter unless that type parameter is constrained to be either a reference type or a value type.  
 >
 > *end note*
 


### PR DESCRIPTION
We missed updating two non-normative note when we added the `unmanaged` constraint in V8. One to allow type parameters to be unmanaged when constrained as such. Another to disallow `?` on type parameters not constrained to be either struct or reference types.

I found this will reviewing the changes for the `default` constraint in V9.