### PR TITLE
Rename draft-10 references to draft-v10 for branch-name consistency

### DIFF
--- a/.github/prompts/post-meeting-propagate.prompt.md
+++ b/.github/prompts/post-meeting-propagate.prompt.md
@@ -21,14 +21,14 @@ Walk these branches in order. Each step merges the previous branch into the next
 1. `draft-v8`   (starting branch — no merge in; just merge its auto-PR)
 2. `draft-v9`   ← merges `draft-v8`
 3. `alpha-v9`   ← merges `draft-v9`
-4. `draft-10`   ← merges `alpha-v9`
-5. `alpha-v10`  ← merges `draft-10`
+4. `draft-v10`  ← merges `alpha-v9`
+5. `alpha-v10`  ← merges `draft-v10`
 6. `draft-v11`  ← merges `alpha-v10`
 7. `v11-alpha`  ← merges `draft-v11`
 8. `draft-v12`  ← merges `v11-alpha`
 
 > **Branch-naming is inconsistent across versions** (e.g. `alpha-v9` vs
-> `v11-alpha`, `draft-10` vs `draft-v11`). Always verify actual branch
+> `v11-alpha`). Always verify actual branch
 > names with `git branch -r | grep upstream/` before starting.
 >
 > When new version branches are added, append them here using the actual

--- a/.github/prompts/post-meeting-rebase-prs.prompt.md
+++ b/.github/prompts/post-meeting-rebase-prs.prompt.md
@@ -58,10 +58,10 @@ If `vN` is missing or unparseable from the comment, list the entry as unrouted a
 
 ### Step 1 — List target base branches
 
-List target base branches (the propagation chain — see the propagate prompt). Default: `draft-v8 draft-v9 alpha-v9 draft-10 alpha-v10 draft-v11 v11-alpha draft-v12`. Allow the user to override.
+List target base branches (the propagation chain — see the propagate prompt). Default: `draft-v8 draft-v9 alpha-v9 draft-v10 alpha-v10 draft-v11 v11-alpha draft-v12`. Allow the user to override.
 
 > **Branch-naming is inconsistent across versions** (e.g. `alpha-v9` vs
-> `v11-alpha`, `draft-10` vs `draft-v11`). Always verify actual branch
+> `v11-alpha`). Always verify actual branch
 > names with `git branch -r | grep upstream/` before starting.
 
 ### Step 2 — For each base branch, list and process open PRs

--- a/admin/branch-diagram.md
+++ b/admin/branch-diagram.md
@@ -31,8 +31,8 @@ gitGraph
    commit id: "v9 reviewed features"
    branch v9-alpha
    commit id: "v9 alpha feature PRs"
-   branch draft-10
-   checkout draft-10
+   branch draft-v10
+   checkout draft-v10
    commit id: "v10 base"
    commit id: "v10 reviewed features"
    branch v10-alpha
@@ -66,8 +66,8 @@ gitGraph
    commit id: "v9 reviewed features"
    branch v9-alpha
    commit id: "v9 alpha feature PRs"
-   branch draft-10
-   checkout draft-10
+   branch draft-v10
+   checkout draft-v10
    commit id: "v10 base"
    commit id: "v10 reviewed features"
    branch v10-alpha
@@ -84,10 +84,10 @@ gitGraph
    merge draft-v8
    checkout v9-alpha
    merge draft-v9
-   checkout draft-10
+   checkout draft-v10
    merge v9-alpha
    checkout v10-alpha
-   merge draft-10
+   merge draft-v10
    checkout draft-v11
    merge v10-alpha
    checkout v11-alpha


### PR DESCRIPTION
Follow-up to the `draft-10` → `draft-v10` branch rename (aligns the one off-convention branch with the `draft-vN` naming used everywhere else). The remote branch was renamed via the GitHub API and its 14 open PRs auto-retargeted; the downstream propagation branches already carry these reference updates. This PR brings the source `draft-v8` in line.

### Changes (docs only — no `standard/` text)
- `.github/prompts/post-meeting-propagate.prompt.md` — propagation chain list; drop the now-resolved "`draft-10` vs `draft-v11`" example from the branch-naming-inconsistency note (kept the still-valid `alpha-v9` vs `v11-alpha` case).
- `.github/prompts/post-meeting-rebase-prs.prompt.md` — default base-branch list + same note reword.
- `admin/branch-diagram.md` — mermaid graph branch tokens.

No functional/spec changes; `standard/` is untouched.

_Note (out of scope, not fixed here): `draft-v8`'s `update-on-merge.yaml` lists `draft-v11` twice and omits `draft-v10`. It's cosmetic and merge-safe (the corrected list already lives on `draft-v10`), so it's left for a separate cleanup if desired._
