### PR TITLE
Update all projects

### DIFF
--- a/tools/ExampleTester.Tests/FastCsprojCompilationParserTests.cs
+++ b/tools/ExampleTester.Tests/FastCsprojCompilationParserTests.cs
@@ -83,7 +83,7 @@ public static class FastCsprojCompilationParserTests
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
+                <TargetFramework>net9.0</TargetFramework>
               </PropertyGroup>
 
             </Project>
@@ -105,7 +105,7 @@ public static class FastCsprojCompilationParserTests
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
+                <TargetFramework>net9.0</TargetFramework>
               </PropertyGroup>
 
             </Project>
@@ -119,7 +119,7 @@ public static class FastCsprojCompilationParserTests
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
+                <TargetFramework>net9.0</TargetFramework>
                 <OutputType>{outputType}</OutputType>
               </PropertyGroup>
 
@@ -139,7 +139,7 @@ public static class FastCsprojCompilationParserTests
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
+                <TargetFramework>net9.0</TargetFramework>
                 <Nullable>{nullable}</Nullable>
               </PropertyGroup>
 
@@ -160,7 +160,7 @@ public static class FastCsprojCompilationParserTests
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
+                <TargetFramework>net9.0</TargetFramework>
                 <AssemblyName>Xyz</AssemblyName>
               </PropertyGroup>
 
@@ -175,7 +175,7 @@ public static class FastCsprojCompilationParserTests
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
+                <TargetFramework>net9.0</TargetFramework>
                 <AllowUnsafeBlocks>{allowUnsafeBlocks}</AllowUnsafeBlocks>
               </PropertyGroup>
 
@@ -200,7 +200,7 @@ public static class FastCsprojCompilationParserTests
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
+                <TargetFramework>net9.0</TargetFramework>
                 <ImplicitUsings>{implicitUsings}</ImplicitUsings>
               </PropertyGroup>
 

--- a/tools/ExampleTester.Tests/FastCsprojCompilationParserTests.cs
+++ b/tools/ExampleTester.Tests/FastCsprojCompilationParserTests.cs
@@ -93,7 +93,7 @@ public static class FastCsprojCompilationParserTests
         result.CompilationOptions.NullableContextOptions.ShouldBe(NullableContextOptions.Disable);
         result.AssemblyName.ShouldBe(Path.GetFileNameWithoutExtension(CsprojFileName));
         result.CompilationOptions.AllowUnsafe.ShouldBeFalse();
-        result.ParseOptions.LanguageVersion.ShouldBe(LanguageVersion.CSharp10); // Due to net6.0
+        result.ParseOptions.LanguageVersion.ShouldBe(LanguageVersion.CSharp13); // Due to net9.0
         result.CompilationOptions.WarningLevel.ShouldBe(9); // Due to net9.0
         result.GeneratedSources.ShouldBeEmpty();
     }

--- a/tools/ExampleTester.Tests/FastCsprojCompilationParserTests.cs
+++ b/tools/ExampleTester.Tests/FastCsprojCompilationParserTests.cs
@@ -94,7 +94,7 @@ public static class FastCsprojCompilationParserTests
         result.AssemblyName.ShouldBe(Path.GetFileNameWithoutExtension(CsprojFileName));
         result.CompilationOptions.AllowUnsafe.ShouldBeFalse();
         result.ParseOptions.LanguageVersion.ShouldBe(LanguageVersion.CSharp10); // Due to net6.0
-        result.CompilationOptions.WarningLevel.ShouldBe(6); // Due to net6.0
+        result.CompilationOptions.WarningLevel.ShouldBe(9); // Due to net9.0
         result.GeneratedSources.ShouldBeEmpty();
     }
 
@@ -109,7 +109,7 @@ public static class FastCsprojCompilationParserTests
               </PropertyGroup>
 
             </Project>
-            """).TargetFramework.ShouldBe("net6.0");
+            """).TargetFramework.ShouldBe("net9.0");
     }
 
     [Test]

--- a/tools/ExampleTester/ExampleTester.csproj
+++ b/tools/ExampleTester/ExampleTester.csproj
@@ -13,12 +13,13 @@
     <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.8.10" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.10" />
     <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.10" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="System.CommandLine" Version="2.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ExampleTester/ExampleTester.csproj
+++ b/tools/ExampleTester/ExampleTester.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.Net60" Version="1.8.10" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.8.10" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.10" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />

--- a/tools/ExampleTester/FastCsprojCompilationParser.cs
+++ b/tools/ExampleTester/FastCsprojCompilationParser.cs
@@ -39,6 +39,9 @@ public static class FastCsprojCompilationParser
         LanguageVersion DefaultLanguageVersion,
         int DefaultWarningLevel);
 
+
+    // When we add new rows here, we need to add the corresponding NuGet package to ExampleTester.csproj. These packages provide the information used
+    // for the reference assemblies.
     private static readonly FrozenDictionary<string, TargetFrameworkInfo> SupportedTargetFrameworks = new KeyValuePair<string, TargetFrameworkInfo>[]
     {
         new("net6.0", new(Basic.Reference.Assemblies.Net60.References.All, LanguageVersion.CSharp10, DefaultWarningLevel: 6)),
@@ -48,6 +51,8 @@ public static class FastCsprojCompilationParser
         new("net10.0", new(Basic.Reference.Assemblies.Net100.References.All, LanguageVersion.CSharp14, DefaultWarningLevel: 10)),
     }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
+    // When we add new versions, this list changes. You'll need to change the current release from ".NET9_0",
+    // and add necessary "NET?_0_OR_GREATER" symbols.
     private static readonly CSharpParseOptions DefaultParseOptions = new(preprocessorSymbols: [
         "TRACE", "RELEASE", "NET", "NET9_0", "NETCOREAPP", "NET5_0_OR_GREATER", "NET6_0_OR_GREATER",
         "NET7_0_OR_GREATER","NET8_0_OR_GREATER","NET9_0_OR_GREATER",

--- a/tools/ExampleTester/FastCsprojCompilationParser.cs
+++ b/tools/ExampleTester/FastCsprojCompilationParser.cs
@@ -45,10 +45,12 @@ public static class FastCsprojCompilationParser
         new("net7.0", new(Basic.Reference.Assemblies.Net70.References.All, LanguageVersion.CSharp11, DefaultWarningLevel: 7)),
         new("net8.0", new(Basic.Reference.Assemblies.Net80.References.All, LanguageVersion.CSharp12, DefaultWarningLevel: 8)),
         new("net9.0", new(Basic.Reference.Assemblies.Net90.References.All, LanguageVersion.CSharp13, DefaultWarningLevel: 9)),
+        new("net10.0", new(Basic.Reference.Assemblies.Net100.References.All, LanguageVersion.CSharp14, DefaultWarningLevel: 10)),
     }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     private static readonly CSharpParseOptions DefaultParseOptions = new(preprocessorSymbols: [
-        "TRACE", "RELEASE", "NET", "NET6_0", "NETCOREAPP", "NET5_0_OR_GREATER", "NET6_0_OR_GREATER",
+        "TRACE", "RELEASE", "NET", "NET9_0", "NETCOREAPP", "NET5_0_OR_GREATER", "NET6_0_OR_GREATER",
+        "NET7_0_OR_GREATER","NET8_0_OR_GREATER","NET9_0_OR_GREATER",
         "NETCOREAPP1_0_OR_GREATER", "NETCOREAPP1_1_OR_GREATER", "NETCOREAPP2_0_OR_GREATER",
         "NETCOREAPP2_1_OR_GREATER",  "NETCOREAPP2_2_OR_GREATER", "NETCOREAPP3_0_OR_GREATER",
         "NETCOREAPP3_1_OR_GREATER"]);

--- a/tools/ExampleTester/FastCsprojCompilationParser.cs
+++ b/tools/ExampleTester/FastCsprojCompilationParser.cs
@@ -51,7 +51,7 @@ public static class FastCsprojCompilationParser
         new("net10.0", new(Basic.Reference.Assemblies.Net100.References.All, LanguageVersion.CSharp14, DefaultWarningLevel: 10)),
     }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    // When we add new versions, this list changes. You'll need to change the current release from ".NET9_0",
+    // When we add new versions, this list changes. You'll need to change the current release from "NET9_0",
     // and add necessary "NET?_0_OR_GREATER" symbols.
     private static readonly CSharpParseOptions DefaultParseOptions = new(preprocessorSymbols: [
         "TRACE", "RELEASE", "NET", "NET9_0", "NETCOREAPP", "NET5_0_OR_GREATER", "NET6_0_OR_GREATER",

--- a/tools/ExampleTester/FastCsprojCompilationParser.cs
+++ b/tools/ExampleTester/FastCsprojCompilationParser.cs
@@ -42,6 +42,9 @@ public static class FastCsprojCompilationParser
     private static readonly FrozenDictionary<string, TargetFrameworkInfo> SupportedTargetFrameworks = new KeyValuePair<string, TargetFrameworkInfo>[]
     {
         new("net6.0", new(Basic.Reference.Assemblies.Net60.References.All, LanguageVersion.CSharp10, DefaultWarningLevel: 6)),
+        new("net7.0", new(Basic.Reference.Assemblies.Net70.References.All, LanguageVersion.CSharp11, DefaultWarningLevel: 7)),
+        new("net8.0", new(Basic.Reference.Assemblies.Net80.References.All, LanguageVersion.CSharp12, DefaultWarningLevel: 8)),
+        new("net9.0", new(Basic.Reference.Assemblies.Net90.References.All, LanguageVersion.CSharp13, DefaultWarningLevel: 9)),
     }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     private static readonly CSharpParseOptions DefaultParseOptions = new(preprocessorSymbols: [
@@ -58,7 +61,8 @@ public static class FastCsprojCompilationParser
             new("NU1605", ReportDiagnostic.Error),
             new("CS1702", ReportDiagnostic.Suppress),
             new("CS1701", ReportDiagnostic.Suppress),
-            new("CS8002", ReportDiagnostic.Suppress)]);
+            new("CS8002", ReportDiagnostic.Suppress),
+            new("SYSLIB0011", ReportDiagnostic.Error)]);
 
     public static CsprojParseResult ParseCsproj(XDocument csprojDocument, string filePath)
     {

--- a/tools/MarkdownConverter.Tests/MarkdownConverter.Tests.csproj
+++ b/tools/MarkdownConverter.Tests/MarkdownConverter.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="XMLUnit.Core" Version="2.11.1" />
+    <PackageReference Include="XMLUnit.Core" Version="2.11.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tools/MarkdownConverter/MarkdownConverter.csproj
+++ b/tools/MarkdownConverter/MarkdownConverter.csproj
@@ -11,9 +11,9 @@
   <ItemGroup>
     <PackageReference Include="csharp2colorized" Version="1.0.3" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
-    <PackageReference Include="FSharp.Core" Version="10.1.201" />
-    <PackageReference Include="FSharp.Formatting" Version="22.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageReference Include="FSharp.Core" Version="11.0.100" />
+    <PackageReference Include="FSharp.Formatting" Version="22.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/StandardAnchorTags/StandardAnchorTags.csproj
+++ b/tools/StandardAnchorTags/StandardAnchorTags.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="System.CommandLine" Version="2.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Utilities/Utilities.csproj
+++ b/tools/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.10" />
+    <PackageReference Include="System.Text.Json" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/tools/example-templates/code-in-class-lib-without-using/Project.csproj
+++ b/tools/example-templates/code-in-class-lib-without-using/Project.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/code-in-class-lib/Project.csproj
+++ b/tools/example-templates/code-in-class-lib/Project.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/code-in-main-without-using/Project.csproj
+++ b/tools/example-templates/code-in-main-without-using/Project.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>annotations</Nullable>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/code-in-main/Project.csproj
+++ b/tools/example-templates/code-in-main/Project.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>annotations</Nullable>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/code-in-partial-class/Project.csproj
+++ b/tools/example-templates/code-in-partial-class/Project.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/tools/example-templates/extern-lib/ExampleProject.csproj
+++ b/tools/example-templates/extern-lib/ExampleProject.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <NoWarn>CS0169</NoWarn>
     <Nullable>annotations</Nullable>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternN2.csproj
+++ b/tools/example-templates/extern-lib/ExternN2.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Nullable>annotations</Nullable>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternR1.csproj
+++ b/tools/example-templates/extern-lib/ExternR1.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Nullable>annotations</Nullable>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternX.csproj
+++ b/tools/example-templates/extern-lib/ExternX.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Nullable>annotations</Nullable>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/extern-lib/ExternY.csproj
+++ b/tools/example-templates/extern-lib/ExternY.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Nullable>annotations</Nullable>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/example-templates/standalone-console-without-using/Project.csproj
+++ b/tools/example-templates/standalone-console-without-using/Project.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <LangVersion>12</LangVersion>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>

--- a/tools/example-templates/standalone-console/Project.csproj
+++ b/tools/example-templates/standalone-console/Project.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <LangVersion>12</LangVersion>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>

--- a/tools/example-templates/standalone-lib-without-using/Project.csproj
+++ b/tools/example-templates/standalone-lib-without-using/Project.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>$example-name</AssemblyName>
-    <LangVersion>12</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
   </PropertyGroup>

--- a/tools/example-templates/standalone-lib/Project.csproj
+++ b/tools/example-templates/standalone-lib/Project.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>$example-name</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
For C# 13, use the .NET 9 target framework, and remove the LangVersion tags.