### PR TITLE
Review and update pattern subsumption and exhaustion

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3887,7 +3887,7 @@ If a switch expression is not subject to a *switch expression conversion*, then
 - The type of the *switch_expression* is the best common type [§12.6.3.16](expressions.md#126316-finding-the-best-common-type-of-a-set-of-expressions)) of the *switch_expression_arm_expression*s of the *switch_expression_arm*s, if such a type exists, and each *switch_expression_arm_expression* can be implicitly converted to that type.
 - It is an error if no such type exists.
 
-It is an error if the pattern of any *switch_expression_arm* is *subsumed* by ([§11.3](patterns.md#113-pattern-subsumption)) the set of patterns of earlier *unguarded* ([§13.8.3](statements.md#1383-the-switch-statement)) *switch_expression_arm*s of the switch expression.
+It is an error if the pattern of any *switch_expression_arm* is *subsumed* by (§11.1) the set of patterns of earlier *unguarded* ([§13.8.3](statements.md#1383-the-switch-statement)) *switch_expression_arm*s of the switch expression.
 
 A switch expression is *exhaustive* if every value of its input is handled by at least one arm of the switch expression. A warning may be issued if a switch expression is not exhaustive.
 

--- a/standard/patterns.md
+++ b/standard/patterns.md
@@ -458,8 +458,9 @@ A set of patterns `Q` *subsumes* a pattern `P` if any of the following condition
 - `P` is a constant pattern and any of the patterns in the set `Q` would match `P`’s *converted value*
 - `P` is a var pattern, the set of patterns `Q` is *exhaustive* ([§11.4](patterns.md#114-pattern-exhaustiveness)) for the type of the pattern input value ([§11.1](patterns.md#111-general)), and, if the pattern input value is of a nullable type, some pattern in `Q` would match `null`.
 - `P` is a declaration pattern with type `T` and the set of patterns `Q` is *exhaustive* for the type `T` ([§11.4](patterns.md#114-pattern-exhaustiveness)).
+- `P` is a *positional_pattern* or a *property_pattern* and every value that `P` would match would also be matched by some pattern in `Q`.
 
-Subsumption involving a *positional_pattern* or a *property_pattern* is not otherwise defined by this specification; an implementation is permitted, but not required, to detect additional cases of subsumption involving such patterns.
+> *Note*: The last rule applies recursively through *sub-patterns*; for example, the set `{ (var x, var y) }` subsumes the pattern `(0, 0)` because every pair of values matched by the latter is also matched by the former. The precise extent to which an implementation detects subsumption involving *positional_pattern*s and *property_pattern*s is not specified beyond what these rules require. *end note*
 
 > *Example*: In the following switch expression, no arm is subsumed even though arms 1, 2, and 3 share the same pattern:
 >
@@ -487,10 +488,13 @@ A set of patterns `Q` is *exhaustive* for a type `T` if any of the following con
 
 1. `T` is an integral or enum type, or a nullable version of one of those, and for every possible value of `T`’s non-nullable underlying type, some pattern in `Q` would match that value; or
 2. Some pattern in `Q` is a *var_pattern* or a *discard_pattern*; or
-3. Some pattern in `Q` is a *declaration pattern* for type `D`, and there is an identity conversion, an implicit reference conversion, or a boxing conversion from `T` to `D`.
+3. Some pattern in `Q` is a *declaration pattern* for type `D`, and there is an identity conversion, an implicit reference conversion, or a boxing conversion from `T` to `D`; or
+4. `Q` contains a set of *positional_pattern*s or *property_pattern*s such that every non-`null` value of `T` is matched by at least one pattern in that set.
 
-A set of patterns containing only *constant_pattern*s, *positional_pattern*s, or *property_pattern*s (in any combination), other than as covered by rule 1 above, is not considered exhaustive by this specification. An implementation is permitted, but not required, to recognize additional sets of patterns as exhaustive.
+> *Note*: Rule 4 applies recursively through *sub-patterns*. The precise extent to which an implementation detects exhaustiveness arising from combinations of *positional_pattern*s, *property_pattern*s, and *constant_pattern*s is not specified beyond what these rules require. *end note*
+<!-- markdownlint-disable MD028 -->
 
+<!-- markdownlint-enable MD028 -->
 > *Example*:
 >
 > <!-- Example: {template:"standalone-console-without-using", name:"PatternExhaustiveness1", replaceEllipsis:true, customEllipsisReplacements: [""], ignoredWarnings:["CS8321"]} -->

--- a/standard/patterns.md
+++ b/standard/patterns.md
@@ -449,7 +449,7 @@ If, after applying the preceding rule, the token `_` is still a *discard_pattern
 
 In a switch statement ([§13.8.3](statements.md#1383-the-switch-statement)), it is an error if a case’s pattern is *subsumed* by the preceding set of *unguarded* ([§13.8.3](statements.md#1383-the-switch-statement)) cases. In a switch expression ([§12.11](expressions.md#1211-switch-expression)), it is an error if a *switch_expression_arm*’s pattern is *subsumed* by the preceding set of *unguarded* *switch_expression_arm*s’ patterns.
 
-> *Note*: This means that any input value would have been matched by one of the previous cases or arms. *end note*
+A pattern `P` is *subsumed* by set of unguarded patterns `Q` if any input value matched by `P` is matched by one of the members of `Q`.
 
 ## 11.4 Pattern exhaustiveness
 

--- a/standard/patterns.md
+++ b/standard/patterns.md
@@ -448,64 +448,9 @@ If, after applying the preceding rule, the token `_` is still a *discard_pattern
 ## 11.3 Pattern subsumption
 
 In a switch statement ([§13.8.3](statements.md#1383-the-switch-statement)), it is an error if a case’s pattern is *subsumed* by the preceding set of *unguarded* ([§13.8.3](statements.md#1383-the-switch-statement)) cases. In a switch expression ([§12.11](expressions.md#1211-switch-expression)), it is an error if a *switch_expression_arm*’s pattern is *subsumed* by the preceding set of *unguarded* *switch_expression_arm*s’ patterns.
+
 > *Note*: This means that any input value would have been matched by one of the previous cases or arms. *end note*
-The following rules define when a set of patterns subsumes a given pattern:
-
-A pattern `P` *would match* a constant `K` if the specification for that pattern’s runtime behavior is that `P` matches `K`.
-
-A set of patterns `Q` *subsumes* a pattern `P` if any of the following conditions hold:
-
-- `P` is a constant pattern and any of the patterns in the set `Q` would match `P`’s *converted value*
-- `P` is a var pattern, the set of patterns `Q` is *exhaustive* ([§11.4](patterns.md#114-pattern-exhaustiveness)) for the type of the pattern input value ([§11.1](patterns.md#111-general)), and, if the pattern input value is of a nullable type, some pattern in `Q` would match `null`.
-- `P` is a declaration pattern with type `T` and the set of patterns `Q` is *exhaustive* for the type `T` ([§11.4](patterns.md#114-pattern-exhaustiveness)).
-
-Subsumption involving a *positional_pattern* or a *property_pattern* is not otherwise defined by this specification; an implementation is permitted, but not required, to detect additional cases of subsumption involving such patterns.
-
-> *Example*: In the following switch expression, no arm is subsumed even though arms 1, 2, and 3 share the same pattern:
->
-> <!-- Example: {template:"code-in-main", name:"SwitchExprUnguardedSubsumption"} -->
-> ```csharp
-> object x = 10;
-> bool b = false;
-> int y = x switch
-> {
->     int i when !b => 0,
->     int i when b  => 1,
->     int i         => 2,
->     _             => 3
-> };
-> ```
->
-> Arms 1 and 2 have non-constant guards and so are not *unguarded*; only arm 3 is *unguarded* with pattern `int i`, which does not subsume the final `_` arm because it does not match a non-`int` value such as `null`. *end example*
 
 ## 11.4 Pattern exhaustiveness
 
-Informally, a set of patterns is exhaustive for a type if, for every possible value of that type other than null, some pattern in the set is applicable.
-The following rules define when a set of patterns is *exhaustive* for a type:
-
-A set of patterns `Q` is *exhaustive* for a type `T` if any of the following conditions hold:
-
-1. `T` is an integral or enum type, or a nullable version of one of those, and for every possible value of `T`’s non-nullable underlying type, some pattern in `Q` would match that value; or
-2. Some pattern in `Q` is a *var_pattern* or a *discard_pattern*; or
-3. Some pattern in `Q` is a *declaration pattern* for type `D`, and there is an identity conversion, an implicit reference conversion, or a boxing conversion from `T` to `D`.
-
-A set of patterns containing only *constant_pattern*s, *positional_pattern*s, or *property_pattern*s (in any combination), other than as covered by rule 1 above, is not considered exhaustive by this specification. An implementation is permitted, but not required, to recognize additional sets of patterns as exhaustive.
-
-> *Example*:
->
-> <!-- Example: {template:"standalone-console-without-using", name:"PatternExhaustiveness1", replaceEllipsis:true, customEllipsisReplacements: [""], ignoredWarnings:["CS8321"]} -->
-> ```csharp
-> static void M(byte b)
-> {
->     switch (b) {
->         case 0: case 1: case 2: ... // handle every specific value of byte
->             break;
->         // error: the pattern 'byte other' is subsumed by the (exhaustive)
->         // previous cases
->         case byte other: 
->             break;
->     }
-> }
-> ```
->
-> *end example*
+A set of patterns is exhaustive if, for every possible input value, some pattern in the set is applicable. When an implementation detects that a set of patterns is not exhaustive, it shall issue a warning.

--- a/standard/patterns.md
+++ b/standard/patterns.md
@@ -13,6 +13,12 @@ A pattern is tested against a value in a number of contexts:
 
 The value against which a pattern is tested is called the ***pattern input value***.
 
+A pattern `P` is *subsumed* by set of unguarded patterns `Q` if any input value matched by `P` is matched by one of the members of `Q`.
+
+In a switch statement ([§13.8.3](statements.md#1383-the-switch-statement)), it is an error if a case’s pattern is *subsumed* by the preceding set of *unguarded* ([§13.8.3](statements.md#1383-the-switch-statement)) cases. In a switch expression ([§12.11](expressions.md#1211-switch-expression)), it is an error if a *switch_expression_arm*’s pattern is *subsumed* by the preceding set of *unguarded* *switch_expression_arm*s’ patterns.
+
+A set of patterns is exhaustive if, for every possible input value, some pattern in the set is applicable. When an implementation detects that a set of patterns is not exhaustive, it shall issue a warning.
+
 ## 11.2 Pattern forms
 
 ### 11.2.1 General
@@ -444,13 +450,3 @@ If, after applying the preceding rule, the token `_` is still a *discard_pattern
 > ```
 >
 > *end example*
-
-## 11.3 Pattern subsumption
-
-In a switch statement ([§13.8.3](statements.md#1383-the-switch-statement)), it is an error if a case’s pattern is *subsumed* by the preceding set of *unguarded* ([§13.8.3](statements.md#1383-the-switch-statement)) cases. In a switch expression ([§12.11](expressions.md#1211-switch-expression)), it is an error if a *switch_expression_arm*’s pattern is *subsumed* by the preceding set of *unguarded* *switch_expression_arm*s’ patterns.
-
-A pattern `P` is *subsumed* by set of unguarded patterns `Q` if any input value matched by `P` is matched by one of the members of `Q`.
-
-## 11.4 Pattern exhaustiveness
-
-A set of patterns is exhaustive if, for every possible input value, some pattern in the set is applicable. When an implementation detects that a set of patterns is not exhaustive, it shall issue a warning.

--- a/standard/patterns.md
+++ b/standard/patterns.md
@@ -456,8 +456,10 @@ A pattern `P` *would match* a constant `K` if the specification for that pattern
 A set of patterns `Q` *subsumes* a pattern `P` if any of the following conditions hold:
 
 - `P` is a constant pattern and any of the patterns in the set `Q` would match `P`’s *converted value*
-- `P` is a var pattern and the set of patterns `Q` is *exhaustive* ([§11.4](patterns.md#114-pattern-exhaustiveness)) for the type of the pattern input value ([§11.1](patterns.md#111-general)), and either the pattern input value is not of a nullable type or some pattern in `Q` would match `null`.
+- `P` is a var pattern, the set of patterns `Q` is *exhaustive* ([§11.4](patterns.md#114-pattern-exhaustiveness)) for the type of the pattern input value ([§11.1](patterns.md#111-general)), and, if the pattern input value is of a nullable type, some pattern in `Q` would match `null`.
 - `P` is a declaration pattern with type `T` and the set of patterns `Q` is *exhaustive* for the type `T` ([§11.4](patterns.md#114-pattern-exhaustiveness)).
+
+Subsumption involving a *positional_pattern* or a *property_pattern* is not otherwise defined by this specification; an implementation is permitted, but not required, to detect additional cases of subsumption involving such patterns.
 
 > *Example*: In the following switch expression, no arm is subsumed even though arms 1, 2, and 3 share the same pattern:
 >
@@ -484,8 +486,10 @@ The following rules define when a set of patterns is *exhaustive* for a type:
 A set of patterns `Q` is *exhaustive* for a type `T` if any of the following conditions hold:
 
 1. `T` is an integral or enum type, or a nullable version of one of those, and for every possible value of `T`’s non-nullable underlying type, some pattern in `Q` would match that value; or
-2. Some pattern in `Q` is a *var pattern*; or
+2. Some pattern in `Q` is a *var_pattern* or a *discard_pattern*; or
 3. Some pattern in `Q` is a *declaration pattern* for type `D`, and there is an identity conversion, an implicit reference conversion, or a boxing conversion from `T` to `D`.
+
+A set of patterns containing only *constant_pattern*s, *positional_pattern*s, or *property_pattern*s (in any combination), other than as covered by rule 1 above, is not considered exhaustive by this specification. An implementation is permitted, but not required, to recognize additional sets of patterns as exhaustive.
 
 > *Example*:
 >

--- a/standard/patterns.md
+++ b/standard/patterns.md
@@ -458,9 +458,8 @@ A set of patterns `Q` *subsumes* a pattern `P` if any of the following condition
 - `P` is a constant pattern and any of the patterns in the set `Q` would match `P`’s *converted value*
 - `P` is a var pattern, the set of patterns `Q` is *exhaustive* ([§11.4](patterns.md#114-pattern-exhaustiveness)) for the type of the pattern input value ([§11.1](patterns.md#111-general)), and, if the pattern input value is of a nullable type, some pattern in `Q` would match `null`.
 - `P` is a declaration pattern with type `T` and the set of patterns `Q` is *exhaustive* for the type `T` ([§11.4](patterns.md#114-pattern-exhaustiveness)).
-- `P` is a *positional_pattern* or a *property_pattern* and every value that `P` would match would also be matched by some pattern in `Q`.
 
-> *Note*: The last rule applies recursively through *sub-patterns*; for example, the set `{ (var x, var y) }` subsumes the pattern `(0, 0)` because every pair of values matched by the latter is also matched by the former. The precise extent to which an implementation detects subsumption involving *positional_pattern*s and *property_pattern*s is not specified beyond what these rules require. *end note*
+Subsumption involving a *positional_pattern* or a *property_pattern* is not otherwise defined by this specification; an implementation is permitted, but not required, to detect additional cases of subsumption involving such patterns.
 
 > *Example*: In the following switch expression, no arm is subsumed even though arms 1, 2, and 3 share the same pattern:
 >
@@ -488,13 +487,10 @@ A set of patterns `Q` is *exhaustive* for a type `T` if any of the following con
 
 1. `T` is an integral or enum type, or a nullable version of one of those, and for every possible value of `T`’s non-nullable underlying type, some pattern in `Q` would match that value; or
 2. Some pattern in `Q` is a *var_pattern* or a *discard_pattern*; or
-3. Some pattern in `Q` is a *declaration pattern* for type `D`, and there is an identity conversion, an implicit reference conversion, or a boxing conversion from `T` to `D`; or
-4. `Q` contains a set of *positional_pattern*s or *property_pattern*s such that every non-`null` value of `T` is matched by at least one pattern in that set.
+3. Some pattern in `Q` is a *declaration pattern* for type `D`, and there is an identity conversion, an implicit reference conversion, or a boxing conversion from `T` to `D`.
 
-> *Note*: Rule 4 applies recursively through *sub-patterns*. The precise extent to which an implementation detects exhaustiveness arising from combinations of *positional_pattern*s, *property_pattern*s, and *constant_pattern*s is not specified beyond what these rules require. *end note*
-<!-- markdownlint-disable MD028 -->
+A set of patterns containing only *constant_pattern*s, *positional_pattern*s, or *property_pattern*s (in any combination), other than as covered by rule 1 above, is not considered exhaustive by this specification. An implementation is permitted, but not required, to recognize additional sets of patterns as exhaustive.
 
-<!-- markdownlint-enable MD028 -->
 > *Example*:
 >
 > <!-- Example: {template:"standalone-console-without-using", name:"PatternExhaustiveness1", replaceEllipsis:true, customEllipsisReplacements: [""], ignoredWarnings:["CS8321"]} -->

--- a/standard/statements.md
+++ b/standard/statements.md
@@ -753,7 +753,7 @@ There can be at most one `default` label in a `switch` statement.
 
 It is an error if the pattern of any switch label is not *applicable* ([§11.2.1](patterns.md#1121-general)) to the type of the input expression.
 
-It is an error if the pattern of any switch label is *subsumed* by ([§11.3](patterns.md#113-pattern-subsumption)) the set of patterns of earlier *unguarded* switch labels of the switch statement.
+It is an error if the pattern of any switch label is *subsumed* by (§11.1) the set of patterns of earlier *unguarded* switch labels of the switch statement.
 
 > *Example*:
 >
@@ -949,7 +949,7 @@ A switch label is reachable if at least one of the following is true:
 - The switch’s *selector_expression* is not a constant value and either
   - the label is a `case` without a guard or with a guard whose value is not the constant false; or
   - it is a `default` label and
-    - the set of patterns appearing among the cases of the switch statement that do not have guards or have guards whose value is the constant true, is not *exhaustive* ([§11.4](patterns.md#114-pattern-exhaustiveness)) for the switch governing type; or
+    - the set of patterns appearing among the cases of the switch statement that do not have guards or have guards whose value is the constant true, is not *exhaustive* (§11.1) for the switch governing type; or
     - the switch governing type is a nullable type and the set of patterns appearing among the cases of the switch statement that do not have guards or have guards whose value is the constant true does not contain a pattern that would match the value `null`.
 - The switch label is referenced by a reachable `goto case` or `goto default` statement.
 
@@ -959,7 +959,7 @@ The end point of a `switch` statement is reachable if the switch statement is re
 
 - The `switch` statement contains a reachable `break` statement that exits the `switch` statement.
 - No `default` label is present and either
-  - The switch’s *selector_expression* is a non-constant value, and the set of patterns appearing among the cases of the switch statement that do not have guards or have guards whose value is the constant true, is not *exhaustive* ([§11.4](patterns.md#114-pattern-exhaustiveness)) for the switch governing type.
+  - The switch’s *selector_expression* is a non-constant value, and the set of patterns appearing among the cases of the switch statement that do not have guards or have guards whose value is the constant true, is not *exhaustive* (§11.1) for the switch governing type.
   - The switch’s *selector_expression* is a non-constant value of a nullable type, and no pattern appearing among the cases of the switch statement that do not have guards or have guards whose value is the constant true would match the value `null`.
   - The switch’s *selector_expression* is a constant value and no `case` label without a guard or whose guard is the constant true would match that value.
 


### PR DESCRIPTION
Fixes #1650 

**This should be reviewed commit by commit**

The first commit takes a minimal approach to describing the new rules for subsumption and exhaustiveness. That keeps the rules at a high level, and avoids any discussion of the particular algorithm to determine either subsumption or exhaustiveness in property patterns and other recursive patterns.

The second commit takes a more maximal approach to the rules, but still tries to avoid the actual algorithm used by a well known compiler. I'm less than satisfied, as it makes more assumptions, but still does a fair amount of handwaving. (Fourth commit fixes a lint issue).

~~My recommendation is to revert the final commit and then merge.~~

After the last meeting, we agreed to update the PR with a new commit to define the terms of subsumption and exhaustiveness, and limit the requirement to produce the diagnostics when either non-exhaustive patterns or subsumed branches are detected.
