### PR TITLE
Correctly classify null literal conversion

### DIFF
--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -155,6 +155,7 @@ An implicit conversion exists from the `null` literal to any reference type or n
 
 The implicit reference conversions are:
 
+- A null literal conversion (§10.2.7) to any reference-type.
 - From any *reference_type* to `object` and `dynamic`.
 - From any *class_type* `S` to any *class_type* `T`, provided `S` is derived from `T`.
 - From any *class_type* `S` to any *interface_type* `T`, provided `S` implements `T`.
@@ -168,8 +169,6 @@ The implicit reference conversions are:
 - From any *reference_type* to a *reference_type* `T` if it has an implicit identity or reference conversion to a *reference_type* `T₀` and `T₀` has an identity conversion to `T`.
 - From any *reference_type* to an interface or delegate type `T` if it has an implicit identity or reference conversion to an interface or delegate type `T₀` and `T₀` is variance-convertible ([§19.2.3.3](interfaces.md#19233-variance-conversion)) to `T`.
 - Implicit conversions involving type parameters that are known to be reference types. See [§10.2.12](conversions.md#10212-implicit-conversions-involving-type-parameters) for more details on implicit conversions involving type parameters.
-
-> *Note*: A null literal conversion ([§10.2.7](conversions.md#1027-null-literal-conversions)) to a reference type is also classified as an implicit reference conversion. *end note*
 
 The implicit reference conversions are those conversions between *reference_type*s that can be proven to always succeed, and therefore require no checks at run-time.
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -149,7 +149,7 @@ The implicit nullable conversions are those nullable conversions ([§10.6.1](con
 
 ### 10.2.7 Null literal conversions
 
-An implicit conversion exists from the `null` literal to any reference type or nullable value type. This conversion produces a null reference if the target type is a reference type, or the null value ([§8.3.12](types.md#8312-nullable-value-types)) of the given nullable value type.
+An implicit conversion exists from the `null` literal to any reference type or nullable value type. This conversion produces a null reference if the target type is a reference type, or the null value ([§8.3.12](types.md#8312-nullable-value-types)) of the given nullable value type. A null literal conversion to a reference type is also classified as an implicit reference conversion ([§10.2.8](conversions.md#1028-implicit-reference-conversions)).
 
 ### 10.2.8 Implicit reference conversions
 
@@ -165,10 +165,11 @@ The implicit reference conversions are:
 - From a single-dimensional array type `S[]` to `System.Collections.Generic.IList<T>`, `System.Collections.Generic.IReadOnlyList<T>`, and their base interfaces, provided that there is an implicit identity or reference conversion from `S` to `T`.
 - From any *array_type* to `System.Array` and the interfaces it implements.
 - From any *delegate_type* to `System.Delegate` and the interfaces it implements.
-- From the null literal ([§6.4.5.7](lexical-structure.md#6457-the-null-literal)) to any reference-type.
 - From any *reference_type* to a *reference_type* `T` if it has an implicit identity or reference conversion to a *reference_type* `T₀` and `T₀` has an identity conversion to `T`.
 - From any *reference_type* to an interface or delegate type `T` if it has an implicit identity or reference conversion to an interface or delegate type `T₀` and `T₀` is variance-convertible ([§19.2.3.3](interfaces.md#19233-variance-conversion)) to `T`.
 - Implicit conversions involving type parameters that are known to be reference types. See [§10.2.12](conversions.md#10212-implicit-conversions-involving-type-parameters) for more details on implicit conversions involving type parameters.
+
+> *Note*: A null literal conversion ([§10.2.7](conversions.md#1027-null-literal-conversions)) to a reference type is also classified as an implicit reference conversion. *end note*
 
 The implicit reference conversions are those conversions between *reference_type*s that can be proven to always succeed, and therefore require no checks at run-time.
 

--- a/standard/conversions.md
+++ b/standard/conversions.md
@@ -155,7 +155,7 @@ An implicit conversion exists from the `null` literal to any reference type or n
 
 The implicit reference conversions are:
 
-- A null literal conversion (§10.2.7) to any reference-type.
+- A null literal conversion (§10.2.7) to any *reference_type*.
 - From any *reference_type* to `object` and `dynamic`.
 - From any *class_type* `S` to any *class_type* `T`, provided `S` is derived from `T`.
 - From any *class_type* `S` to any *interface_type* `T`, provided `S` implements `T`.


### PR DESCRIPTION
Fixes #1631 

None of the references to 10.2.8 (implicit reference conversions) specify that a null literal conversion applies, but it obviously does. A conversion from the null literal to a reference type was clasified as both a null literal conversion and an implicit reference conversion. To fix this, make the following two changes:

- Add normative language that a null literal conversion is classified as an implicit reference conversions.
- Add an informative note in 10.2.8 that provides a cross reference to the same.