### PR TITLE
Fix code-fence detection in the anchor updater

### DIFF
--- a/tools/StandardAnchorTags.Tests/ReferenceUpdateProcessorTests.cs
+++ b/tools/StandardAnchorTags.Tests/ReferenceUpdateProcessorTests.cs
@@ -1,0 +1,22 @@
+using StandardAnchorTags;
+
+namespace StandardAnchorTags.Tests;
+
+public class ReferenceUpdateProcessorTests
+{
+    [TestCase("```csharp")]
+    [TestCase("  ```")]
+    [TestCase("> ```console")]
+    [TestCase(">> ```")]
+    public void RecognizesCodeFenceDelimiters(string line)
+    {
+        Assert.That(ReferenceUpdateProcessor.IsCodeFenceDelimiter(line), Is.True);
+    }
+
+    [TestCase("<!-- Maintenance note: use ```console for output. -->")]
+    [TestCase("Text containing ``` inline.")]
+    public void DoesNotTreatFenceMentionsAsDelimiters(string line)
+    {
+        Assert.That(ReferenceUpdateProcessor.IsCodeFenceDelimiter(line), Is.False);
+    }
+}

--- a/tools/StandardAnchorTags.Tests/StandardAnchorTags.Tests.csproj
+++ b/tools/StandardAnchorTags.Tests/StandardAnchorTags.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StandardAnchorTags\StandardAnchorTags.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/tools/StandardAnchorTags/Properties/AssemblyInfo.cs
+++ b/tools/StandardAnchorTags/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("StandardAnchorTags.Tests")]

--- a/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
+++ b/tools/StandardAnchorTags/ReferenceUpdateProcessor.cs
@@ -32,7 +32,7 @@ internal class ReferenceUpdateProcessor
             while (await readStream.ReadLineAsync() is string line)
             {
                 // Don't add links in codefenced examples.
-                inCodeFence ^= line.Contains("```");
+                inCodeFence ^= IsCodeFenceDelimiter(line);
                 lineNumber++;
                 var updatedLine = (!inCodeFence && line.Contains(sectionReference))
                     ? ProcessSectionLinks(line, lineNumber, inputPath)
@@ -50,6 +50,17 @@ internal class ReferenceUpdateProcessor
         {
             File.Move(tmpFileName, inputPath, true);
         }
+    }
+
+    internal static bool IsCodeFenceDelimiter(string line)
+    {
+        ReadOnlySpan<char> remaining = line.AsSpan().TrimStart();
+        while (!remaining.IsEmpty && remaining[0] == '>')
+        {
+            remaining = remaining[1..].TrimStart();
+        }
+
+        return remaining.StartsWith("```", StringComparison.Ordinal);
     }
 
     private string ProcessSectionLinks(string line, int lineNumber, string path)

--- a/tools/tools.sln
+++ b/tools/tools.sln
@@ -22,6 +22,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleFormatter", "Example
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleTester.Tests", "ExampleTester.Tests\ExampleTester.Tests.csproj", "{6AE7A04F-85DE-46EA-8696-F748B6130971}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StandardAnchorTags.Tests", "StandardAnchorTags.Tests\StandardAnchorTags.Tests.csproj", "{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -128,6 +130,18 @@ Global
 		{6AE7A04F-85DE-46EA-8696-F748B6130971}.Release|x64.Build.0 = Release|Any CPU
 		{6AE7A04F-85DE-46EA-8696-F748B6130971}.Release|x86.ActiveCfg = Release|Any CPU
 		{6AE7A04F-85DE-46EA-8696-F748B6130971}.Release|x86.Build.0 = Release|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Debug|x64.Build.0 = Debug|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Debug|x86.Build.0 = Debug|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Release|x64.ActiveCfg = Release|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Release|x64.Build.0 = Release|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Release|x86.ActiveCfg = Release|Any CPU
+		{DD0FB88E-0E16-45CD-A833-8BDD8EE197F0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Restricts code-fence state changes to actual fence delimiter lines, including blockquoted fences. HTML comments or prose that merely mention triple backticks no longer suppress later section-reference updates.

Adds a dedicated `StandardAnchorTags.Tests` project with regression coverage for the maintenance-comment failure and normal fence forms.

Validation: `dotnet test tools/StandardAnchorTags.Tests/StandardAnchorTags.Tests.csproj` — 6 passed.