### PR TITLE
Don't add links in codefences

### DIFF
--- a/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
+++ b/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
@@ -28,10 +28,13 @@ internal class ReferenceUpdateProcessor
         using (var readStream = new StreamReader(inputPath))
         {
             using StreamWriter writeStream = new(tmpFileName);
+            bool inCodeFence = false;
             while (await readStream.ReadLineAsync() is string line)
             {
+                // Don't add links in codefenced examples.
+                inCodeFence ^= line.Contains("```");
                 lineNumber++;
-                var updatedLine = line.Contains(sectionReference)
+                var updatedLine = (!inCodeFence && line.Contains(sectionReference))
                     ? ProcessSectionLinks(line, lineNumber, inputPath)
                     : line;
                 await writeStream.WriteLineAsync(updatedLine);


### PR DESCRIPTION
If a code fenced sample or declaration contains a section reference, don't add a link to the markdown. Keep it a raw xref.

The markdown links won't get replaced, so they'll show up in the finished spec