### PR TITLE
Clarify rules on safety and sizeof

### DIFF
--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3201,7 +3201,7 @@ The `typeof` operator can be used on a type parameter. It is a compile time erro
 
 ### 12.8.19 The sizeof operator
 
-The `sizeof` operator returns the number of 8-bit bytes occupied by a variable of a given type. The type specified as an operand to sizeof shall be an *unmanaged_type* ([§8.8](types.md#88-unmanaged-types)).
+The `sizeof` operator returns the number of 8-bit bytes occupied by a variable of a given type.
 
 ```ANTLR
 sizeof_expression
@@ -3227,7 +3227,7 @@ For certain predefined types the `sizeof` operator yields a constant `int` value
 |`sizeof(bool)`     | 1          |
 |`sizeof(decimal)`  | 16         |
 
-For an enum type `T`, the result of the expression `sizeof(T)` is a constant value equal to the size of its underlying type, as given above. For all other operand types, the `sizeof` operator is specified in [§24.6.9](unsafe-code.md#2469-the-sizeof-operator).
+For an enum type `T`, the result of the expression `sizeof(T)` is a constant value equal to the size of its underlying type, as given above. For all other operand types, the `sizeof` operator is specified in [§24.6.9](unsafe-code.md#2469-the-sizeof-operator), and is allowed only in an unsafe context.
 
 ### 12.8.20 The checked and unchecked operators
 

--- a/standard/expressions.md
+++ b/standard/expressions.md
@@ -3209,7 +3209,7 @@ sizeof_expression
     ;
 ```
 
-For certain predefined types the `sizeof` operator yields a constant `int` value as shown in the table below:
+For certain types the `sizeof` operator yields a constant `int` value as shown in the table below:
 
 |**Expression**     | **Result** |
 |-----------------  | ---------- |
@@ -3227,7 +3227,9 @@ For certain predefined types the `sizeof` operator yields a constant `int` value
 |`sizeof(bool)`     | 1          |
 |`sizeof(decimal)`  | 16         |
 
-For an enum type `T`, the result of the expression `sizeof(T)` is a constant value equal to the size of its underlying type, as given above. For all other operand types, the `sizeof` operator is specified in [§24.6.9](unsafe-code.md#2469-the-sizeof-operator), and is allowed only in an unsafe context.
+For an enum type `T`, the result of the expression `sizeof(T)` is a constant value equal to the size of its underlying type, as given above.
+
+For all other operand types, the `sizeof` operator is specified in [§24.6.9](unsafe-code.md#2469-the-sizeof-operator), and is allowed only in an unsafe context.
 
 ### 12.8.20 The checked and unchecked operators
 

--- a/standard/unsafe-code.md
+++ b/standard/unsafe-code.md
@@ -668,7 +668,7 @@ Because an implicit conversion exists from any pointer type to the `void*` type,
 
 ### 24.6.9 The sizeof operator
 
-For certain predefined types ([§12.8.19](expressions.md#12819-the-sizeof-operator)), the `sizeof` operator yields a constant `int` value. For all other types, the result of the `sizeof` operator is implementation-defined and is classified as a value, not a constant.
+For certain types ([§12.8.19](expressions.md#12819-the-sizeof-operator)), the `sizeof` operator yields a constant `int` value. For all other types, the result of the `sizeof` operator is implementation-defined and is classified as a value, not a constant.
 
 The order in which members are packed into a struct is unspecified.
 


### PR DESCRIPTION
This is a small focused change, but fixes what I (at least) misinterpreted at least twice.

In version 7.3 we correctly updated the rules for in 8.8 for Unmanaged types to include struct types where the fields are all unmanaged types. This includes generic types where the type parameter has the `unmanaged` constraint.

However, we didn't restate the restrictions for `sizeof` in 12.8.19 to prevent extending the allowed types in safe context to include those types.

I updated the language in 12.8.19 to make those restrictions clear.