### PR TITLE
[Version 11.0] Feature support for Numeric IntPtr

### DIFF
--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -117,8 +117,6 @@ All identity conversions are symmetric. If an identity conversion exists from `T
 
 In most cases, an identity conversion has no effect at runtime. However, since floating point operations may be performed at higher precision than prescribed by their type ([§8.3.7](types.md#837-floating-point-types)), assignment of their results may result in a loss of precision, and explicit casts are guaranteed to reduce precision to what is prescribed by the type ([§12.9.8](expressions.md#1298-cast-expressions)).
 
-There is an identity conversion between `nint` and `System.IntPtr`, and between `nuint` and `System.UIntPtr`.
-
 For the compound types array, nullable type, constructed type, and tuple, there is an identity conversion between native integers ([§8.3.6](types.md#836-integral-types)) and their underlying types.
 
 ### 10.2.3 Implicit numeric conversions

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -287,6 +287,8 @@ As an example of numeric promotion, consider the predefined implementations of t
 ```csharp
 int operator *(int x, int y);
 uint operator *(uint x, uint y);
+nint operator *(nint x, nint y);
+nuint operator *(nuint x, nuint y);
 long operator *(long x, long y);
 ulong operator *(ulong x, ulong y);
 float operator *(float x, float y);

--- a/standard/types.md
+++ b/standard/types.md
@@ -280,7 +280,7 @@ A struct type is a value type that can declare constants, fields, methods, prope
 
 ### 8.3.5 Simple types
 
-Except for `nint` and `nuint`, the simple types are aliases for predefined `struct` types in the `System` namespace, as described in the table below.
+The simple types are aliases for predefined `struct` types in the `System` namespace, as described in the table below.
 
 **Keyword** | **Aliased type**
 ----------- | ------------------
@@ -290,8 +290,8 @@ Except for `nint` and `nuint`, the simple types are aliases for predefined `stru
   `ushort`  |   `System.UInt16`
   `int`     |   `System.Int32`
   `uint`    |   `System.UInt32`
-  `nint`    |    none; see below
-  `nuint`   |    none; see below
+  `nint`    |   `System.IntPtr`
+  `nuint`   |   `System.UIntPtr`
   `long`    |   `System.Int64`
   `ulong`   |   `System.UInt64`
   `char`    |   `System.Char`
@@ -300,7 +300,7 @@ Except for `nint` and `nuint`, the simple types are aliases for predefined `stru
   `bool`    |   `System.Boolean`
   `decimal` |   `System.Decimal`
 
-Every simple type has members. Each simple type that is an alias for a predefined struct type, has that struct type’s members.
+Every simple type has members. Each simple type has its aliased struct type’s members.
 
 > *Example*: `int` has any implementation-specific members declared in `System.Int32` and the members (required and implementation specific) inherited from `System.Object`, and the following statements are permitted:
 >

--- a/standard/types.md
+++ b/standard/types.md
@@ -324,14 +324,6 @@ Every simple type has members. Each simple type has its aliased struct type’s 
 >
 > *end note*.
 
-<!-- C# 11: In C# 11, nint and nuint become true aliases for System.IntPtr and System.UIntPtr. The following paragraphs describing the non-alias relationship should be updated or removed. -->
-
-The types `nint` and `nuint` are represented by the types `System.IntPtr` and `System.UIntPtr`, respectively, and are *not* aliases for these types. In this context being *represented by* means:
-
-- The only members directly accessible for `nint` and `nuint` are the required methods of `Object` ([§C.2](standard-library.md#c2-standard-library-types-defined-in-isoiec-23271)). Any other members of `System.IntPtr` and `System.UIntPtr` may be accessed via those types.
-- Operations performed through `dynamic` binding on `System.IntPtr` and `System.UIntPtr` values do not have access to the `nint` and `nuint` operators.
-- In all other respects `nint` and `nuint` behave as if they are aliases of `System.IntPtr` and `System.UIntPtr`.
-
 ### 8.3.6 Integral types
 
 C# supports the following integral types, with the sizes and value ranges, as shown:

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -787,14 +787,20 @@ In an unsafe context, the `+` operator ([§12.13.5](expressions.md#12135-additio
 ```csharp
 T* operator +(T* x, int y);
 T* operator +(T* x, uint y);
+T* operator +(T* x, nint y);
+T* operator +(T* x, nuint y);
 T* operator +(T* x, long y);
 T* operator +(T* x, ulong y);
 T* operator +(int x, T* y);
 T* operator +(uint x, T* y);
+T* operator +(nint x, T* y);
+T* operator +(nuint x, T* y);
 T* operator +(long x, T* y);
 T* operator +(ulong x, T* y);
 T* operator –(T* x, int y);
 T* operator –(T* x, uint y);
+T* operator -(T* x, nint y);
+T* operator -(T* x, nuint y);
 T* operator –(T* x, long y);
 T* operator –(T* x, ulong y);
 long operator –(T* x, T* y);
@@ -802,7 +808,7 @@ long operator –(T* x, T* y);
 
 There are no predefined operators for pointer addition or subtraction with native integer ([§8.3.6](types.md#836-integral-types)) offsets. Instead, `nint` and `nuint` values shall be promoted to `long` and `ulong`, respectively, with pointer arithmetic using the predefined operators for those types.
 
-Given an expression `P` of a data pointer type `T*` and an expression `N` of type `int`, `uint`, `long`, or `ulong`, the expressions `P + N` and `N + P` compute the pointer value of type `T*` that results from adding `N * sizeof(T)` to the address given by `P`. Likewise, the expression `P – N` computes the pointer value of type `T*` that results from subtracting `N * sizeof(T)` from the address given by `P`.
+Given an expression `P` of a data pointer type `T*` and an expression `N` of type `int`, `uint`, `nint`, `nuint`, `long`, or `ulong`, the expressions `P + N` and `N + P` compute the pointer value of type `T*` that results from adding `N * sizeof(T)` to the address given by `P`. Likewise, the expression `P – N` computes the pointer value of type `T*` that results from subtracting `N * sizeof(T)` from the address given by `P`.
 
 Given two expressions, `P` and `Q`, of a data pointer type `T*`, the expression `P – Q` computes the difference between the addresses given by `P` and `Q` and then divides that difference by `sizeof(T)`. The type of the result is always `long`. In effect, `P - Q` is computed as `((long)(P) - (long)(Q)) / sizeof(T)`.
 


### PR DESCRIPTION
This is Rex's adaptation of the corresponding [MS proposal](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-11.0/numeric-intptr.md).

## Issue 1

Since .NET 5, `IntPtr` and `UIntrPtr` have had properties `MinValue` and `MaxValue`. Shall we admit that and add these members to the library annex as new members of an existing type?

## Issue 2

Should we add any new operators (such as addition and subtraction) to `IntPtr`/`UIntPtr` in the library annex?

## Issue 3

The following text was added to 8.3.5 Simple types in Rex's Draft V9 PR #1457. Please review it to see which text should be kept, which should be deleted, and which should be changed.

Although `nint` and `nuint` shall be represented by the types `System.IntPtr` and `System.UIntPtr`, respectively, `nint` and `nuint` are *not* aliases for those types. As such, not all members of the corresponding `System` types are defined for `nint` and `nuint`. Instead, the compiler shall make available additional conversions and operations for the types `System.IntPtr` and `System.UIntPtr`, when used in the context of native integer types.
Consider the following:

<!-- Example: {template:"standalone-console-without-using", name:"SimpleTypes2, expectedErrors:["CS0266"], ignoredWarnings:["CS0219"]} -->
```csharp
nint a1 = 1;           // OK
System.IntPtr a2 = 1;  // Error: no implicit conversion
```

While the implementation provides operations and conversions for `nint` and `nuint` that are appropriate for integer types, those operations and conversions are not available on the `System` type counterparts. Similarly,

<!-- Example: {template:"code-in-main-without-using", name:"SimpleTypes3", expectedException:"RuntimeBinderException"} -->
```csharp
M((nint)1);

static void M(dynamic d)
{
    var v = d >> 2; // RuntimeBinderException: '>>' cannot be applied to operands
                    // of type System.IntPtr/System.UIntPtr and int
}
```

The only constructor for `nint` or `nuint` is the parameter-less constructor.

The following members of `System.IntPtr` and `System.UIntPtr` are explicitly excluded from `nint` or `nuint`:

```csharp
// constructors
// arithmetic operators
// implicit and explicit conversions
public static readonly IntPtr Zero; // use 0 instead
public static int Size { get; }     // use sizeof() instead
public static IntPtr Add(IntPtr pointer, int offset);
public static IntPtr Subtract(IntPtr pointer, int offset);
public int ToInt32();
public long ToInt64();
public void* ToPointer();
```

The remaining members of `System.IntPtr` and `System.UIntPtr` are implicitly included in `nint` and `nuint`. These are:

```csharp
public override bool Equals(object obj);
public override int GetHashCode();
public override string ToString();
public string ToString(string format);
```
Interfaces implemented by `System.IntPtr` and `System.UIntPtr` are implicitly included in `nint` and `nuint`, with occurrences of the underlying types replaced by the corresponding native integer types. For example, if `IntPtr` implements `ISerializable`, `IEquatable<IntPtr>`, and `IComparable<IntPtr>`, then `nint` implements `ISerializable`, `IEquatable<nint>`, and `IComparable<nint>`.

`nint` and `System.IntPtr`, and `nuint` and `System.UIntPtr`, are considered equivalent for overriding, hiding, and implementing, however.

Overloads cannot differ by `nint` and `System.IntPtr`, and `nuint` and `System.UIntPtr`, alone. However, overrides and implementations may differ by `nint` and `System.IntPtr`, or `nuint` and `System.UIntPtr`, alone.

Methods hide other methods that differ by `nint` and `System.IntPtr`, or `nuint` and `System.UIntPtr`, alone.

`typeof(nint)` is `typeof(System.IntPtr)`, and `typeof(nuint)` is `typeof(System.UIntPtr)`.[
