### PR TITLE
Add ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,4 @@ test-grammar/
 
 # don't checkin jar files:
 *.jar
+*.lscache


### PR DESCRIPTION
The newest release of the C# DevKit creates a "cache" file for every .csproj in the repo. These shouldn't be checked in.