### PR TITLE
Update the SDK versions

### DIFF
--- a/.github/workflows/grammar-validator.yaml
+++ b/.github/workflows/grammar-validator.yaml
@@ -21,10 +21,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v6.0.2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Set up JDK 15
       uses: actions/setup-java@v5

--- a/.github/workflows/renumber-sections.yaml
+++ b/.github/workflows/renumber-sections.yaml
@@ -26,10 +26,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v6.0.2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Run section renumbering dry run
       run: |

--- a/.github/workflows/smart-quotes.yaml
+++ b/.github/workflows/smart-quotes.yaml
@@ -24,10 +24,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v6.0.2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Smarten quotes
       id: smarten-quote

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -34,15 +34,15 @@ jobs:
       uses: actions/checkout@v6.0.2
 
     # We build examples against .NET 6.0, but use
-    # 8.0 for the tools themselves. (The closer we
+    # 10.0 for the tools themselves. (The closer we
     # are to the target language version we're standardising,
     # the better.)
-    - name: Setup .NET 6.0 and 8.0
+    - name: Setup .NET 6.0 and 10.0
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           6.0.x
-          8.0.x
+          10.0.x
 
     - name: Extract and validate tests
       run: |

--- a/.github/workflows/tools-tests.yaml
+++ b/.github/workflows/tools-tests.yaml
@@ -25,10 +25,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v6.0.2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Run all tests
       run: |

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -30,10 +30,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v6.0.2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Set up JDK 15
       uses: actions/setup-java@v5

--- a/.github/workflows/word-converter.yaml
+++ b/.github/workflows/word-converter.yaml
@@ -30,10 +30,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v6.0.2
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Run converter
       run: |


### PR DESCRIPTION
We now run all tools on .NET 10. Newer versions will use newer versions for testing as well.

Thanks to @Nigel-Ecma for spotting this.

