### PR TITLE
Fix inline array example fence

### DIFF
--- a/standard/structs.md
+++ b/standard/structs.md
@@ -554,7 +554,7 @@ Any indexers or `Slice` methods declared for an inline array type that have sign
 > *Example*: Consider the following:
 >
 > <!-- Example: {template:"standalone-console-without-using", name:"InlineArays4", replaceEllipsis:true, customEllipsisReplacements: ["Console.WriteLine(\"in indexer [int]\");","return 0;"]} -->
-```csharp
+> ```csharp
 > var buffer = new Buffer();
 > int x = buffer[2];      // element access
 >
@@ -573,8 +573,6 @@ Any indexers or `Slice` methods declared for an inline array type that have sign
 > ```
 >
 > Even though the struct declares an indexer taking an `int` argument, that indexer is not used by element access `buffer[2]`. *end example*
-
-
 
 ## 16.7 Record struct and non-record struct differences
 


### PR DESCRIPTION
## Summary
Fixes a Markdown structure defect that prevented bookmark generation for §16.7 and §16.8 sections.

## Root Cause
The opening code fence in the blockquoted inline-array example (near line 557) was not blockquoted, while its closing fence was. This asymmetry caused Markdown parsing to swallow §16.7 through §16.8.8.2 as code content, preventing Docfx from generating anchors for these headings.

## Changes
- Prefix opening fence with blockquote marker (line 557): \\\csharp → > \\\csharp
- Remove two now-visible excess blank lines before § 16.7

The fence is now balanced, restoring proper Markdown parsing.

## Impact
Resolves 12 unique missing anchor targets across §16.7 and §16.8 sections. All current warnings in dotnet/docs#55428 related to structs.md headings are fixed.

## Validation
- standard/structs.md: markdownlint 0 issues (MD012 resolved)
- All 57/57 physical headings parse as CommonMark headings
- No broken anchor targets in standard/structs.md  
- git diff --check: passing

## CI Note
Full standard/*.md markdownlint scan has 13 pre-existing base issues in attributes.md, classes.md, and variables.md on alpha-v12. This PR does not touch those files and does not introduce new issues.