### PR TITLE
Specify version specific branch

### DIFF
--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -65,6 +65,7 @@ jobs:
       with:
         title: "Automated Section renumber and grammar extraction"
         body: "renumber sections. Add grammar"
+        branch: ${{ github.ref_name }}-renumber-sections-and-grammar
 
     - name: Run converter
       id: run-converter


### PR DESCRIPTION
Found based on #1470 and #1471

In our 7/22 meeting, we merged updated features for both C# 8 and C# 9.  The tools did the correct work, but made all commits on one branch.  So, both of these PRs picked up changes from the v8 and v9 PRs.

This change instructs the workflow to create the pull request branch name based on the base branch version it started with. Doing that means it will not accidentically cross versions when the automation runs.