### PR TITLE
Update agent prompts after this month's propagation cycle

### DIFF
--- a/.github/prompts/post-meeting-propagate.prompt.md
+++ b/.github/prompts/post-meeting-propagate.prompt.md
@@ -63,6 +63,29 @@ head-movement checks defined below.
 - Auto-PRs may show a `BLOCKED` merge state due to branch protection rules requiring review approval — this is normal and not a CI failure. Wait for checks to pass, then merge.
 - You have `git` and `gh` available, and push permission to this repo.
 
+## Authoritative remote (set and validate once)
+
+Use one remote for discovery, baselines, merges, comparisons, and pushes.
+This workflow intentionally does not support separate read and write remotes.
+
+```bash
+REMOTE="${REMOTE:-upstream}"
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+FETCH_REPO="$(gh repo view "$(git remote get-url "$REMOTE")" \
+  --json nameWithOwner -q .nameWithOwner)"
+PUSH_REPO="$(gh repo view "$(git remote get-url --push "$REMOTE")" \
+  --json nameWithOwner -q .nameWithOwner)"
+printf 'Authoritative remote: %s (fetch=%s, push=%s, gh=%s)\n' \
+  "$REMOTE" "$FETCH_REPO" "$PUSH_REPO" "$REPO"
+test "$FETCH_REPO" = "$REPO" && test "$PUSH_REPO" = "$REPO"
+```
+
+The final `test` is mandatory. Stop if it fails, if either URL cannot be
+resolved, or if the selected remote does not expose every branch in the
+propagation chain. Keep `REMOTE` unchanged for the entire A1 → B → A2 run.
+The Phase A manifest must record the same remote name and repository; stop
+if it does not match.
+
 ## Discover the propagation chain
 
 Do not rely on a fixed list or assume every alpha is named `alpha-vN`.
@@ -70,8 +93,8 @@ Do not rely on a fixed list or assume every alpha is named `alpha-vN`.
 1. Fetch and list the actual remote branch names:
 
    ```bash
-   git fetch upstream --prune
-   git for-each-ref refs/remotes/upstream \
+   git fetch "$REMOTE" --prune
+   git for-each-ref "refs/remotes/$REMOTE" \
      --format='%(refname:strip=3)' \
      | grep -E '^(draft-v[0-9]+|alpha-v[0-9]+|v[0-9]+-alpha)$' \
      | sort -V
@@ -121,24 +144,29 @@ for the duration of the run.
 
    Load Phase A1's feature-PR manifest. Require one record per dynamically
    enumerated feature PR, including PR number, base branch, head SHA, patch
-   path, and UTC cutoff time. Report the manifest's resulting PR count. Stop
-   if the manifest is missing, has duplicate PR numbers, or its count differs
-   from a fresh enumeration of open PRs on the discovered target draft
-   branches.
+   path, UTC cutoff time, and the authoritative remote name and repository.
+   Report the manifest's resulting PR count. Stop if the manifest is missing,
+   has duplicate PR numbers, names a different remote or repository, or its
+   count differs from a fresh enumeration of open PRs on the discovered
+   target draft branches.
 
 2. **Baseline.** Determine the SHA on each branch in the chain at the
-   *previous* propagation. A reliable proxy is the most recent merge commit whose subject begins with `Post-meeting propagation:` on that branch (`git log --grep '^Post-meeting propagation:' -1 --format=%H origin/<branch>`). Record `BASE_<branch>` for each branch. If a branch has no such commit yet, fall back to the branch point and warn the user.
+   *previous* propagation. A reliable proxy is the most recent merge commit
+   whose subject begins with `Post-meeting propagation:` on that branch
+   (`git log --grep '^Post-meeting propagation:' -1 --format=%H "$REMOTE/<branch>"`).
+   Record `BASE_<branch>` for each branch. If a branch has no such commit
+   yet, fall back to the branch point and warn the user.
 
 3. **Deletion inventory** for the starting branch. Identify text the
    committee removed in this cycle so Step B can recognize resurrection:
 
    ```bash
    # Files where lines were removed since the previous propagation:
-   git log "$BASE_<starting>"..origin/<starting> --diff-filter=MD \
+   git log "$BASE_<starting>".."$REMOTE/<starting>" --diff-filter=MD \
      --name-only --pretty=format: -- standard/ | sort -u
 
    # Hunks (negative lines) for review:
-   git log "$BASE_<starting>"..origin/<starting> -p -- standard/ \
+   git log "$BASE_<starting>".."$REMOTE/<starting>" -p -- standard/ \
      > "$RUN_DIR/starting-deletions.patch"
    ```
 
@@ -149,7 +177,7 @@ for the duration of the run.
    ```bash
    for b in <chain>; do
      git --no-pager grep -nE '<!--[^>]*(vNext|v[0-9]+|future|upcoming|TODO)' \
-       "origin/$b" -- 'standard/*.md' | sed "s|^origin/$b:||" \
+       "$REMOTE/$b" -- 'standard/*.md' | sed "s|^$REMOTE/$b:||" \
        > "$RUN_DIR/vnext-baseline-$b.txt" || true
    done
    ```
@@ -170,8 +198,10 @@ Before starting, confirm the chain with the user and show which branches will be
 
 ### Step A — Process auto-PR on the current branch
 
-1. `git fetch --all --prune`
-2. `git checkout <branch>` and `git pull --ff-only`
+1. `git fetch "$REMOTE" --prune`
+2. `git checkout <branch>` (or create it from `"$REMOTE/<branch>"` if it
+   does not exist), then `git pull --ff-only "$REMOTE" <branch>`. Require
+   local `HEAD` to equal `"$REMOTE/<branch>"` before continuing.
 3. Find the auto-PR opened by `update-on-merge.yaml`:
 
    ```bash
@@ -184,7 +214,8 @@ Before starting, confirm the chain with the user and show which branches will be
    - Wait until checks pass (`gh pr checks <num> --watch` is acceptable, with a reasonable timeout — if it doesn't go green within a few minutes, stop and ask the user).
    - The auto-PR's checks include the `StandardAnchorTags` job. If that job reports any `TOC002` ("`<ref>` not found") diagnostic, **stop** even if `gh pr checks` reports the PR overall as mergeable — broken cross-references must be resolved before merging.
    - Merge it with a **merge commit**: `gh pr merge <num> --merge --delete-branch`.
-   - `git pull --ff-only` on the branch.
+   - `git fetch "$REMOTE" <branch>` and
+     `git pull --ff-only "$REMOTE" <branch>` on the branch.
 5. If not found and this is the starting branch, ask the user whether to wait, run the tools locally (`tools/run-smarten.sh`, `tools/run-section-renumber.sh`), or proceed without them. Do not run tools locally without explicit consent.
 6. If not found on a downstream branch (it should appear after the merge in step B below), continue.
 
@@ -193,7 +224,7 @@ Before starting, confirm the chain with the user and show which branches will be
 1. Still on `<branch>`, run:
 
    ```bash
-   git merge --no-ff origin/<previous-branch> \
+   git merge --no-ff "$REMOTE/<previous-branch>" \
      -m "Post-meeting propagation: merge <previous-branch> into <branch>"
    ```
 
@@ -210,7 +241,7 @@ Before starting, confirm the chain with the user and show which branches will be
      run `checkout --theirs/--ours`, recover with `git checkout -m <file>`
      to restore the conflict markers.
    - For each conflicted hunk in `standard/*.md`:
-     a. Cross-check the hunk's file and line range against the deletion inventory captured in Pre-flight (`$RUN_DIR/starting-deletions.patch`) **and** against any prior `Post-meeting propagation:` merges on the downstream branch (`git log --grep '^Post-meeting propagation:' -p origin/<branch> -- <file>`).
+     a. Cross-check the hunk's file and line range against the deletion inventory captured in Pre-flight (`$RUN_DIR/starting-deletions.patch`) **and** against any prior `Post-meeting propagation:` merges on the downstream branch (`git log --grep '^Post-meeting propagation:' -p "$REMOTE/<branch>" -- <file>`).
      b. If the downstream side intentionally removed the text, keep the deletion and re-apply only non-overlapping upstream edits to the surrounding region.
      c. If unclear, **abort the merge** (`git merge --abort`) and report to the user with the file, line range, and both sides of the hunk.
    - Mechanical "take upstream" is acceptable **only** for:
@@ -237,7 +268,12 @@ Run the section-renumber tool in dry-run mode against the post-merge working tre
     --owner dotnet --repo csharpstandard --dryrun )
 ```
 
-1. **Broken references.** Any *new* `TOC002` ("`<ref>` not found") diagnostic that was not already present on `upstream/<branch>` before the merge is a **hard stop**. Compare the tool output against a pre-merge run (or `git stash && run && git stash pop`) to distinguish new from pre-existing. Pre-existing TOC002s from incomplete feature PRs on alpha branches are expected and should be reported but do not block the merge.
+1. **Broken references.** Any *new* `TOC002` ("`<ref>` not found")
+   diagnostic that was not already present on `"$REMOTE/<branch>"` before
+   the merge is a **hard stop**. Compare the tool output against a pre-merge
+   run (or `git stash && run && git stash pop`) to distinguish new from
+   pre-existing. Pre-existing TOC002s from incomplete feature PRs on alpha
+   branches are expected and should be reported but do not block the merge.
 2. **Mandatory raw symbolic-reference audit.** Run this independently of
    the tool and save the output:
 
@@ -268,9 +304,8 @@ diff "$RUN_DIR/vnext-baseline-<branch>.txt" "$RUN_DIR/vnext-current-<branch>.txt
   > "$RUN_DIR/vnext-delta-<branch>.txt" || true
 ```
 
-> Strip the `HEAD:` prefix with `sed` so diffs against the baseline
-> (which uses `upstream/<branch>:` as prefix) don't produce false
-> positives on every line.
+> Strip the `HEAD:` prefix with `sed`; the baseline command likewise strips
+> `"$REMOTE/<branch>:"`, preventing false positives on every line.
 
 For each *new* comment in the delta, record:
 
@@ -281,10 +316,35 @@ For each *new* comment in the delta, record:
 
 Persist the accumulated list across the whole run. Include it in the final report so `post-meeting-rebase-prs.prompt.md` can consume it. **Do not edit `standard/*.md` to remove or apply these comments.**
 
-### Step B.7 — Push
+### Step B.7 — Finalize, push, and verify
 
-1. Push: `git push origin <branch>`.
-2. The push triggers `update-on-merge.yaml`, which will open a fresh auto-PR. Loop back to Step A for this branch before moving on.
+For a draft branch, run this step after B.6. For an alpha branch, **defer
+this entire step until Step D has applied, validated, and committed every
+fresh feature delta**. An alpha's first and only propagation push must
+already contain its committee merge and fresh feature content.
+
+1. Require a clean working tree. For an alpha, also require the Step D
+   finalization commit and record it as `ALPHA_FINAL_SHA`.
+2. Push the exact local head:
+
+   ```bash
+   git push "$REMOTE" HEAD:<branch>
+   git fetch "$REMOTE" <branch>
+   test "$(git rev-parse HEAD)" = "$(git rev-parse "$REMOTE/<branch>")"
+   ```
+
+   A failed equality check is a hard stop: the remote branch is not the
+   validated local result.
+3. If `update-on-merge.yaml` covers this branch, the push opens a fresh
+   auto-PR. Loop back to Step A for this branch. After merging that PR,
+   fetch again and require `ALPHA_FINAL_SHA` (for an alpha) to be an ancestor
+   of `"$REMOTE/<branch>"`:
+
+   ```bash
+   git merge-base --is-ancestor "$ALPHA_FINAL_SHA" "$REMOTE/<branch>"
+   ```
+
+4. Do not advance to another branch until the remote verification succeeds.
 
 ### Step B.8 — Cheap re-rebase of moved `draft-vN` feature PRs (draft branches with open feature PRs)
 
@@ -296,8 +356,9 @@ created by Step B.7, so the feature PRs rebase onto the final draft head for
 this version.
 
 - Do the **cheap re-rebase of ONLY the vN PRs whose base moved** and
-  regenerate their `.patch` (Phase A machinery — `git rebase upstream/draft-vN`
-  then `git format-patch upstream/draft-vN..<headRefName>`). Do **not**
+  regenerate their `.patch` (Phase A machinery —
+  `git rebase "$REMOTE/draft-vN"` then
+  `git format-patch "$REMOTE/draft-vN..$REMOTE/<headRefName>"`). Do **not**
   re-rebase PRs whose base did not move.
 - Immediately before rebasing each PR, query `headRefOid` again and compare
   it with the manifest pin. If it moved after the recorded cutoff, stop for
@@ -349,8 +410,10 @@ feature deltas**, built in ONE pass:
    error. For each drifted ref, read the intended concept from the merged
    anchor slug, find that concept's actual number on this branch, and set
    BOTH the number and the anchor manually.
-5. **Dry-run and raw-reference validate** (alpha branches get no auto-PR, so do NOT commit
-   renumber/grammar output — revert it after validating):
+5. **Dry-run and raw-reference validate.** Alpha branches commonly get no
+   auto-PR, so do **not** commit renumber/grammar output; revert only that
+   generated validation output after checking it, without reverting the
+   surgical feature-delta edits:
 
    ```bash
    ( cd tools && dotnet run --project StandardAnchorTags -- \
@@ -361,10 +424,26 @@ feature deltas**, built in ONE pass:
    **hard stop**. Also repeat the mandatory raw `rg` audit from Step B.5
    across all `standard/*.md`; any unexplained `§[a-z][a-z0-9-]*`, `§xx`,
    or `#xx` match is a hard stop.
-6. **Finalize before advancing.** Only when the discovered alpha carries BOTH the
+6. **Commit the complete alpha delta before any alpha push.** Review
+   `git status --short`, `git diff --check`, and the full diff. Stage only
+   the intentional surgical feature-delta files, inspect
+   `git diff --cached`, and create a normal commit:
+
+   ```bash
+   git commit -m "Post-meeting propagation: finalize <alpha-branch> feature deltas"
+   ALPHA_FINAL_SHA="$(git rev-parse HEAD)"
+   ```
+
+   If the manifest has no applicable feature delta and the tree is already
+   clean, record that no separate delta commit was required and use the
+   committee merge commit as `ALPHA_FINAL_SHA`. Then run Step B.7. Never
+   leave alpha delta edits only in the working tree or only in a local
+   commit.
+7. **Finalize before advancing.** Only when the discovered alpha carries BOTH the
    committee changes AND the fresh vN patches may the sweep proceed to
-   `draft-v(N+1)`. This reduces propagation risk; it does not replace
-   downstream semantic and reference verification.
+   `draft-v(N+1)`. Require the verified authoritative remote head from
+   Step B.7 to contain `ALPHA_FINAL_SHA`. This reduces propagation risk; it
+   does not replace downstream semantic and reference verification.
 
 ### Step C — Move to the next branch
 
@@ -378,6 +457,8 @@ next branch in the chain. Continue until the chain is done.
 When finished (or when stopped on a conflict), produce a short report:
 
 - For each branch: action taken (auto-PR merged, propagation merge SHA, skipped).
+- The validated authoritative remote name and repository used for every
+  discovery, baseline, merge, comparison, and push.
 - The dynamically enumerated feature-PR count and the manifest cutoff time.
 - For each version N: whether its discovered alpha branch was **finalized** (committee changes + fresh vN deltas applied surgically, semantic comparison complete, dry-run and raw-reference audits clean) before `draft-v(N+1)` was started, and the list of vN PR numbers, pinned SHAs, and patches applied (Step D / Step B.8).
 - Any PR head that moved after cutoff and how it was refreshed or why work stopped.
@@ -394,4 +475,7 @@ When finished (or when stopped on a conflict), produce a short report:
 - Never force-push to any `draft-v*`, `alpha-v*`, or `v*-alpha` branch.
 - Never use `git reset --hard` on a tracked branch.
 - Never merge any PR other than the automated renumber/grammar PR.
+- Never change `REMOTE` or substitute another remote during the run.
+- Never advance past an alpha until its `ALPHA_FINAL_SHA` is present on the
+  verified authoritative remote branch.
 - If `gh` shows the auto-PR's checks failing, stop and ask the user.

--- a/.github/prompts/post-meeting-propagate.prompt.md
+++ b/.github/prompts/post-meeting-propagate.prompt.md
@@ -12,33 +12,49 @@ You are propagating the changes merged into the current "starting" draft branch 
 The monthly post-meeting work is split into two phases (see
 `post-meeting-rebase-prs.prompt.md` for **Phase A**):
 
-- **Phase A — parallel PR rebase (runs first / in parallel).** Rebase all
-  ~54 open feature PRs onto their own base `draft-vN`. Independent per
-  PR/version → embarrassingly parallel. Produces a **fresh `.patch` per PR**
-  that this phase consumes.
+- **Phase A1 — feature-PR preparation (runs first).** Dynamically enumerate
+  the open feature PRs for the discovered draft branches, report the count,
+  rebase or notify them as appropriate, and produce a patch manifest. Each
+  manifest entry pins the PR number, base branch, head SHA, patch path, and
+  per-PR UTC cutoff time.
 - **Phase B — this prompt: a single serial sweep up the chain, atomic per
   version.** For each version N in chain order, (1) propagate the
   committee-merged changes into `draft-vN`, (2) real-renumber `draft-vN`
   (watch the concept-drift trap), (3) cheap re-rebase only the vN PRs whose
-  base moved in step 1, (4) **rebuild `alpha-vN`** by surgically applying the
-  fresh vN patches onto the EXISTING alpha structure (Option 1 — never a
-  from-scratch structural reorg), dry-run-validate, then (5) advance so
-  `draft-v(N+1)` is based on the now-finalized `alpha-vN`.
+  base moved in step 1 and update their manifest pins, (4) **reconstruct the
+  version's alpha branch** by surgically applying the fresh feature deltas
+  onto its existing structure, validate, then (5) advance so
+  `draft-v(N+1)` is based on the now-finalized discovered alpha branch.
+- **Phase A2 — notification follow-up (runs after Phase B).** Consume Phase
+  B's deletion and future-version comment inventories to post alpha-drift
+  and routing notices. Phase A2 does not feed alpha reconstruction.
+
+Do not interpret the phase names as a repeating A/B cycle. The chronology is
+**A1 → B → A2**. Phase B may call the narrowly scoped Phase A rebase
+machinery only to refresh PRs whose base moved during Phase B.
 
 ### ⚠️ Ordering invariant (the crux — do not violate)
 
-**Never propagate or build anything downstream of `alpha-vN` until
-`alpha-vN` is finalized with BOTH the committee-merged changes AND the fresh
-feature-PR patches.** In one sentence: `alpha-vN` = finalized `draft-vN` +
-fresh vN patches, constructed in **ONE pass**, before `draft-v(N+1)` is built
-on it.
+**Never propagate or build anything downstream of version N's discovered
+alpha branch until that branch is finalized with BOTH the committee-merged
+changes AND the fresh feature-PR patches.** In one sentence: finalized alpha
+= finalized `draft-vN` + fresh vN feature deltas, constructed in **ONE
+pass**, before `draft-v(N+1)` is built on it.
 
-This is what eliminates the second (double) propagation cascade hit in the
-2026-07 cycle: propagating across the whole chain first builds
-`draft-v10..v12` on alphas whose feature-PR content is still **stale**, so
-refreshing the patches later (e.g. the #1458 records rebase) invalidates
-everything downstream and forces a second full cascade. Finalizing each alpha
-before building on it removes that second pass.
+This ordering reduces the risk of a second propagation cascade: propagating
+the whole chain before refreshing alpha feature content can make downstream
+branches depend on stale alpha text. It does not eliminate downstream drift.
+Every later draft and alpha still requires the raw-reference, semantic, and
+head-movement checks defined below.
+
+## Observed failure modes this workflow must detect
+
+- A numbered heading can retain a stale symbolic anchor such as `§xx` or
+  `§some-placeholder`.
+- A feature PR can move after the patch cutoff, making the recorded patch
+  stale even when it still applies cleanly.
+- A downstream conflict resolution can preserve older normative structure
+  or wording instead of the intended later-version language.
 
 ## Assumptions
 
@@ -47,43 +63,46 @@ before building on it removes that second pass.
 - Auto-PRs may show a `BLOCKED` merge state due to branch protection rules requiring review approval — this is normal and not a CI failure. Wait for checks to pass, then merge.
 - You have `git` and `gh` available, and push permission to this repo.
 
-## Propagation chain
+## Discover the propagation chain
 
-Walk these branches in order. Each step merges the previous branch into the next with a regular merge commit and pushes.
+Do not rely on a fixed list or assume every alpha is named `alpha-vN`.
 
-1. `draft-v8`   (starting branch — no merge in; just merge its auto-PR)
-2. `draft-v9`   ← merges `draft-v8`
-3. `alpha-v9`   ← merges `draft-v9`
-4. `draft-v10`  ← merges `alpha-v9`
-5. `alpha-v10`  ← merges `draft-v10`
-6. `draft-v11`  ← merges `alpha-v10`
-7. `v11-alpha`  ← merges `draft-v11`
-8. `draft-v12`  ← merges `v11-alpha`
+1. Fetch and list the actual remote branch names:
+
+   ```bash
+   git fetch upstream --prune
+   git for-each-ref refs/remotes/upstream \
+     --format='%(refname:strip=3)' \
+     | grep -E '^(draft-v[0-9]+|alpha-v[0-9]+|v[0-9]+-alpha)$' \
+     | sort -V
+   ```
+
+2. Starting with the user-supplied draft branch (default `draft-v8`),
+   enumerate later `draft-vN` branches by numeric version. For each version,
+   discover whether the remote has `alpha-vN` or `vN-alpha`; use the one that
+   exists. `v11-alpha` is valid and must not be rewritten as `alpha-v11`.
+   Stop if both names exist for one version or if the branch topology is
+   ambiguous.
+3. Build the ordered chain as the starting draft, then each later draft,
+   followed by its discovered alpha when one exists. Confirm the order
+   against `admin/branch-diagram.md` and remote ancestry. Report the exact
+   discovered chain before changing anything.
 
 > **Walk this chain as a per-version, atomic-per-version sweep.** For each
 > version N, finish `draft-vN` (propagate committee changes + renumber +
-> cheap re-rebase of moved vN PRs) **and** finalize `alpha-vN` (rebuild it
-> from the fresh vN patches — Step D) BEFORE advancing to `draft-v(N+1)`. The
-> alpha branch (`alpha-vN` / `vN-alpha`) is never just a plain merge of its
-> draft: it must also receive the fresh feature-PR patches in the same pass,
-> per the ordering invariant above.
-
-> **Branch-naming is inconsistent across versions** (e.g. `alpha-v9` vs
-> `v11-alpha`). Always verify actual branch
-> names with `git branch -r | grep upstream/` before starting.
+> cheap re-rebase of moved vN PRs) **and** finalize the discovered alpha
+> branch (rebuild it from the fresh vN patches — Step D) BEFORE advancing to
+> `draft-v(N+1)`. The discovered alpha branch (`alpha-vN` or `vN-alpha`) is
+> never just a plain merge of its draft: it must also receive the fresh
+> feature-PR patches in the same pass, per the ordering invariant above.
 >
-> When new version branches are added, append them here using the actual
-> branch names on the remote. Also add any new branches to
-> `.github/workflows/update-on-merge.yaml` `on.push.branches`.
->
-> Note: `update-on-merge.yaml` currently only triggers on `standard-v6`,
-> `standard-v7`, `draft-v8`, `draft-v9`, `draft-v11`, and `draft-v12`.
-> Alpha branches are **not** covered, so no auto-PR will appear on those
-> branches — the renumber/grammar tools must be run by a later merge into
-> the next draft branch.
+> Inspect `.github/workflows/update-on-merge.yaml` and report which
+> discovered branches are covered by `on.push.branches`. Do not assume an
+> auto-PR will appear on an uncovered branch. Alpha branches are commonly
+> uncovered, so their validation must be completed locally before advancing.
 
 If the user names a different starting branch, start there and propagate to
-every later branch in the list.
+every later branch in the discovered chain.
 
 ## Pre-flight (run once, before walking the chain)
 
@@ -91,10 +110,26 @@ These artifacts are referenced by Step B (conflict resolution) and Step B.6
 (future-version comment inventory). Capture them up front and persist them
 for the duration of the run.
 
-1. **Baseline.** Determine the SHA on each branch in the chain at the
+1. **Run directory and Phase A manifest.** Create a persistent, untracked run
+   directory under `.git`, not a temporary system directory:
+
+   ```bash
+   RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+   RUN_DIR="$(git rev-parse --git-path "post-meeting/$RUN_ID")"
+   mkdir -p "$RUN_DIR"
+   ```
+
+   Load Phase A1's feature-PR manifest. Require one record per dynamically
+   enumerated feature PR, including PR number, base branch, head SHA, patch
+   path, and UTC cutoff time. Report the manifest's resulting PR count. Stop
+   if the manifest is missing, has duplicate PR numbers, or its count differs
+   from a fresh enumeration of open PRs on the discovered target draft
+   branches.
+
+2. **Baseline.** Determine the SHA on each branch in the chain at the
    *previous* propagation. A reliable proxy is the most recent merge commit whose subject begins with `Post-meeting propagation:` on that branch (`git log --grep '^Post-meeting propagation:' -1 --format=%H origin/<branch>`). Record `BASE_<branch>` for each branch. If a branch has no such commit yet, fall back to the branch point and warn the user.
 
-2. **Deletion inventory** for the starting branch. Identify text the
+3. **Deletion inventory** for the starting branch. Identify text the
    committee removed in this cycle so Step B can recognize resurrection:
 
    ```bash
@@ -104,22 +139,23 @@ for the duration of the run.
 
    # Hunks (negative lines) for review:
    git log "$BASE_<starting>"..origin/<starting> -p -- standard/ \
-     > /tmp/starting-deletions.patch
+     > "$RUN_DIR/starting-deletions.patch"
    ```
 
    Show the user the list of PRs merged this cycle (`gh pr list --base <starting> --state merged --search 'merged:>=<last-meeting-date>'`) and ask which performed substantive prose removals. Persist that list.
 
-3. **vNext-comment baseline** for every branch in the chain. Snapshot the current set of HTML comments in `standard/*.md` mentioning a future version, so Step B.6 can diff against it after each merge:
+4. **vNext-comment baseline** for every branch in the chain. Snapshot the current set of HTML comments in `standard/*.md` mentioning a future version, so Step B.6 can diff against it after each merge:
 
    ```bash
    for b in <chain>; do
      git --no-pager grep -nE '<!--[^>]*(vNext|v[0-9]+|future|upcoming|TODO)' \
        "origin/$b" -- 'standard/*.md' | sed "s|^origin/$b:||" \
-       > /tmp/vnext-baseline-$b.txt || true
+       > "$RUN_DIR/vnext-baseline-$b.txt" || true
    done
    ```
 
-   The grep is intentionally loose (false positives are fine — Phase 4 surfaces them for human triage; nothing is auto-applied).
+   The grep is intentionally loose (false positives are fine — Phase A2
+   surfaces them for human triage; nothing is auto-applied).
 
 ## Procedure
 
@@ -127,9 +163,10 @@ Before starting, confirm the chain with the user and show which branches will be
 
 > **Per-version sweep.** Although the steps below are written per *branch*,
 > execute them as a serial sweep that is **atomic per version**: for version
-> N, finish `draft-vN` (Steps A–B.8) **and** finalize `alpha-vN` (Step D)
-> before touching `draft-v(N+1)`. Do not run ahead down the chain — the
-> ordering invariant above forbids building on an unfinalized alpha.
+> N, finish `draft-vN` (Steps A–B.8) **and** finalize its discovered alpha
+> branch (Step D) before touching `draft-v(N+1)`. Do not run ahead down the
+> chain — the ordering invariant above forbids building on an unfinalized
+> alpha.
 
 ### Step A — Process auto-PR on the current branch
 
@@ -173,7 +210,7 @@ Before starting, confirm the chain with the user and show which branches will be
      run `checkout --theirs/--ours`, recover with `git checkout -m <file>`
      to restore the conflict markers.
    - For each conflicted hunk in `standard/*.md`:
-     a. Cross-check the hunk's file and line range against the deletion inventory captured in Pre-flight (`/tmp/starting-deletions.patch`) **and** against any prior `Post-meeting propagation:` merges on the downstream branch (`git log --grep '^Post-meeting propagation:' -p origin/<branch> -- <file>`).
+     a. Cross-check the hunk's file and line range against the deletion inventory captured in Pre-flight (`$RUN_DIR/starting-deletions.patch`) **and** against any prior `Post-meeting propagation:` merges on the downstream branch (`git log --grep '^Post-meeting propagation:' -p origin/<branch> -- <file>`).
      b. If the downstream side intentionally removed the text, keep the deletion and re-apply only non-overlapping upstream edits to the surrounding region.
      c. If unclear, **abort the merge** (`git merge --abort`) and report to the user with the file, line range, and both sides of the hunk.
    - Mechanical "take upstream" is acceptable **only** for:
@@ -201,8 +238,23 @@ Run the section-renumber tool in dry-run mode against the post-merge working tre
 ```
 
 1. **Broken references.** Any *new* `TOC002` ("`<ref>` not found") diagnostic that was not already present on `upstream/<branch>` before the merge is a **hard stop**. Compare the tool output against a pre-merge run (or `git stash && run && git stash pop`) to distinguish new from pre-existing. Pre-existing TOC002s from incomplete feature PRs on alpha branches are expected and should be reported but do not block the merge.
-2. **Concept drift.** Count how many section numbers the dry run would change (lines beginning with `§` in the tool's diff output). If more than ~25 sections shift, sections have drifted enough that surviving cross-references like `§X.Y (Foo)` may now point at a different concept — the renumber tool fixes the *number* but cannot detect when the *concept* (parenthetical name, surrounding prose) is now wrong. Pause, list the affected references to the user, and proceed only on explicit confirmation.
-3. The actual renumber/grammar regeneration runs in the auto-PR opened by `update-on-merge.yaml` after push (Step A on the next iteration); do not commit dry-run output.
+2. **Mandatory raw symbolic-reference audit.** Run this independently of
+   the tool and save the output:
+
+   ```bash
+   rg -n -e '§[a-z][a-z0-9-]*' -e '§xx' -e '#xx' \
+     standard --glob '*.md' \
+     > "$RUN_DIR/symbolic-refs-<branch>.txt" || true
+   ```
+
+   Review every match. A retained placeholder is a hard stop unless the
+   branch intentionally permits that exact pre-merge placeholder and it is
+   recorded in the report. This raw audit is mandatory because
+   `StandardAnchorTags` and its `TOC002` diagnostics previously missed
+   placeholders that remained in otherwise valid text, including symbolic
+   anchors left after headings had already been numbered.
+3. **Concept drift.** Count how many section numbers the dry run would change (lines beginning with `§` in the tool's diff output). If more than ~25 sections shift, sections have drifted enough that surviving cross-references like `§X.Y (Foo)` may now point at a different concept — the renumber tool fixes the *number* but cannot detect when the *concept* (parenthetical name, surrounding prose) is now wrong. Pause, list the affected references to the user, and proceed only on explicit confirmation.
+4. The actual renumber/grammar regeneration runs in the auto-PR opened by `update-on-merge.yaml` after push (Step A on the next iteration); do not commit dry-run output.
 
 ### Step B.6 — Future-version comment inventory
 
@@ -211,9 +263,9 @@ against the Pre-flight baseline to surface anything new this propagation brought
 
 ```bash
 git --no-pager grep -nE '<!--[^>]*(vNext|v[0-9]+|future|upcoming|TODO)' \
-  HEAD -- 'standard/*.md' | sed 's|^HEAD:||' > /tmp/vnext-current-<branch>.txt
-diff /tmp/vnext-baseline-<branch>.txt /tmp/vnext-current-<branch>.txt \
-  > /tmp/vnext-delta-<branch>.txt || true
+  HEAD -- 'standard/*.md' | sed 's|^HEAD:||' > "$RUN_DIR/vnext-current-<branch>.txt"
+diff "$RUN_DIR/vnext-baseline-<branch>.txt" "$RUN_DIR/vnext-current-<branch>.txt" \
+  > "$RUN_DIR/vnext-delta-<branch>.txt" || true
 ```
 
 > Strip the `HEAD:` prefix with `sed` so diffs against the baseline
@@ -239,42 +291,65 @@ Persist the accumulated list across the whole run. Include it in the final repor
 This implements step (3) of the per-version sweep. If Step B moved
 `draft-vN` (committee changes landed on it this cycle), the vN feature PRs
 that **Phase A** (`post-meeting-rebase-prs.prompt.md`) already rebased now
-have a stale base.
+have a stale base. Run this step only after Step A has merged the auto-PR
+created by Step B.7, so the feature PRs rebase onto the final draft head for
+this version.
 
 - Do the **cheap re-rebase of ONLY the vN PRs whose base moved** and
   regenerate their `.patch` (Phase A machinery — `git rebase upstream/draft-vN`
   then `git format-patch upstream/draft-vN..<headRefName>`). Do **not**
   re-rebase PRs whose base did not move.
-- These refreshed patches are the input to Step D's `alpha-vN` rebuild. The
+- Immediately before rebasing each PR, query `headRefOid` again and compare
+  it with the manifest pin. If it moved after the recorded cutoff, stop for
+  that PR; do not overwrite or build an alpha from a stale patch. After a
+  successful rebase, update that PR's manifest entry with the new head SHA,
+  regenerated patch, and a new UTC cutoff time.
+- These refreshed patches are the input to Step D's alpha rebuild. The
   patches Phase B applies to the alpha are always the freshest
   post-propagation ones, not the Phase-A starting patches.
 
-### Step D — Rebuild `alpha-vN` from the fresh feature patches (alpha branches only — Option 1, surgical)
+### Step D — Surgically reconstruct the alpha from fresh feature deltas
 
 **This is the step that was previously unprompted — its absence is what let
 the ordering slip and produced the 2026-07 double-propagation cascade.** Run
-it whenever `<branch>` is an alpha branch (`alpha-vN` / `vN-alpha`), after
-Step B has propagated the committee changes into it and **BEFORE** the chain
-advances to the next draft.
+it whenever `<branch>` is a discovered alpha branch (`alpha-vN` or
+`vN-alpha`), after Step B has propagated the committee changes into it and
+**BEFORE** the chain advances to the next draft.
 
-`alpha-vN` must equal **finalized `draft-vN` + the fresh vN feature-PR
-patches**, built in ONE pass:
+The discovered alpha must equal **finalized `draft-vN` + the fresh vN
+feature deltas**, built in ONE pass:
 
-1. **Confirm the fresh per-PR patches for version N are current.** Phase A
-   produced them and Step B.8 refreshed any whose base moved. If in doubt,
-   regenerate them (`git format-patch upstream/draft-vN..<headRefName>`).
-2. **Apply each fresh vN patch surgically onto the EXISTING `alpha-vN`
-   structure** — wording-only / subtractive hunks. **Never** rebuild
-   `alpha-vN` from scratch or reorganize its structure (Option 1; see the
-   v10→v11 structural-divergence trap). A from-scratch structural reorg
-   amplifies churn into every downstream branch.
-3. **Watch the renumber concept-drift trap.** The renumber tool keeps a
+1. **Recheck every PR head after the potentially long propagation run.**
+   Query each manifest PR's current `headRefOid` and compare it with the
+   pinned SHA and cutoff time. If any head moved, stop alpha reconstruction,
+   refresh that PR through Phase A machinery, record a new pin and cutoff,
+   and restart validation. Never silently use the older patch.
+2. **Treat patches as feature-delta evidence, not commit-replay scripts.**
+   Apply the minimal normative delta onto the existing alpha structure.
+   Do not replay synchronization or base-merge commits wholesale, and do not
+   replace an alpha file with the feature PR's version. Preserve
+   branch-specific later-version language and structure unless the feature
+   itself intentionally changes it.
+3. **Perform a semantic three-way comparison for every high-conflict
+   normative section.** Compare:
+   - the section in the prior finalized alpha (`BASE_<alpha-branch>`),
+   - the section in the finalized target `draft-vN`, and
+   - the section at the pinned current feature-PR head.
+
+   Record the intended feature semantics, committee changes, and
+   later-version-only language that the reconstructed alpha must preserve.
+   Review the resulting alpha against that record. A patch applying cleanly,
+   a successful rebase, or correct renumbering is not evidence that the
+   normative result is semantically correct. If the three sources cannot be
+   reconciled confidently, stop and report the exact section and competing
+   text.
+4. **Watch the renumber concept-drift trap.** The renumber tool keeps a
    `§NUMBER` and rewrites the ANCHOR to whatever concept now sits at that
    number, silently corrupting cross-refs while the dry-run reports **no**
    error. For each drifted ref, read the intended concept from the merged
    anchor slug, find that concept's actual number on this branch, and set
    BOTH the number and the anchor manually.
-4. **Dry-run validate** (alpha branches get no auto-PR, so do NOT commit
+5. **Dry-run and raw-reference validate** (alpha branches get no auto-PR, so do NOT commit
    renumber/grammar output — revert it after validating):
 
    ```bash
@@ -283,32 +358,40 @@ patches**, built in ONE pass:
    ```
 
    Any *new* `TOC002` diagnostic relative to the pre-rebuild baseline is a
-   **hard stop**.
-5. **Finalize before advancing.** Only when `alpha-vN` carries BOTH the
+   **hard stop**. Also repeat the mandatory raw `rg` audit from Step B.5
+   across all `standard/*.md`; any unexplained `§[a-z][a-z0-9-]*`, `§xx`,
+   or `#xx` match is a hard stop.
+6. **Finalize before advancing.** Only when the discovered alpha carries BOTH the
    committee changes AND the fresh vN patches may the sweep proceed to
-   `draft-v(N+1)` (whose Step B merges from this now-finalized `alpha-vN`).
+   `draft-v(N+1)`. This reduces propagation risk; it does not replace
+   downstream semantic and reference verification.
 
 ### Step C — Move to the next branch
 
 Advance the per-version sweep. Before starting `draft-v(N+1)`, confirm
-`alpha-vN` is finalized per Step D — **the ordering invariant forbids building
-`draft-v(N+1)` on an unfinalized alpha.** Repeat A–D for the next branch in
-the chain. Continue until the chain is done.
+the discovered alpha is finalized per Step D — **the ordering invariant
+forbids building `draft-v(N+1)` on an unfinalized alpha.** Repeat A–D for the
+next branch in the chain. Continue until the chain is done.
 
 ## Reporting
 
 When finished (or when stopped on a conflict), produce a short report:
 
 - For each branch: action taken (auto-PR merged, propagation merge SHA, skipped).
-- For each version N: whether `alpha-vN` was **finalized** (committee changes + fresh vN patches applied surgically, dry-run clean) before `draft-v(N+1)` was started, and the list of vN patches applied (Step D / Step B.8).
+- The dynamically enumerated feature-PR count and the manifest cutoff time.
+- For each version N: whether its discovered alpha branch was **finalized** (committee changes + fresh vN deltas applied surgically, semantic comparison complete, dry-run and raw-reference audits clean) before `draft-v(N+1)` was started, and the list of vN PR numbers, pinned SHAs, and patches applied (Step D / Step B.8).
+- Any PR head that moved after cutoff and how it was refreshed or why work stopped.
+- The high-conflict normative sections compared and any unresolved semantic differences.
+- Any raw symbolic-reference matches and their disposition.
 - Any branches where you stopped and why.
 - The deletion inventory captured in Pre-flight (file list + originating PR numbers).
 - The accumulated future-version comment inventory from Step B.6 (file:line, comment text, source branch, best-guess target version). Hand this to `post-meeting-rebase-prs.prompt.md`.
-- A reminder to the user to run `post-meeting-rebase-prs.prompt.md` next.
+- A reminder to run the Phase A2 notification pass in
+  `post-meeting-rebase-prs.prompt.md`.
 
 ## Safety rules
 
-- Never force-push to any `draft-v*` or `v*-alpha` branch.
+- Never force-push to any `draft-v*`, `alpha-v*`, or `v*-alpha` branch.
 - Never use `git reset --hard` on a tracked branch.
 - Never merge any PR other than the automated renumber/grammar PR.
 - If `gh` shows the auto-PR's checks failing, stop and ask the user.

--- a/.github/prompts/post-meeting-propagate.prompt.md
+++ b/.github/prompts/post-meeting-propagate.prompt.md
@@ -1,11 +1,44 @@
 ---
 mode: agent
-description: Propagate post-meeting changes through all draft and alpha branches.
+description: Phase B — serial per-version sweep that propagates committee changes and finalizes each alpha (committee changes + fresh patches) before advancing.
 ---
 
-# Post-meeting: propagate changes through draft & alpha branches
+# Post-meeting: propagate changes through draft & alpha branches (Phase B)
 
 You are propagating the changes merged into the current "starting" draft branch (after a TC49-TG2 committee meeting) forward through every future draft and alpha branch. See `admin/branch-diagram.md` for the rationale.
+
+## Phase B of the two-phase post-meeting workflow
+
+The monthly post-meeting work is split into two phases (see
+`post-meeting-rebase-prs.prompt.md` for **Phase A**):
+
+- **Phase A — parallel PR rebase (runs first / in parallel).** Rebase all
+  ~54 open feature PRs onto their own base `draft-vN`. Independent per
+  PR/version → embarrassingly parallel. Produces a **fresh `.patch` per PR**
+  that this phase consumes.
+- **Phase B — this prompt: a single serial sweep up the chain, atomic per
+  version.** For each version N in chain order, (1) propagate the
+  committee-merged changes into `draft-vN`, (2) real-renumber `draft-vN`
+  (watch the concept-drift trap), (3) cheap re-rebase only the vN PRs whose
+  base moved in step 1, (4) **rebuild `alpha-vN`** by surgically applying the
+  fresh vN patches onto the EXISTING alpha structure (Option 1 — never a
+  from-scratch structural reorg), dry-run-validate, then (5) advance so
+  `draft-v(N+1)` is based on the now-finalized `alpha-vN`.
+
+### ⚠️ Ordering invariant (the crux — do not violate)
+
+**Never propagate or build anything downstream of `alpha-vN` until
+`alpha-vN` is finalized with BOTH the committee-merged changes AND the fresh
+feature-PR patches.** In one sentence: `alpha-vN` = finalized `draft-vN` +
+fresh vN patches, constructed in **ONE pass**, before `draft-v(N+1)` is built
+on it.
+
+This is what eliminates the second (double) propagation cascade hit in the
+2026-07 cycle: propagating across the whole chain first builds
+`draft-v10..v12` on alphas whose feature-PR content is still **stale**, so
+refreshing the patches later (e.g. the #1458 records rebase) invalidates
+everything downstream and forces a second full cascade. Finalizing each alpha
+before building on it removes that second pass.
 
 ## Assumptions
 
@@ -26,6 +59,14 @@ Walk these branches in order. Each step merges the previous branch into the next
 6. `draft-v11`  ← merges `alpha-v10`
 7. `v11-alpha`  ← merges `draft-v11`
 8. `draft-v12`  ← merges `v11-alpha`
+
+> **Walk this chain as a per-version, atomic-per-version sweep.** For each
+> version N, finish `draft-vN` (propagate committee changes + renumber +
+> cheap re-rebase of moved vN PRs) **and** finalize `alpha-vN` (rebuild it
+> from the fresh vN patches — Step D) BEFORE advancing to `draft-v(N+1)`. The
+> alpha branch (`alpha-vN` / `vN-alpha`) is never just a plain merge of its
+> draft: it must also receive the fresh feature-PR patches in the same pass,
+> per the ordering invariant above.
 
 > **Branch-naming is inconsistent across versions** (e.g. `alpha-v9` vs
 > `v11-alpha`). Always verify actual branch
@@ -83,6 +124,12 @@ for the duration of the run.
 ## Procedure
 
 Before starting, confirm the chain with the user and show which branches will be touched. Confirm the pre-flight artifacts above are captured. Then for each branch in order:
+
+> **Per-version sweep.** Although the steps below are written per *branch*,
+> execute them as a serial sweep that is **atomic per version**: for version
+> N, finish `draft-vN` (Steps A–B.8) **and** finalize `alpha-vN` (Step D)
+> before touching `draft-v(N+1)`. Do not run ahead down the chain — the
+> ordering invariant above forbids building on an unfinalized alpha.
 
 ### Step A — Process auto-PR on the current branch
 
@@ -187,15 +234,73 @@ Persist the accumulated list across the whole run. Include it in the final repor
 1. Push: `git push origin <branch>`.
 2. The push triggers `update-on-merge.yaml`, which will open a fresh auto-PR. Loop back to Step A for this branch before moving on.
 
+### Step B.8 — Cheap re-rebase of moved `draft-vN` feature PRs (draft branches with open feature PRs)
+
+This implements step (3) of the per-version sweep. If Step B moved
+`draft-vN` (committee changes landed on it this cycle), the vN feature PRs
+that **Phase A** (`post-meeting-rebase-prs.prompt.md`) already rebased now
+have a stale base.
+
+- Do the **cheap re-rebase of ONLY the vN PRs whose base moved** and
+  regenerate their `.patch` (Phase A machinery — `git rebase upstream/draft-vN`
+  then `git format-patch upstream/draft-vN..<headRefName>`). Do **not**
+  re-rebase PRs whose base did not move.
+- These refreshed patches are the input to Step D's `alpha-vN` rebuild. The
+  patches Phase B applies to the alpha are always the freshest
+  post-propagation ones, not the Phase-A starting patches.
+
+### Step D — Rebuild `alpha-vN` from the fresh feature patches (alpha branches only — Option 1, surgical)
+
+**This is the step that was previously unprompted — its absence is what let
+the ordering slip and produced the 2026-07 double-propagation cascade.** Run
+it whenever `<branch>` is an alpha branch (`alpha-vN` / `vN-alpha`), after
+Step B has propagated the committee changes into it and **BEFORE** the chain
+advances to the next draft.
+
+`alpha-vN` must equal **finalized `draft-vN` + the fresh vN feature-PR
+patches**, built in ONE pass:
+
+1. **Confirm the fresh per-PR patches for version N are current.** Phase A
+   produced them and Step B.8 refreshed any whose base moved. If in doubt,
+   regenerate them (`git format-patch upstream/draft-vN..<headRefName>`).
+2. **Apply each fresh vN patch surgically onto the EXISTING `alpha-vN`
+   structure** — wording-only / subtractive hunks. **Never** rebuild
+   `alpha-vN` from scratch or reorganize its structure (Option 1; see the
+   v10→v11 structural-divergence trap). A from-scratch structural reorg
+   amplifies churn into every downstream branch.
+3. **Watch the renumber concept-drift trap.** The renumber tool keeps a
+   `§NUMBER` and rewrites the ANCHOR to whatever concept now sits at that
+   number, silently corrupting cross-refs while the dry-run reports **no**
+   error. For each drifted ref, read the intended concept from the merged
+   anchor slug, find that concept's actual number on this branch, and set
+   BOTH the number and the anchor manually.
+4. **Dry-run validate** (alpha branches get no auto-PR, so do NOT commit
+   renumber/grammar output — revert it after validating):
+
+   ```bash
+   ( cd tools && dotnet run --project StandardAnchorTags -- \
+       --owner dotnet --repo csharpstandard --dryrun )
+   ```
+
+   Any *new* `TOC002` diagnostic relative to the pre-rebuild baseline is a
+   **hard stop**.
+5. **Finalize before advancing.** Only when `alpha-vN` carries BOTH the
+   committee changes AND the fresh vN patches may the sweep proceed to
+   `draft-v(N+1)` (whose Step B merges from this now-finalized `alpha-vN`).
+
 ### Step C — Move to the next branch
 
-Repeat A–B for the next branch in the chain. Continue until the chain is done.
+Advance the per-version sweep. Before starting `draft-v(N+1)`, confirm
+`alpha-vN` is finalized per Step D — **the ordering invariant forbids building
+`draft-v(N+1)` on an unfinalized alpha.** Repeat A–D for the next branch in
+the chain. Continue until the chain is done.
 
 ## Reporting
 
 When finished (or when stopped on a conflict), produce a short report:
 
 - For each branch: action taken (auto-PR merged, propagation merge SHA, skipped).
+- For each version N: whether `alpha-vN` was **finalized** (committee changes + fresh vN patches applied surgically, dry-run clean) before `draft-v(N+1)` was started, and the list of vN patches applied (Step D / Step B.8).
 - Any branches where you stopped and why.
 - The deletion inventory captured in Pre-flight (file list + originating PR numbers).
 - The accumulated future-version comment inventory from Step B.6 (file:line, comment text, source branch, best-guess target version). Hand this to `post-meeting-rebase-prs.prompt.md`.

--- a/.github/prompts/post-meeting-rebase-prs.prompt.md
+++ b/.github/prompts/post-meeting-rebase-prs.prompt.md
@@ -1,18 +1,42 @@
 ---
 mode: agent
-description: Rebase same-repo feature PRs and notify fork PR authors after propagation.
+description: Phase A — rebase same-repo feature PRs onto their own base, produce a fresh per-PR patch for Phase B, and notify fork PR authors.
 ---
 
-# Post-meeting: rebase / notify feature PRs
+# Phase A — rebase feature PRs & produce per-PR patches (+ notify authors)
 
-After `post-meeting-propagate.prompt.md` has updated all draft/alpha branches, every open feature PR is now stale relative to its base. Update each PR according to whether its head branch is in this repo or on a fork.
+This is **Phase A** of the two-phase post-meeting workflow (see
+`post-meeting-propagate.prompt.md` for **Phase B**, the serial per-version
+sweep). Phase A **runs first, or in parallel with nothing blocking it**: the
+per-PR rebases are independent per PR/version, so this phase is embarrassingly
+parallel across all ~54 open feature PRs.
 
-This prompt also consumes two artifacts from the propagate run:
+Phase A does two things:
+
+1. **Rebase every open feature PR onto its own current base `draft-vN`**
+   (update each PR per whether its head is in this repo or on a fork), and
+2. **Produce a fresh `.patch` per PR** — this is the artifact **Phase B
+   consumes** in its `alpha-vN` rebuild (Step D of the propagate prompt).
+   Make the patch explicit: without it Phase B cannot surgically apply the
+   fresh feature content onto the existing alpha structure (Option 1).
+
+> **Ordering note.** After Phase B propagates the committee changes into
+> `draft-vN`, it does a *cheap re-rebase* of only the vN PRs whose base moved
+> and **refreshes their patches** (propagate prompt, Step B.8). So the patches
+> Phase B ultimately applies are the freshest post-propagation ones; the
+> patches produced here are the starting point.
+
+### Notification / routing steps depend on Phase B output
+
+Steps 0 and 0.5 below (alpha-drift detection and vNext-comment routing)
+consume artifacts that **Phase B produces**:
 
 - the **future-version comment inventory** (Step B.6 of the propagate prompt) — used by Step 0.5 below to route those notes to the appropriate feature PRs;
 - the deletion inventory — used as context when judging rebase conflicts.
 
-Ask the user for the propagate report (or its location) before starting.
+Run the rebase + patch core (Steps 1–2) up front; run Steps 0 and 0.5 as a
+**follow-up notification pass once Phase B has produced its report.** Ask the
+user for the propagate report (or its location) before running Steps 0 and 0.5.
 
 ## Procedure
 
@@ -121,9 +145,28 @@ For each PR returned:
      the push.
   7. Otherwise: `git push --force-with-lease upstream <headRefName>`.
      Record success with the new SHA.
+  8. **Produce the per-PR patch (Phase B input).** Capture the PR's commits
+     relative to its base as a patch file so Phase B can surgically apply them
+     onto `alpha-vN`:
+
+     ```bash
+     mkdir -p patches/<base>
+     git format-patch "upstream/<base>..<headRefName>" \
+       --stdout > "patches/<base>/pr-<num>.patch"
+     ```
+
+     Record the patch path alongside the new SHA. This is the fresh vN patch
+     Phase B's `alpha-vN` rebuild consumes; if Phase B later moves `<base>`
+     via committee propagation, its cheap re-rebase regenerates this patch
+     (propagate prompt, Step B.8).
 
 - If the head is on a fork, **do not attempt to rebase.** Post the
-  **please-rebase** comment below. Avoid duplicate comments: skip if any existing comment on the PR already contains the marker `<!-- post-meeting-rebase-notice -->`.
+  **please-rebase** comment below. Avoid duplicate comments: skip if any existing comment on the PR already contains the marker `<!-- post-meeting-rebase-notice -->`. Then capture a **best-effort patch** from the PR's current head so Phase B still has an input for the `alpha-vN` rebuild — note it may need refreshing once the author rebases:
+
+  ```bash
+  mkdir -p patches/<base>
+  gh pr diff <num> --patch > "patches/<base>/pr-<num>.patch"
+  ```
 
 ## Comment templates
 
@@ -170,6 +213,7 @@ Post via `gh pr comment <num> --body-file <tempfile>`.
 At the end, output a table grouped by base branch:
 
 - PRs successfully rebased + force-pushed (with new SHA)
+- **Per-PR patches produced** (path `patches/<base>/pr-<num>.patch` per PR) — the Phase B input set the `alpha-vN` rebuild consumes; flag any fork PRs whose patch is best-effort/stale pending author rebase
 - PRs left for manual rebase (with reason — including any failing `TOC002` references from the post-rebase cross-reference check)
 - Fork PRs commented on
 - PRs that already had the notice (skipped)

--- a/.github/prompts/post-meeting-rebase-prs.prompt.md
+++ b/.github/prompts/post-meeting-rebase-prs.prompt.md
@@ -40,7 +40,7 @@ Phase A does two things:
 > Phase B ultimately applies are the freshest post-propagation ones; the
 > patches produced here are the starting point.
 
-### Phase A2 notification and routing depend on Phase B output
+## Phase A2 notification and routing depend on Phase B output
 
 Steps 4 and 5 below (alpha-drift detection and vNext-comment routing)
 consume artifacts that **Phase B produces**:
@@ -54,6 +54,31 @@ user for the propagate report (or its location) before running A2.
 
 ## Phase A1 — prepare pinned feature-PR inputs
 
+### Authoritative remote (set and validate once)
+
+Use one remote for every read and write against the repository that owns the
+draft, alpha, and same-repository feature branches. Do not discover from one
+remote and rebase, compare, or push through another.
+
+```bash
+REMOTE="${REMOTE:-upstream}"
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+REPO_OWNER="${REPO%%/*}"
+FETCH_REPO="$(gh repo view "$(git remote get-url "$REMOTE")" \
+  --json nameWithOwner -q .nameWithOwner)"
+PUSH_REPO="$(gh repo view "$(git remote get-url --push "$REMOTE")" \
+  --json nameWithOwner -q .nameWithOwner)"
+printf 'Authoritative remote: %s (fetch=%s, push=%s, gh=%s)\n' \
+  "$REMOTE" "$FETCH_REPO" "$PUSH_REPO" "$REPO"
+test "$FETCH_REPO" = "$REPO" && test "$PUSH_REPO" = "$REPO"
+```
+
+The final `test` is mandatory. Stop if it fails, if either URL cannot be
+resolved, or if the selected remote does not expose both the discovered base
+branches and same-repository PR heads. This workflow intentionally does not
+support separate read and write remotes. Keep `REMOTE` unchanged for the
+entire A1 → B → A2 run and record its name and repository in the manifest.
+
 ### Step 1 — Discover branches and enumerate target PRs
 
 Do not use a fixed branch list or PR count.
@@ -61,8 +86,8 @@ Do not use a fixed branch list or PR count.
 1. Fetch and list the actual remote branch names:
 
    ```bash
-   git fetch upstream --prune
-   git for-each-ref refs/remotes/upstream \
+   git fetch "$REMOTE" --prune
+   git for-each-ref "refs/remotes/$REMOTE" \
      --format='%(refname:strip=3)' \
      | grep -E '^(draft-v[0-9]+|alpha-v[0-9]+|v[0-9]+-alpha)$' \
      | sort -V
@@ -109,8 +134,9 @@ must contain at least:
 
 Before Phase B starts, recheck every head and set each record's `cutoffTime`
 to the time of that successful check. Finalize the manifest with a top-level
-UTC `finalizedAt`, the total PR count, and the exact discovered branch
-chain. Phase B must reject a missing, duplicate, or count-mismatched
+UTC `finalizedAt`, the total PR count, the exact discovered branch chain, and
+the validated authoritative remote name and repository. Phase B must
+reject a missing, duplicate, count-mismatched, or remote-mismatched
 manifest.
 
 ### Step 3 — Process each enumerated PR
@@ -123,14 +149,16 @@ For each manifest PR:
    preparation; do not continue from a stale snapshot.
 2. Process the PR according to its head repository:
 
-- If `headRepositoryOwner.login` matches this repo's owner (`dotnet`), the head is in this repo. **Rebase it:**
+- If `headRepositoryOwner.login` matches `REPO_OWNER`, the head is in the
+  authoritative repository. **Rebase it:**
   1. `gh pr checkout <num>` — if this fails to fast-forward (branch has
-     diverged from upstream), run `git reset --hard upstream/<headRefName>`
-     to sync to the upstream version of the PR branch before proceeding.
+     diverged from the authoritative remote), run
+     `git reset --hard "$REMOTE/<headRefName>"` to sync to the authoritative
+     version of the PR branch before proceeding.
   2. **Capture the pre-rebase SHA** so we can recover if the post-rebase cross-reference check fails: `PRE=$(git rev-parse HEAD)`.
-  3. `git fetch upstream <base>`
-  4. `git rebase upstream/<base>` — **use `upstream/`** (the main repo
-     remote), not `origin/`. The PR branches track `upstream`.
+  3. `git fetch "$REMOTE" <base> <headRefName>`
+  4. `git rebase "$REMOTE/<base>"`. The base, PR head, comparisons, and
+     push must all use the validated authoritative remote.
   5. **If the rebase has conflicts:**
      - **Binary conflicts** in `.github/workflows/dependencies/` (e.g.
        `GrammarTestingEnv.tgz`): resolve by taking the PR's version
@@ -164,21 +192,28 @@ For each manifest PR:
      cross-references. Recover with `git reset --hard "$PRE"`, record
      the PR as "needs manual rebase", and move on. To distinguish new
      from pre-existing: check the same ref against
-     `upstream/<headRefName>` (the pre-rebase state). Pre-existing
+     `"$REMOTE/<headRefName>"` (the pre-rebase state). Pre-existing
      TOC002s from incomplete feature work are expected and do not block
      the push.
   7. Immediately before push, query `headRefOid` again. If it differs from
      the remote SHA captured immediately before checkout, stop and restart
      this PR; the author moved it during the run. Otherwise:
-     `git push --force-with-lease upstream <headRefName>`. Record success
-     with the new SHA.
+     `git push --force-with-lease "$REMOTE" HEAD:<headRefName>`. Then verify:
+
+     ```bash
+     git fetch "$REMOTE" <headRefName>
+     test "$(git rev-parse HEAD)" = \
+       "$(git rev-parse "$REMOTE/<headRefName>")"
+     ```
+
+     Record success with that verified SHA.
   8. **Produce the per-PR patch (Phase B input).** Capture the PR's commits
      relative to its base as a patch file so Phase B can surgically apply them
      onto `alpha-vN`:
 
      ```bash
      mkdir -p "$RUN_DIR/patches/<base>"
-     git format-patch "upstream/<base>..<headRefName>" \
+     git format-patch "$REMOTE/<base>..$REMOTE/<headRefName>" \
        --stdout > "$RUN_DIR/patches/<base>/pr-<num>.patch"
      ```
 
@@ -222,7 +257,7 @@ For every open PR P with base `draft-vN`:
    touching the same files:
 
    ```bash
-   git log upstream/<alpha-for-vN> --author='<login>' -- <files…>
+   git log "$REMOTE/<alpha-for-vN>" --author='<login>' -- <files…>
    ```
 
 3. If prior commits exist and the current PR head SHA introduces changes to
@@ -311,7 +346,8 @@ At the end, output a table grouped by base branch:
 
 - PRs successfully rebased + force-pushed (with new SHA)
 - The dynamically discovered branch chain, exact feature-PR count, manifest
-  path, per-PR UTC cutoffs, and manifest finalization time
+  path, authoritative remote/repository, per-PR UTC cutoffs, and manifest
+  finalization time
 - **Per-PR patches produced** (path `$RUN_DIR/patches/<base>/pr-<num>.patch`
   per PR, with pinned head SHA) — the Phase B input set the alpha rebuild
   consumes; flag any fork PRs whose patch is best-effort/stale pending author
@@ -329,4 +365,5 @@ At the end, output a table grouped by base branch:
 - Never close or merge a feature PR.
 - Never push to a fork.
 - Always use `--force-with-lease`, never `--force`.
+- Never change `REMOTE` or substitute another remote during the run.
 - If `gh pr checkout` fails (e.g. permissions), record and skip.

--- a/.github/prompts/post-meeting-rebase-prs.prompt.md
+++ b/.github/prompts/post-meeting-rebase-prs.prompt.md
@@ -7,9 +7,23 @@ description: Phase A — rebase same-repo feature PRs onto their own base, produ
 
 This is **Phase A** of the two-phase post-meeting workflow (see
 `post-meeting-propagate.prompt.md` for **Phase B**, the serial per-version
-sweep). Phase A **runs first, or in parallel with nothing blocking it**: the
-per-PR rebases are independent per PR/version, so this phase is embarrassingly
-parallel across all ~54 open feature PRs.
+sweep).
+
+The complete chronology is:
+
+1. **Phase A1 — this prompt's preparation pass.** Discover the actual draft
+   and alpha branch names, dynamically enumerate the open feature PRs, report
+   the resulting count, rebase or notify each PR as appropriate, and pin its
+   patch inputs.
+2. **Phase B — propagation and alpha reconstruction.** Run the serial
+   per-version sweep. If Phase B moves a PR's draft base, it invokes only the
+   rebase/patch machinery here to refresh that PR's pin.
+3. **Phase A2 — this prompt's notification pass.** After Phase B reports its
+   inventories, route future-version comments and send alpha-drift notices.
+
+Do not run A2 before Phase B, and do not interpret A2 as input to the alpha
+reconstruction. PR processing within A1 is independent and may run in
+parallel after the enumeration snapshot is complete.
 
 Phase A does two things:
 
@@ -18,7 +32,7 @@ Phase A does two things:
 2. **Produce a fresh `.patch` per PR** — this is the artifact **Phase B
    consumes** in its `alpha-vN` rebuild (Step D of the propagate prompt).
    Make the patch explicit: without it Phase B cannot surgically apply the
-   fresh feature content onto the existing alpha structure (Option 1).
+   fresh feature content onto the existing alpha structure.
 
 > **Ordering note.** After Phase B propagates the committee changes into
 > `draft-vN`, it does a *cheap re-rebase* of only the vN PRs whose base moved
@@ -26,78 +40,88 @@ Phase A does two things:
 > Phase B ultimately applies are the freshest post-propagation ones; the
 > patches produced here are the starting point.
 
-### Notification / routing steps depend on Phase B output
+### Phase A2 notification and routing depend on Phase B output
 
-Steps 0 and 0.5 below (alpha-drift detection and vNext-comment routing)
+Steps 4 and 5 below (alpha-drift detection and vNext-comment routing)
 consume artifacts that **Phase B produces**:
 
-- the **future-version comment inventory** (Step B.6 of the propagate prompt) — used by Step 0.5 below to route those notes to the appropriate feature PRs;
+- the **future-version comment inventory** (Step B.6 of the propagate prompt) — used by Step 5 below to route those notes to the appropriate feature PRs;
 - the deletion inventory — used as context when judging rebase conflicts.
 
-Run the rebase + patch core (Steps 1–2) up front; run Steps 0 and 0.5 as a
-**follow-up notification pass once Phase B has produced its report.** Ask the
-user for the propagate report (or its location) before running Steps 0 and 0.5.
+Run the discovery, rebase, pinning, and patch core (Steps 1–3) in A1. Run
+Steps 4 and 5 only as A2, after Phase B has produced its report. Ask the
+user for the propagate report (or its location) before running A2.
 
-## Procedure
+## Phase A1 — prepare pinned feature-PR inputs
 
-### Step 0 — Detect feature-PR drift across cycles
+### Step 1 — Discover branches and enumerate target PRs
 
-A feature PR open against `draft-vN` may have been edited between meetings, while an *earlier* version of the same feature was already merged into `vN-alpha` at a previous meeting. Plain propagation will not carry the new edits onto `vN-alpha` until the next meeting. Surface these so authors can decide whether to open a separate alpha-targeted PR sooner.
+Do not use a fixed branch list or PR count.
 
-For every open PR P with base `draft-vN`:
-
-1. Read its files: `gh pr view <num> --json files,author,number,headRefOid`.
-2. Look for prior commits on `vN-alpha` by the same author touching the same files:
+1. Fetch and list the actual remote branch names:
 
    ```bash
-   git log upstream/vN-alpha --author='<login>' -- <files…>
+   git fetch upstream --prune
+   git for-each-ref refs/remotes/upstream \
+     --format='%(refname:strip=3)' \
+     | grep -E '^(draft-v[0-9]+|alpha-v[0-9]+|v[0-9]+-alpha)$' \
+     | sort -V
    ```
 
-3. If prior commits exist and the current PR head SHA introduces changes to those files not yet on `vN-alpha`, record P as **"alpha has stale version"**.
-
-Surface the list to the user. **Do not** cherry-pick or push to `vN-alpha`. Instead, post the **alpha-drift notice** comment template (below) on each affected PR; the marker dedupes on rerun.
-
-### Step 0.5 — Route future-version comments to feature PRs
-
-Consume the future-version comment inventory from the propagate prompt's report. For each entry (file:line, comment text, source branch, best-guess target `vN`):
-
-1. List candidate open PRs:
+2. Starting at the user-supplied draft (default `draft-v8`), discover later
+   `draft-vN` branches and the corresponding alpha branch named either
+   `alpha-vN` or `vN-alpha`. Use the name that actually exists;
+   `v11-alpha` is valid. Stop if both alpha spellings exist for a version or
+   the topology is ambiguous. Confirm the result against
+   `admin/branch-diagram.md`.
+3. Feature PRs target draft branches. For every discovered target
+   `draft-vN`, list all open PRs with an explicit high limit and capture
+   `number`, `baseRefName`, `headRefOid`, `headRefName`,
+   `headRepositoryOwner`, `isDraft`, `author`, `title`, and `url`:
 
    ```bash
-   gh pr list --base draft-vN --state open --json number,title,files,url
-   gh pr list --base vN-alpha --state open --json number,title,files,url
+   gh pr list --base <base> --state open --limit 1000 \
+     --json number,baseRefName,headRefOid,headRefName,headRepositoryOwner,isDraft,author,title,url
    ```
 
-2. Match the comment to candidate PRs by:
-   - **file path**: the comment's file appears in the PR's changed files;
-   - **proximity**: the comment's line is within or near a hunk modified by the PR (best-effort; surface multiple candidates rather than guessing).
+4. Combine and de-duplicate the results by PR number. Report the exact
+   discovered branch chain and resulting feature-PR count before processing
+   any PR. The count is run data, never prompt text.
 
-3. For each (comment, candidate-PR) pair, post the **vNext-routing** comment template (below) on the PR. The HTML marker `<!-- post-meeting-vnext-routing -->` includes the source `file:line` so re-runs do not duplicate (skip if a comment with that marker and the same `file:line` already exists on the PR).
+### Step 2 — Create the pinned run manifest
 
-4. Comments with **no** candidate PR are listed in the final report under "unrouted vNext comments" for the user to triage.
-
-If `vN` is missing or unparseable from the comment, list the entry as unrouted and surface it in the report.
-
-**This step never edits `standard/*.md`.** The prompts neither apply nor remove these comments; the matched PR's author decides whether to fold the change in or open a new PR.
-
-### Step 1 — List target base branches
-
-List target base branches (the propagation chain — see the propagate prompt). Default: `draft-v8 draft-v9 alpha-v9 draft-v10 alpha-v10 draft-v11 v11-alpha draft-v12`. Allow the user to override.
-
-> **Branch-naming is inconsistent across versions** (e.g. `alpha-v9` vs
-> `v11-alpha`). Always verify actual branch
-> names with `git branch -r | grep upstream/` before starting.
-
-### Step 2 — For each base branch, list and process open PRs
-
-For each base branch, list open PRs:
+Create a persistent, untracked run directory under `.git`:
 
 ```bash
-gh pr list --base <base> --state open \
-  --json number,title,headRefName,headRepositoryOwner,isDraft,author,url
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="$(git rev-parse --git-path "post-meeting/$RUN_ID")"
+mkdir -p "$RUN_DIR/patches"
 ```
 
-For each PR returned:
+Create `$RUN_DIR/feature-prs.json` from the dynamic enumeration. Each record
+must contain at least:
+
+- PR number and base branch;
+- head branch and repository owner;
+- enumerated head SHA;
+- patch path and processing status;
+- `capturedAt` and `cutoffTime` in UTC.
+
+Before Phase B starts, recheck every head and set each record's `cutoffTime`
+to the time of that successful check. Finalize the manifest with a top-level
+UTC `finalizedAt`, the total PR count, and the exact discovered branch
+chain. Phase B must reject a missing, duplicate, or count-mismatched
+manifest.
+
+### Step 3 — Process each enumerated PR
+
+For each manifest PR:
+
+1. Query `gh pr view <num> --json headRefOid,baseRefName,state` immediately
+   before processing. If the PR closed, changed base, or its head differs
+   from the enumerated SHA, update the enumeration and restart that PR's
+   preparation; do not continue from a stale snapshot.
+2. Process the PR according to its head repository:
 
 - If `headRepositoryOwner.login` matches this repo's owner (`dotnet`), the head is in this repo. **Rebase it:**
   1. `gh pr checkout <num>` — if this fails to fast-forward (branch has
@@ -143,30 +167,103 @@ For each PR returned:
      `upstream/<headRefName>` (the pre-rebase state). Pre-existing
      TOC002s from incomplete feature work are expected and do not block
      the push.
-  7. Otherwise: `git push --force-with-lease upstream <headRefName>`.
-     Record success with the new SHA.
+  7. Immediately before push, query `headRefOid` again. If it differs from
+     the remote SHA captured immediately before checkout, stop and restart
+     this PR; the author moved it during the run. Otherwise:
+     `git push --force-with-lease upstream <headRefName>`. Record success
+     with the new SHA.
   8. **Produce the per-PR patch (Phase B input).** Capture the PR's commits
      relative to its base as a patch file so Phase B can surgically apply them
      onto `alpha-vN`:
 
      ```bash
-     mkdir -p patches/<base>
+     mkdir -p "$RUN_DIR/patches/<base>"
      git format-patch "upstream/<base>..<headRefName>" \
-       --stdout > "patches/<base>/pr-<num>.patch"
+       --stdout > "$RUN_DIR/patches/<base>/pr-<num>.patch"
      ```
 
-     Record the patch path alongside the new SHA. This is the fresh vN patch
-     Phase B's `alpha-vN` rebuild consumes; if Phase B later moves `<base>`
-     via committee propagation, its cheap re-rebase regenerates this patch
-     (propagate prompt, Step B.8).
+     Record the patch path, new head SHA, and UTC `capturedAt` in the
+     manifest. This is the fresh vN patch Phase B consumes; if Phase B later
+     moves `<base>` via committee propagation, its cheap re-rebase updates
+     the SHA, patch, and cutoff (propagate prompt, Step B.8).
 
 - If the head is on a fork, **do not attempt to rebase.** Post the
   **please-rebase** comment below. Avoid duplicate comments: skip if any existing comment on the PR already contains the marker `<!-- post-meeting-rebase-notice -->`. Then capture a **best-effort patch** from the PR's current head so Phase B still has an input for the `alpha-vN` rebuild — note it may need refreshing once the author rebases:
 
   ```bash
-  mkdir -p patches/<base>
-  gh pr diff <num> --patch > "patches/<base>/pr-<num>.patch"
+  mkdir -p "$RUN_DIR/patches/<base>"
+  gh pr diff <num> --patch > "$RUN_DIR/patches/<base>/pr-<num>.patch"
   ```
+
+  Record the current `headRefOid`, patch path, UTC `capturedAt`, and
+  `bestEffort: true` in the manifest. Phase B must recheck the fork PR head
+  and stop if it moved after cutoff.
+
+After all PRs are processed, query every manifest PR's `headRefOid` one more
+time. If any head moved during the long run, refresh it. Otherwise set that
+record's `cutoffTime`, then set the top-level `finalizedAt`. Report the final
+PR count and cutoff range.
+
+## Phase A2 — notify and route after Phase B
+
+### Step 4 — Detect feature-PR drift across cycles
+
+A feature PR open against `draft-vN` may have been edited between meetings,
+while an *earlier* version of the same feature was already merged into that
+version's discovered alpha branch at a previous meeting. Plain propagation
+will not carry the new edits onto the alpha until the next meeting. Surface
+these so authors can decide whether to open a separate alpha-targeted PR
+sooner.
+
+For every open PR P with base `draft-vN`:
+
+1. Read its files: `gh pr view <num> --json files,author,number,headRefOid`.
+2. Look for prior commits on the discovered alpha branch by the same author
+   touching the same files:
+
+   ```bash
+   git log upstream/<alpha-for-vN> --author='<login>' -- <files…>
+   ```
+
+3. If prior commits exist and the current PR head SHA introduces changes to
+   those files not yet on the discovered alpha, record P as **"alpha has
+   stale version"**.
+
+Surface the list to the user. **Do not** cherry-pick or push to the alpha.
+Instead, post the **alpha-drift notice** comment template (below) on each
+affected PR; the marker dedupes on rerun.
+
+### Step 5 — Route future-version comments to feature PRs
+
+Consume the future-version comment inventory from the propagate prompt's
+report. For each entry (file:line, comment text, source branch, best-guess
+target `vN`):
+
+1. List candidate open PRs:
+
+   ```bash
+   gh pr list --base draft-vN --state open --json number,title,files,url
+   gh pr list --base <alpha-for-vN> --state open --json number,title,files,url
+   ```
+
+2. Match the comment to candidate PRs by:
+   - **file path**: the comment's file appears in the PR's changed files;
+   - **proximity**: the comment's line is within or near a hunk modified by
+     the PR (best-effort; surface multiple candidates rather than guessing).
+3. For each (comment, candidate-PR) pair, post the **vNext-routing** comment
+   template (below). The HTML marker
+   `<!-- post-meeting-vnext-routing -->` includes the source `file:line` so
+   re-runs do not duplicate it. Skip the comment if that marker and the same
+   `file:line` already exist on the PR.
+4. List comments with **no** candidate PR in the final report under
+   "unrouted vNext comments" for user triage.
+
+If `vN` is missing or unparseable from the comment, list the entry as
+unrouted and surface it in the report.
+
+**This step never edits `standard/*.md`.** The prompts neither apply nor
+remove these comments; the matched PR's author decides whether to fold the
+change in or open a new PR.
 
 ## Comment templates
 
@@ -213,12 +310,19 @@ Post via `gh pr comment <num> --body-file <tempfile>`.
 At the end, output a table grouped by base branch:
 
 - PRs successfully rebased + force-pushed (with new SHA)
-- **Per-PR patches produced** (path `patches/<base>/pr-<num>.patch` per PR) — the Phase B input set the `alpha-vN` rebuild consumes; flag any fork PRs whose patch is best-effort/stale pending author rebase
+- The dynamically discovered branch chain, exact feature-PR count, manifest
+  path, per-PR UTC cutoffs, and manifest finalization time
+- **Per-PR patches produced** (path `$RUN_DIR/patches/<base>/pr-<num>.patch`
+  per PR, with pinned head SHA) — the Phase B input set the alpha rebuild
+  consumes; flag any fork PRs whose patch is best-effort/stale pending author
+  rebase
+- Any PR head that moved during the run and how its manifest entry was
+  refreshed
 - PRs left for manual rebase (with reason — including any failing `TOC002` references from the post-rebase cross-reference check)
 - Fork PRs commented on
 - PRs that already had the notice (skipped)
-- PRs flagged with the **alpha-drift notice** (Step 0)
-- vNext comments routed (PR number + source `file:line`) and any **unrouted vNext comments** for human triage (Step 0.5)
+- PRs flagged with the **alpha-drift notice** (Step 4)
+- vNext comments routed (PR number + source `file:line`) and any **unrouted vNext comments** for human triage (Step 5)
 
 ## Safety rules
 

--- a/.github/workflows/update-on-merge.yaml
+++ b/.github/workflows/update-on-merge.yaml
@@ -65,7 +65,7 @@ jobs:
       with:
         title: "Automated Section renumber and grammar extraction"
         body: "renumber sections. Add grammar"
-        branch: ${{ github.ref_name }}-renumber-sections-and-grammar
+        branch: renumber-sections-and-grammar-${{ github.ref_name }}
 
     - name: Run converter
       id: run-converter


### PR DESCRIPTION
Updates the post-meeting agent prompts based on the propagation-cycle failures and review feedback.

The revised workflow now:
- discovers actual draft/alpha branch names and dynamically reports the feature-PR count;
- defines the A1 → B → A2 chronology and responsibilities;
- pins feature PR numbers, head SHAs, patches, and cutoff times, with movement checks;
- requires raw symbolic-reference audits and semantic three-way comparisons;
- applies surgical feature deltas without replaying synchronization merges or losing later-version language; and
- treats finalized alphas as risk reduction, with downstream verification still required.

The existing workflow change also renames the automated renumbering branch so it does not match the protected-branch pattern.